### PR TITLE
[codex] Windows native対応の追加修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Normalize line endings to LF in the repository
+* text=auto eol=lf
+
+# Go source files: always LF
+*.go text eol=lf
+
+# YAML/JSON/Markdown: always LF
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+
+# Shell scripts: always LF
+*.sh text eol=lf
+
+# Makefiles require tabs; normalize to LF
+Makefile text eol=lf
+
+# Binary files: no conversion
+*.exe binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.zip binary
+*.tar binary
+*.gz binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,12 @@ jobs:
         fi
 
   test:
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - name: Checkout code
@@ -42,14 +46,51 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    - name: Run tests with coverage
+    - name: Run tests
       run: go test -coverprofile=coverage.out ./...
 
     - name: Upload coverage
-      uses: actions/upload-artifact@v7
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v6
       with:
         name: coverage
         path: coverage.out
+
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Build acr
+      run: go build ./cmd/acr
+
+  install:
+    name: Install (windows-latest)
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Install acr from source
+      run: go install ./cmd/acr
 
   test-race:
     name: Test (Race Detection)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Run tests
-      run: go test -coverprofile=coverage.out ./...
+      run: go test ${{ runner.os != 'Windows' && '-coverprofile=coverage.out' || '' }} ./...
+      shell: bash
 
     - name: Upload coverage
       if: matrix.os == 'ubuntu-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ bin/acr
 # Claude Code local settings
 .claude/settings.local.json
 bin/acr-test
+
+/.omc/
+/back_log/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,9 +18,13 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     # Custom ldflags for version info
     ldflags:
       - -s -w
@@ -40,6 +44,10 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
     formats:
       - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
     files:
       - README.md
       - LICENSE
@@ -92,13 +100,14 @@ release:
 
     ## Installation
 
-    ### Homebrew (Recommended)
+    ### Homebrew (macOS)
     ```bash
     brew install --cask richhaase/tap/acr
     ```
 
     ### Direct Download
     Download the appropriate archive from the assets below and extract the `acr` binary.
+    Windows releases are published as `zip` archives containing `acr.exe`.
 
     ### From Source
     ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,104 @@
+# AGENTS.md
+
+このファイルの適用範囲は、このリポジトリ全体です。
+
+## 方針
+
+- 既存設計を尊重し、最小差分で直す。
+- 変更後は、触った領域に対応するテストとビルドを自分で実行して確認する。
+- 長い運用メモをここに集約しすぎない。新しい知見は README / back_log / テストに反映する。
+
+## プロジェクト概要
+
+- このリポジトリは Go 製 CLI `acr` の**native Windows**ポーティングである。
+- フォーク元である https://github.com/richhaase/agentic-code-reviewer はmac/unix系のみを対象とした実装であり，これをnative windows環境で動作するよう改変する．
+- LLM reviewer CLI (`codex`, `claude`, `gemini`) を subprocess で起動する。
+- GitHub 連携は `gh` CLI 前提。
+
+主要ディレクトリ:
+
+- `cmd/acr/`: CLI エントリポイントと orchestration
+- `internal/agent/`: reviewer / summarizer CLI 呼び出しと parser
+- `internal/runner/`: 並列 reviewer 実行
+- `internal/summarizer/`, `internal/fpfilter/`: 要約と false positive filter
+- `integration/`: 実バイナリを使う integration test
+
+## ビルドとテスト
+
+Unix 系では `make` が使えるが、Windows / PowerShell では直接 `go` コマンドを優先する。
+
+よく使う確認:
+
+```powershell
+go test ./internal/agent ./internal/runner ./integration
+go test ./...
+go build ./cmd/acr
+```
+
+ローカルキャッシュ権限で失敗する環境では、リポジトリ内キャッシュを使う:
+
+```powershell
+$env:GOCACHE="$PWD\.cache\go-build"
+$env:GOMODCACHE="$PWD\.cache\gomod"
+go test ./internal/agent ./internal/runner ./integration
+go build -o .\acr.exe .\cmd\acr
+```
+
+## Windows のローカルバイナリ運用
+
+重要:
+
+- Windows で動作確認するときは、`PATH` 上の古い `acr.exe` を使わない。
+- `acr` ではなく、必ずリポジトリ直下の `.\acr.exe` を明示実行する。
+
+推奨手順:
+
+```powershell
+$env:GOCACHE="$PWD\.cache\go-build"
+$env:GOMODCACHE="$PWD\.cache\gomod"
+go build -o .\acr.exe .\cmd\acr
+.\acr.exe --help
+```
+
+ローカルレビュー確認例:
+
+```powershell
+.\acr.exe --local --reviewers 3 --base HEAD~1 --reviewer-agent codex,claude,gemini --verbose
+```
+
+理由:
+
+- `go install` 済みの `C:\Users\<user>\go\bin\acr.exe` が古いことがある。
+- PowerShell では `acr` と打つとカレントディレクトリの `acr.exe` ではなく `PATH` 上の別バイナリが選ばれることがある。
+
+## reviewer CLI 検証時の注意
+
+- `codex` / `claude` / `gemini` の単独 CLI 動作確認と、`.\acr.exe` 経由の reviewer 実行確認は分けて考える。
+- Windows では reviewer CLI が内部で追加 subprocess を spawn することがあるため、必要に応じて reviewer stderr を確認する。
+- 3 エージェント並列レビューを試す場合は `--verbose` を付ける。
+
+## 変更時の最低確認
+
+- `internal/agent/` を触ったら:
+  - `go test ./internal/agent ./internal/runner ./integration`
+- `cmd/acr/` を触ったら:
+  - `go build -o .\acr.exe .\cmd\acr`
+  - 必要なら `.\acr.exe --help`
+- reviewer 実行パスを触ったら:
+  - 可能なら `.\acr.exe --local ... --verbose` で実動作確認
+
+## コミット方針
+
+- 変更は意味単位で分割する。
+- 過去コミットの是正なら `fixup` を優先する。
+- ユーザーが明示しない限り push しない。
+
+## 作業ログ
+
+- 長めの調査内容や次スレッドへの引継ぎは `back_log/` に Markdown で残す。
+- ファイル名は`{YYYY-MM-DD}_{XX}.md`とし，`XX`は01からカウントアップさせる．
+- 少なくとも次を含める:
+  - 目的
+  - 実際にしたこと
+  - 未実行タスク
+  - 次スレッドでやるべきこと

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ cd your-repo
 acr
 ```
 
+On Windows, use the source install or the release ZIP described below.
+
 ## Prerequisites
 
 You need **at least one** of the following LLM CLIs installed and authenticated:
@@ -71,7 +73,22 @@ graph TD
 brew install richhaase/tap/acr
 ```
 
-### From Source
+### Windows
+
+ACR works on Windows native with `codex`, `claude`, or `gemini` as the review backend.
+
+#### From Source
+
+```powershell
+go install github.com/richhaase/agentic-code-reviewer/cmd/acr@latest
+acr --help
+```
+
+#### Direct Download
+
+Download the Windows release ZIP from GitHub Releases and extract `acr.exe`.
+
+### From Source (macOS / Linux)
 
 ```bash
 go install github.com/richhaase/agentic-code-reviewer/cmd/acr@latest
@@ -363,6 +380,8 @@ Requires the `gh` CLI to be authenticated.
 
 ## Development
 
+### Unix / macOS
+
 ```bash
 # List available targets
 make help
@@ -387,6 +406,14 @@ make fmt
 
 # Clean build artifacts
 make clean
+```
+
+### Windows (PowerShell)
+
+```powershell
+go test ./...
+go build ./cmd/acr
+go install ./cmd/acr
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.

--- a/agentic-code-reviewer-analysis.md
+++ b/agentic-code-reviewer-analysis.md
@@ -1,0 +1,224 @@
+# agentic-code-reviewer 技術調査レポート
+
+> リポジトリ: https://github.com/richhaase/agentic-code-reviewer
+> 調査日: 2026-04-11
+
+## 1. プロジェクト概要
+
+- **言語**: Go
+- **目的**: 複数の AI Coding Agent CLI を並列実行し、コードレビューの findings を集約・要約・偽陽性フィルタリングするツール
+- **対応バックエンド**: Codex (OpenAI), Claude (Anthropic), Gemini (Google)
+- **CLI フレームワーク**: spf13/cobra
+- **設定ファイル**: `.acr.yaml` (gopkg.in/yaml.v3)
+
+## 2. アーキテクチャ全体像
+
+```
+N個のレビュアーを並列実行 (runner)
+  │  各レビュアーの findings を集約
+  ▼
+Finding Summarizer (LLM でクラスタリング・要約)
+  │
+  │  並行: Feedback Summarizer (PR の既存コメントを構造化)
+  ▼
+FP Filter (LLM で fp_score 判定 + agreement bonus)
+  │  threshold 以上を除外
+  ▼
+最終レポート出力 / PR コメント投稿
+```
+
+LLM API を直接呼び出すのではなく、`exec.CommandContext` 経由で各 CLI をサブプロセスとして起動し、標準入出力をパイプする設計。
+
+## 3. 対応エージェントと CLI 呼び出し
+
+### 3.1 レビュー実行時
+
+| エージェント | CLI コマンド | 引数 |
+|---|---|---|
+| codex (デフォルト) | `codex exec --json --color never review --base <ref>` | guidance 無し時。guidance 有り時は `codex exec --json --color never -` でstdin入力 |
+| claude | `claude --print -` | stdin にプロンプト+diff を流す |
+| gemini | `gemini -o json -` | stdin にプロンプト+diff を流す |
+
+### 3.2 サマリ / FP フィルタ実行時
+
+| エージェント | CLI コマンド | 備考 |
+|---|---|---|
+| codex | `codex exec --json --color never -` | stdin にプロンプト+JSON |
+| claude | `claude --print --output-format json -` | 100KB超は一時ファイル+Read tool |
+| gemini | `gemini -o json -` | stdin にプロンプト+JSON |
+
+すべてのエージェントで `--model` オプションによるモデルオーバーライドが可能。
+
+### 3.3 エージェントレジストリ
+
+`internal/agent/factory.go` にレジストリパターンで管理：
+
+```go
+var registry = map[string]agentRegistry{
+    "codex":  { newAgent, newReviewParser, newSummaryParser },
+    "claude": { newAgent, newReviewParser, newSummaryParser },
+    "gemini": { newAgent, newReviewParser, newSummaryParser },
+}
+```
+
+新規エージェント追加は1箇所の登録で完結する。
+
+## 4. False Positive Filter (`internal/fpfilter/`)
+
+### 4.1 動作原理
+
+LLM に「偽陽性評価者」としてプロンプトを送り、各 finding に `fp_score` (0-100) を付けさせる。
+
+- `fp_score >= threshold (デフォルト75)` → false positive として除去
+- fail-open 設計: LLM 実行失敗・パース失敗時はフィルタをスキップし全 finding を通す
+
+### 4.2 agreement bonus（ヒューリスティック補正）
+
+複数レビュアのうち報告比率が低い finding には fp_score にボーナスを加算：
+
+```go
+func agreementBonus(reviewerCount, totalReviewers int) int {
+    ratio := float64(reviewerCount) / float64(totalReviewers)
+    switch {
+    case ratio < 0.2: return 15  // 20%未満の合意 → +15
+    case ratio < 0.4: return 10  // 40%未満の合意 → +10
+    default:          return 0
+    }
+}
+```
+
+### 4.3 prior feedback 統合
+
+PR上の過去コメント（DISMISSED / FIXED / INTENTIONAL / ACKNOWLEDGED）をプロンプトに注入し、既知の議論済み項目のスコアを引き上げる。
+
+### 4.4 プロンプトの判定基準
+
+| 分類 | fp_score | 具体例 |
+|---|---|---|
+| LIKELY FALSE POSITIVE | 70-100 | スタイル/フォーマット、ドキュメント提案、"Consider doing X" |
+| UNCERTAIN | 40-60 | エビデンス不足、コンテキスト依存 |
+| LIKELY TRUE POSITIVE | 0-30 | セキュリティ脆弱性、null参照、リソースリーク、競合状態 |
+
+### 4.5 使用するバックエンド
+
+`SummarizerAgent` と `SummarizerModel` を流用（独自設定なし）。デフォルトは codex。
+
+## 5. Summarizer（2層構造）
+
+### 5.1 Finding Summarizer (`internal/summarizer/`)
+
+複数レビュアの並列レビュー結果をLLMに渡し、重複する finding をクラスタリング・要約する。
+
+- 入力: `[]domain.AggregatedFinding` → JSON
+- 出力: `findings` (アクション要) と `info` (情報のみ) に分類
+- 使用バックエンド: `SummarizerAgent` (デフォルト: codex)
+
+### 5.2 Feedback Summarizer (`internal/feedback/`)
+
+`gh pr view` 等で PR のコメント・リプライを取得し、LLM に渡して過去のコード指摘を構造化抽出する。
+
+- 出力形式: `STATUS: "finding description" -- reason (by @author)`
+- STATUS: DISMISSED / FIXED / ACKNOWLEDGED / INTENTIONAL
+- 抽出結果は FP Filter のプロンプトに注入される
+- 使用バックエンド: `PRFeedbackAgent` (未設定時は `SummarizerAgent` にフォールバック)
+- レビュアーと並行して実行される（goroutine + sync.WaitGroup）
+
+## 6. 各コンポーネントのデフォルトバックエンド
+
+| コンポーネント | 設定キー | デフォルト |
+|---|---|---|
+| レビュアー | `ReviewerAgents` | `["codex"]` |
+| Finding Summarizer | `SummarizerAgent` | `"codex"` |
+| FP Filter | `SummarizerAgent` (流用) | `"codex"` |
+| Feedback Summarizer | `PRFeedbackAgent` → `SummarizerAgent` | `"codex"` |
+
+## 7. レビュアーエージェントの外部制御可能性
+
+### 7.1 モデル指定
+
+| 設定対象 | CLI フラグ | 環境変数 | .acr.yaml |
+|---|---|---|---|
+| レビュアー | `--reviewer-model` | `ACR_REVIEWER_MODEL` | `reviewer_model` |
+| Summarizer / FP Filter | `--summarizer-model` | `ACR_SUMMARIZER_MODEL` | `summarizer_model` |
+
+**制限**: モデル指定はレビュアー全体で1つ。エージェントごとの個別モデル指定は不可。異種エージェント混成時に `--reviewer-model` を指定すると、全バックエンドに同じ文字列が渡される。
+
+### 7.2 各バックエンドの数（分配比率）
+
+`--reviewer-agent` (`-a`) はカンマ区切りで複数エージェントを指定可能。分配はラウンドロビン：
+
+```go
+func AgentForReviewer(agents []Agent, reviewerID int) Agent {
+    return agents[(reviewerID-1)%len(agents)]
+}
+```
+
+例: `--reviewer-agent codex,claude,gemini -r 9` → 各3台ずつ均等分配
+
+重み付けの直接指定はできないが、同じ名前を繰り返すことで擬似的に制御可能：
+```
+--reviewer-agent codex,codex,claude -r 6
+→ codex:4, claude:2
+```
+
+### 7.3 guidance（スコープ / レビュー指示）
+
+| 設定方法 | 優先順位 |
+|---|---|
+| `--guidance "テキスト"` | 1 (最高) |
+| `--guidance-file path` | 2 |
+| `ACR_GUIDANCE` 環境変数 | 3 |
+| `ACR_GUIDANCE_FILE` 環境変数 | 4 |
+| `.acr.yaml: guidance_file` | 5 |
+
+guidance はレビュープロンプト中の `{{guidance}}` プレースホルダに展開される：
+
+```go
+func RenderPrompt(template, guidance string) string {
+    return strings.ReplaceAll(template, "{{guidance}}", "\nAdditional context:\n"+guidance)
+}
+```
+
+**制限**: 全レビュアーに同一の guidance が渡される。エージェントごとに異なる guidance を渡すことは不可。
+
+### 7.4 その他の制御パラメータ
+
+| 項目 | CLI フラグ | 環境変数 | .acr.yaml | デフォルト |
+|---|---|---|---|---|
+| レビュアー数 | `-r` | `ACR_REVIEWERS` | `reviewers` | 5 |
+| 同時実行数 | `-c` | `ACR_CONCURRENCY` | `concurrency` | = reviewers |
+| タイムアウト (レビュアー) | `-t` | `ACR_TIMEOUT` | `timeout` | 10m |
+| リトライ回数 | `-R` | `ACR_RETRIES` | `retries` | 1 |
+| ref-file モード | `--ref-file` | — | — | auto (大きいdiffで自動) |
+| FP フィルタ有効 | `--no-fp-filter` | `ACR_FP_FILTER` | `fp_filter.enabled` | true |
+| FP 閾値 | `--fp-threshold` | `ACR_FP_THRESHOLD` | `fp_filter.threshold` | 75 |
+| Summarizer タイムアウト | `--summarizer-timeout` | `ACR_SUMMARIZER_TIMEOUT` | `summarizer_timeout` | 5m |
+| FP Filter タイムアウト | `--fp-filter-timeout` | `ACR_FP_FILTER_TIMEOUT` | `fp_filter_timeout` | 5m |
+| 除外パターン | `--exclude-pattern` | — | `filters.exclude_patterns` | — |
+| PR feedback 有効 | `--no-pr-feedback` | `ACR_PR_FEEDBACK` | `pr_feedback.enabled` | true |
+| PR feedback エージェント | `--pr-feedback-agent` | `ACR_PR_FEEDBACK_AGENT` | `pr_feedback.agent` | = summarizer |
+
+設定優先順位: CLI フラグ > 環境変数 > .acr.yaml > デフォルト値
+
+### 7.5 できること・できないことの整理
+
+**できる:**
+- バックエンドの種類選択（codex / claude / gemini の任意組合せ）
+- 全レビュアー共通のモデル指定
+- ラウンドロビンによる分配比率の擬似制御（名前の繰り返し）
+- 全レビュアー共通の guidance 注入
+- 並列数・タイムアウト・リトライの制御
+
+**できない:**
+- エージェントごとに異なるモデルを指定
+- エージェントごとに異なる guidance / プロンプトを渡す
+- 分配比率の明示的な重み指定
+- レビュープロンプト自体のカスタマイズ（ハードコード）
+- レビュアーごとに異なるタイムアウトやリトライ設定
+
+## 8. 設計思想
+
+- **レビュアーは均質な「投票者」**: 個別チューニングより「N人の独立レビュアーのコンセンサス」を重視
+- **LLM 依存**: FP Filter も Summarizer も独自の NLP/ML モデルは使わず、全面的に LLM のプロンプトエンジニアリングに依存
+- **fail-open**: LLM 実行失敗時はフィルタをスキップして全 finding を通す安全設計
+- **CLI ラッパー**: LLM API を直接呼ばず、各ベンダーの CLI をサブプロセスとして起動することで認証・モデル管理を各 CLI に委譲

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -467,12 +466,16 @@ func runReview(cmd *cobra.Command, _ []string) error {
 
 	// Handle signals
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, interruptSignals()...)
+	defer signal.Stop(sigCh)
 	go func() {
-		<-sigCh
-		fmt.Fprintln(os.Stderr)
-		logger.Log("Interrupted, shutting down...", terminal.StyleWarning)
-		cancel()
+		select {
+		case <-sigCh:
+			fmt.Fprintln(os.Stderr)
+			logger.Log("Interrupted, shutting down...", terminal.StyleWarning)
+			cancel()
+		case <-ctx.Done():
+		}
 	}()
 
 	// Set up worktree (--pr or --worktree-branch)

--- a/cmd/acr/signals_unix.go
+++ b/cmd/acr/signals_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func interruptSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/cmd/acr/signals_windows.go
+++ b/cmd/acr/signals_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func interruptSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,7 +1,7 @@
 // Package integration provides end-to-end tests for the acr binary using mock agent CLIs.
 //
 // These tests replace the BATS integration tests with Go tests that:
-//   - Use mock CLI scripts instead of real LLM backends (zero cost, fast, deterministic)
+//   - Use mock CLI binaries instead of real LLM backends (zero cost, fast, deterministic)
 //   - Test the full binary (build → exec → assert output + exit code)
 //   - Cover success paths, error paths, output format, and flag handling
 //
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -42,7 +43,11 @@ func ensureBinary(t *testing.T) string {
 	buildOnce.Do(func() {
 		builtAcrRoot = findRepoRoot(t)
 		// Use a stable path under the build dir so it persists across tests
-		builtAcrBin = filepath.Join(builtAcrRoot, "bin", "acr-test")
+		name := "acr-test"
+		if runtime.GOOS == "windows" {
+			name += ".exe"
+		}
+		builtAcrBin = filepath.Join(builtAcrRoot, "bin", name)
 		build := exec.Command("go", "build", "-o", builtAcrBin, "./cmd/acr")
 		build.Dir = builtAcrRoot
 		out, err := build.CombinedOutput()
@@ -82,15 +87,47 @@ func setupTestEnv(t *testing.T) *testEnv {
 // withMockAgents prepends the mock directory to PATH so mock CLIs are found first.
 func (e *testEnv) withMockAgents() []string {
 	env := os.Environ()
-	newPath := e.mockDir + ":" + e.origPath
+	newPath := e.mockDir
+	if e.origPath != "" {
+		newPath += string(os.PathListSeparator) + e.origPath
+	}
 	// Replace PATH in env slice
-	for i, v := range env {
-		if strings.HasPrefix(v, "PATH=") {
-			env[i] = "PATH=" + newPath
-			return env
+	if env, ok := replaceEnvVar(env, "PATH", newPath); ok {
+		env = append(env, integrationMockEnv+"=1")
+		return env
+	}
+	env = append(env, "PATH="+newPath)
+	env = append(env, integrationMockEnv+"=1")
+	return env
+}
+
+func replaceEnvVar(env []string, key, value string) ([]string, bool) {
+	lastMatch := -1
+
+	for i, entry := range env {
+		name, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			continue
+		}
+
+		if runtime.GOOS == "windows" {
+			if strings.EqualFold(name, key) {
+				lastMatch = i
+			}
+			continue
+		}
+
+		if name == key {
+			lastMatch = i
 		}
 	}
-	return append(env, "PATH="+newPath)
+
+	if lastMatch == -1 {
+		return env, false
+	}
+
+	env[lastMatch] = key + "=" + value
+	return env, true
 }
 
 // run executes acr with the given args and returns stdout, stderr, and exit code.
@@ -232,107 +269,39 @@ func geminiLGTMSummary() string {
 	return `{"response":"{\"findings\":[],\"info\":[]}"}`
 }
 
-// --- Mock CLI Script Generators ---
-
-// writeMockCLI writes a shell script that returns canned responses.
-// The script examines its arguments to determine if it's being called as
-// a reviewer (--print without --output-format) or summarizer/fp-filter (--output-format json).
+// writeMock* copies the current test binary into the mock directory using the
+// requested command name. The binary itself switches into mock-CLI mode when
+// the integrationMockEnv environment variable is present.
 func writeMockCodex(t *testing.T, dir string, reviewResponse, summaryResponse string) {
 	t.Helper()
-	// Codex uses --json for structured output (summarizer) vs no --json (reviewer)
-	script := fmt.Sprintf(`#!/bin/sh
-# Consume stdin to prevent broken pipe on large diffs
-cat /dev/stdin >/dev/null 2>&1
-
-has_json=false
-for arg in "$@"; do
-    if [ "$arg" = "--json" ]; then
-        has_json=true
-    fi
-done
-
-if [ "$has_json" = "true" ]; then
-    printf '%%s\n' '%s'
-else
-    cat <<'REVIEW_EOF'
-%s
-REVIEW_EOF
-fi
-`, escape(summaryResponse), reviewResponse)
-
-	writeMock(t, dir, "codex", script)
+	t.Setenv(integrationCodexReviewEnv, reviewResponse)
+	t.Setenv(integrationCodexSummaryEnv, summaryResponse)
+	writeMock(t, dir, "codex")
 }
 
 func writeMockClaude(t *testing.T, dir string, reviewResponse, summaryResponse string) {
 	t.Helper()
-	// Claude uses --output-format json for structured output (summarizer) vs --print only (reviewer)
-	script := fmt.Sprintf(`#!/bin/sh
-has_json=false
-for arg in "$@"; do
-    if [ "$arg" = "json" ]; then
-        has_json=true
-    fi
-done
-
-if [ "$has_json" = "true" ]; then
-    cat /dev/stdin >/dev/null 2>&1
-    printf '%%s\n' '%s'
-else
-    cat /dev/stdin >/dev/null 2>&1
-    cat <<'REVIEW_EOF'
-%s
-REVIEW_EOF
-fi
-`, escape(summaryResponse), reviewResponse)
-
-	writeMock(t, dir, "claude", script)
+	t.Setenv(integrationClaudeReviewEnv, reviewResponse)
+	t.Setenv(integrationClaudeSummaryEnv, summaryResponse)
+	writeMock(t, dir, "claude")
 }
 
 func writeMockGemini(t *testing.T, dir string, reviewResponse, summaryResponse string) {
 	t.Helper()
-	// Gemini uses -o json for structured output (summarizer) vs no -o (reviewer)
-	script := fmt.Sprintf(`#!/bin/sh
-has_json=false
-for arg in "$@"; do
-    if [ "$arg" = "json" ]; then
-        has_json=true
-    fi
-done
-
-if [ "$has_json" = "true" ]; then
-    cat /dev/stdin >/dev/null 2>&1
-    printf '%%s\n' '%s'
-else
-    cat /dev/stdin >/dev/null 2>&1
-    cat <<'REVIEW_EOF'
-%s
-REVIEW_EOF
-fi
-`, escape(summaryResponse), reviewResponse)
-
-	writeMock(t, dir, "gemini", script)
+	t.Setenv(integrationGeminiReviewEnv, reviewResponse)
+	t.Setenv(integrationGeminiSummaryEnv, summaryResponse)
+	writeMock(t, dir, "gemini")
 }
 
-func writeMock(t *testing.T, dir, name, script string) {
+func writeMock(t *testing.T, dir, name string) {
 	t.Helper()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
-		t.Fatalf("failed to write mock %s: %v", name, err)
-	}
+	copyIntegrationHelperBinary(t, dir, name)
 }
 
 // Also mock gh CLI to prevent real GitHub API calls
 func writeMockGH(t *testing.T, dir string) {
 	t.Helper()
-	script := `#!/bin/sh
-# Mock gh - return empty/error for all commands
-exit 1
-`
-	writeMock(t, dir, "gh", script)
-}
-
-func escape(s string) string {
-	return strings.ReplaceAll(s, "'", "'\"'\"'")
+	writeMock(t, dir, "gh")
 }
 
 // --- Tests ---
@@ -345,6 +314,37 @@ func TestVersion(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "acr v") {
 		t.Errorf("expected 'acr v' in output, got: %s", stdout)
+	}
+}
+
+func TestReplaceEnvVar_PathCaseInsensitiveOnWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-specific PATH casing behavior")
+	}
+
+	env, ok := replaceEnvVar([]string{"Path=C:\\Windows\\System32"}, "PATH", "C:\\tmp")
+	if !ok {
+		t.Fatal("replaceEnvVar did not find Path entry")
+	}
+	if env[0] != "PATH=C:\\tmp" {
+		t.Fatalf("replaceEnvVar() = %q, want %q", env[0], "PATH=C:\\tmp")
+	}
+}
+
+func TestReplaceEnvVar_ReplacesLastMatch(t *testing.T) {
+	env, ok := replaceEnvVar([]string{
+		"PATH=C:\\first",
+		"OTHER=1",
+		"PATH=C:\\second",
+	}, "PATH", "C:\\tmp")
+	if !ok {
+		t.Fatal("replaceEnvVar did not find PATH entry")
+	}
+	if env[0] != "PATH=C:\\first" {
+		t.Fatalf("first PATH entry = %q, want unchanged", env[0])
+	}
+	if env[2] != "PATH=C:\\tmp" {
+		t.Fatalf("last PATH entry = %q, want %q", env[2], "PATH=C:\\tmp")
 	}
 }
 
@@ -666,32 +666,27 @@ func TestInvalidAgentName(t *testing.T) {
 
 func TestMissingAgentCLI(t *testing.T) {
 	env := setupTestEnv(t)
-	// Create a dir with gh mock but no agent CLIs
-	// Prepend it to PATH so it shadows any real agent CLIs
 	noAgentDir := t.TempDir()
-	writeMockGH(t, noAgentDir)
-
-	// Write dummy scripts that shadow real agent CLIs but exit with "not found"
-	for _, name := range []string{"codex", "claude", "gemini"} {
-		script := "#!/bin/sh\nexit 127\n"
-		if err := os.WriteFile(filepath.Join(noAgentDir, name), []byte(script), 0755); err != nil {
-			t.Fatal(err)
-		}
-	}
+	copyIntegrationHelperBinary(t, noAgentDir, "codex")
+	copyIntegrationHelperBinary(t, noAgentDir, "claude")
+	copyIntegrationHelperBinary(t, noAgentDir, "gemini")
+	copyIntegrationHelperBinary(t, noAgentDir, "gh")
 
 	cmd := exec.Command(env.acrBin, "--local", "--reviewer-agent", "codex",
 		"--summarizer-agent", "codex", "--base", "HEAD~1")
 	cmd.Dir = env.repoDir
-	// Prepend noAgentDir to PATH (keeps system tools like git available)
-	// Replace PATH in env slice to avoid duplicate entries
+	// Prepend noAgentDir to PATH so the helper binaries shadow any real CLIs.
 	sysEnv := os.Environ()
-	newPath := noAgentDir + ":" + env.origPath
-	for i, v := range sysEnv {
-		if strings.HasPrefix(v, "PATH=") {
-			sysEnv[i] = "PATH=" + newPath
-			break
-		}
+	newPath := noAgentDir
+	if env.origPath != "" {
+		newPath += string(os.PathListSeparator) + env.origPath
 	}
+	var replaced bool
+	sysEnv, replaced = replaceEnvVar(sysEnv, "PATH", newPath)
+	if !replaced {
+		sysEnv = append(sysEnv, "PATH="+newPath)
+	}
+	sysEnv = append(sysEnv, integrationMockEnv+"=1", integrationMockModeEnv+"=missing")
 	cmd.Env = sysEnv
 
 	out, err := cmd.CombinedOutput()

--- a/integration/testhelpers_test.go
+++ b/integration/testhelpers_test.go
@@ -1,0 +1,125 @@
+package integration
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const integrationMockEnv = "ACR_INTEGRATION_TEST_HELPER"
+const integrationMockModeEnv = "ACR_INTEGRATION_TEST_HELPER_MODE"
+const (
+	integrationCodexReviewEnv   = "ACR_INTEGRATION_CODEX_REVIEW"
+	integrationCodexSummaryEnv  = "ACR_INTEGRATION_CODEX_SUMMARY"
+	integrationClaudeReviewEnv  = "ACR_INTEGRATION_CLAUDE_REVIEW"
+	integrationClaudeSummaryEnv = "ACR_INTEGRATION_CLAUDE_SUMMARY"
+	integrationGeminiReviewEnv  = "ACR_INTEGRATION_GEMINI_REVIEW"
+	integrationGeminiSummaryEnv = "ACR_INTEGRATION_GEMINI_SUMMARY"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(integrationMockEnv) == "1" {
+		os.Exit(runIntegrationMockCLI())
+	}
+	os.Exit(m.Run())
+}
+
+func runIntegrationMockCLI() int {
+	name := strings.ToLower(strings.TrimSuffix(filepath.Base(os.Args[0]), filepath.Ext(os.Args[0])))
+	_, _ = io.Copy(io.Discard, os.Stdin)
+
+	if os.Getenv(integrationMockModeEnv) == "missing" {
+		return 127
+	}
+
+	switch name {
+	case "codex":
+		if hasArg("--json") {
+			fmt.Fprintln(os.Stdout, envOrDefault(integrationCodexSummaryEnv, codexSummarizerResponse))
+			return 0
+		}
+		fmt.Fprint(os.Stdout, envOrDefault(integrationCodexReviewEnv, codexReviewerResponse))
+		return 0
+	case "claude":
+		if hasArg("json") {
+			fmt.Fprintln(os.Stdout, envOrDefault(integrationClaudeSummaryEnv, claudeSummarizerJSON()))
+			return 0
+		}
+		fmt.Fprint(os.Stdout, envOrDefault(integrationClaudeReviewEnv, claudeReviewerResponse))
+		return 0
+	case "gemini":
+		if hasArg("json") {
+			fmt.Fprintln(os.Stdout, envOrDefault(integrationGeminiSummaryEnv, geminiSummarizerJSON()))
+			return 0
+		}
+		fmt.Fprint(os.Stdout, envOrDefault(integrationGeminiReviewEnv, geminiReviewerResponse))
+		return 0
+	case "gh":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func hasArg(target string) bool {
+	for _, arg := range os.Args[1:] {
+		if arg == target {
+			return true
+		}
+	}
+	return false
+}
+
+func copyIntegrationHelperBinary(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	src, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to determine test executable path: %v", err)
+	}
+
+	dst := filepath.Join(dir, integrationHelperBinaryName(name))
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("failed to open test executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		t.Fatalf("failed to create helper binary %s: %v", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		t.Fatalf("failed to copy helper binary to %s: %v", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("failed to close helper binary %s: %v", dst, err)
+	}
+
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(dst, 0o755); err != nil {
+			t.Fatalf("failed to mark helper binary executable: %v", err)
+		}
+	}
+
+	return dst
+}
+
+func integrationHelperBinaryName(name string) string {
+	if runtime.GOOS == "windows" && !strings.HasSuffix(strings.ToLower(name), ".exe") {
+		return name + ".exe"
+	}
+	return name
+}

--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"runtime"
 	"slices"
 	"strings"
 )
@@ -27,6 +28,34 @@ var authHints = map[string]string{
 	"codex":  "Set OPENAI_API_KEY or run 'codex auth' to authenticate.",
 }
 
+var nonAuthStartupPatterns = []string{
+	"spawn eperm",
+	"uv_spawn",
+	"failed to relaunch",
+	"operation not permitted",
+	"access is denied",
+}
+
+func containsAuthSignal(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	for _, pattern := range authStderrPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsNonAuthStartupSignal(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	for _, pattern := range nonAuthStartupPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsAuthFailure returns true if the given exit code and stderr indicate
 // an authentication failure for the named agent. Exit code 0 is never
 // considered an auth failure.
@@ -37,18 +66,20 @@ func IsAuthFailure(agentName string, exitCode int, stderr string) bool {
 
 	if codes, ok := authExitCodes[agentName]; ok {
 		if slices.Contains(codes, exitCode) {
+			// Some Windows CLI launch failures reuse the same exit code as auth errors.
+			// Preserve known auth exit codes unless stderr clearly indicates a
+			// startup/spawn failure unrelated to authentication.
+			if runtime.GOOS == "windows" {
+				if containsAuthSignal(stderr) {
+					return true
+				}
+				return !containsNonAuthStartupSignal(stderr)
+			}
 			return true
 		}
 	}
 
-	lower := strings.ToLower(stderr)
-	for _, pattern := range authStderrPatterns {
-		if strings.Contains(lower, pattern) {
-			return true
-		}
-	}
-
-	return false
+	return containsAuthSignal(stderr)
 }
 
 // AuthHint returns an actionable error message for the named agent.

--- a/internal/agent/auth_test.go
+++ b/internal/agent/auth_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"runtime"
 	"testing"
 )
 
@@ -13,6 +14,9 @@ func TestIsAuthFailure(t *testing.T) {
 		want     bool
 	}{
 		{"gemini exit 41", "gemini", 41, "", true},
+		{"gemini exit 41 with spawn EPERM follows platform behavior", "gemini", 41, "spawn EPERM", runtime.GOOS != "windows"},
+		{"gemini exit 41 with relaunch failure follows platform behavior", "gemini", 41, "Failed to relaunch the CLI process", runtime.GOOS != "windows"},
+		{"gemini exit 41 with auth stderr remains auth failure", "gemini", 41, "authentication required", true},
 		{"gemini exit 0 is never auth failure", "gemini", 0, "", false},
 		{"gemini other exit code", "gemini", 1, "", false},
 		{"unknown agent with auth stderr", "unknown", 1, "api_key not set", true},

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -27,26 +27,26 @@ func TestClaudeAgent_Name(t *testing.T) {
 }
 
 func TestClaudeAgent_IsAvailable(t *testing.T) {
-	agent := NewClaudeAgent("")
-	err := agent.IsAvailable()
+	t.Run("available", func(t *testing.T) {
+		prepareMockCLI(t, "claude", "args")
+		agent := NewClaudeAgent("")
+		if err := agent.IsAvailable(); err != nil {
+			t.Errorf("IsAvailable() unexpected error = %v", err)
+		}
+	})
 
-	// Check if claude is in PATH
-	_, lookPathErr := exec.LookPath("claude")
-
-	if lookPathErr != nil {
-		// Claude not in PATH - should return error
+	t.Run("missing", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		agent := NewClaudeAgent("")
+		err := agent.IsAvailable()
 		if err == nil {
 			t.Error("IsAvailable() should return error when claude is not in PATH")
+			return
 		}
 		if !strings.Contains(err.Error(), "claude CLI not found") {
 			t.Errorf("IsAvailable() error = %v, want error containing 'claude CLI not found'", err)
 		}
-	} else {
-		// Claude is in PATH - should return nil
-		if err != nil {
-			t.Errorf("IsAvailable() unexpected error = %v", err)
-		}
-	}
+	})
 }
 
 func TestClaudeAgent_ExecuteReview_ClaudeNotAvailable(t *testing.T) {
@@ -135,14 +135,7 @@ func TestClaudeAgent_ExecuteReview_Args(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockScript := filepath.Join(tmpDir, "claude")
-	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"ARG:$arg\"; done\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "claude", "args-prefix-stdin")
 
 	agent := NewClaudeAgent("")
 	ctx := context.Background()
@@ -206,14 +199,7 @@ func TestClaudeAgent_ExecuteReview_RefFileMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockScript := filepath.Join(tmpDir, "claude")
-	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\ncat\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "claude", "stdin")
 
 	agent := NewClaudeAgent("")
 	ctx := context.Background()
@@ -282,14 +268,7 @@ func TestClaudeAgent_ExecuteReview_ExplicitRefFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockScript := filepath.Join(tmpDir, "claude")
-	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\ncat\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "claude", "stdin")
 
 	agent := NewClaudeAgent("")
 	ctx := context.Background()
@@ -317,15 +296,7 @@ func TestClaudeAgent_ExecuteReview_ExplicitRefFile(t *testing.T) {
 }
 
 func TestClaudeAgent_ExecuteSummary_Args(t *testing.T) {
-	tmpDir := t.TempDir()
-	mockScript := filepath.Join(tmpDir, "claude")
-	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"ARG:$arg\"; done\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "claude", "args-prefix-stdin")
 
 	agent := NewClaudeAgent("")
 	ctx := context.Background()

--- a/internal/agent/cmd_reader.go
+++ b/internal/agent/cmd_reader.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os/exec"
 	"sync"
-	"syscall"
 )
 
 // Compile-time interface check
@@ -28,8 +27,8 @@ type cmdReader struct {
 
 // Close implements io.Closer and waits for the command to complete.
 // After Close returns, ExitCode() will return the process exit code.
-// If the context was canceled or timed out, it kills the entire process group
-// to ensure no orphaned processes are left behind.
+// If the context was canceled or timed out, exec.Cmd.Wait handles cancellation
+// via the command's configured Cancel hook and WaitDelay.
 // Close is safe for concurrent calls - only the first call performs cleanup.
 func (r *cmdReader) Close() error {
 	r.closeOnce.Do(func() {
@@ -38,18 +37,15 @@ func (r *cmdReader) Close() error {
 			_ = closer.Close()
 		}
 
-		// Kill the process group if context was canceled or timed out
+		// Preserve cancellation for callers using plain exec.Command without a
+		// custom Cancel hook. executeCommand installs cmd.Cancel, so this fallback
+		// does not double-terminate normal reviewer processes.
 		if r.cmd != nil && r.cmd.Process != nil {
-			// Capture PID before any state changes to prevent race condition
-			pid := r.cmd.Process.Pid
-
-			if r.ctx != nil && r.ctx.Err() != nil {
-				// Kill the entire process group (negative PID)
-				// Ignore errors - process may have already exited
-				_ = syscall.Kill(-pid, syscall.SIGKILL)
+			if r.ctx != nil && r.ctx.Err() != nil && r.cmd.Cancel == nil {
+				_ = terminateProcessTree(r.cmd)
 			}
 
-			// Wait for command to complete and capture exit code
+			// Wait for command completion and capture exit status.
 			err := r.cmd.Wait()
 			if err != nil {
 				if exitErr, ok := err.(*exec.ExitError); ok {

--- a/internal/agent/cmd_reader.go
+++ b/internal/agent/cmd_reader.go
@@ -50,6 +50,8 @@ func (r *cmdReader) Close() error {
 			if err != nil {
 				if exitErr, ok := err.(*exec.ExitError); ok {
 					r.exitCode = exitErr.ExitCode()
+				} else if r.cmd.ProcessState != nil {
+					r.exitCode = r.cmd.ProcessState.ExitCode()
 				} else {
 					r.exitCode = -1
 				}

--- a/internal/agent/cmd_reader_test.go
+++ b/internal/agent/cmd_reader_test.go
@@ -242,12 +242,12 @@ func TestTerminateProcessTree_ReturnsErrProcessDoneForCompletedProcess(t *testin
 		t.Fatalf("ReadAll() error = %v", err)
 	}
 
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v, want nil", err)
+	}
+
 	err = terminateProcessTree(cmd)
 	if !errors.Is(err, os.ErrProcessDone) {
 		t.Fatalf("terminateProcessTree() error = %v, want os.ErrProcessDone", err)
-	}
-
-	if err := cmd.Wait(); err != nil {
-		t.Fatalf("Wait() error = %v, want nil", err)
 	}
 }

--- a/internal/agent/cmd_reader_test.go
+++ b/internal/agent/cmd_reader_test.go
@@ -2,16 +2,16 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 	"testing"
 )
 
 func TestCmdReader_Close(t *testing.T) {
-	// Create a simple command that we can close
-	cmd := exec.Command("echo", "test")
+	cmd := newHelperCommand(t, "exit")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatalf("Failed to create stdout pipe: %v", err)
@@ -49,7 +49,7 @@ func TestCmdReader_Close_NilCommand(t *testing.T) {
 }
 
 func TestCmdReader_Close_CommandNotStarted(t *testing.T) {
-	cmd := exec.Command("echo", "test")
+	cmd := newHelperCommand(t, "exit")
 
 	reader := &cmdReader{
 		Reader: strings.NewReader("test"),
@@ -63,7 +63,8 @@ func TestCmdReader_Close_CommandNotStarted(t *testing.T) {
 }
 
 func TestCmdReader_ExitCode_Success(t *testing.T) {
-	cmd := exec.Command("true")
+	cmd := newHelperCommand(t, "exit")
+	cmd.Env = append(cmd.Env, agentTestHelperExitEnv+"=0")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatalf("Failed to create stdout pipe: %v", err)
@@ -87,7 +88,8 @@ func TestCmdReader_ExitCode_Success(t *testing.T) {
 }
 
 func TestCmdReader_ExitCode_Failure(t *testing.T) {
-	cmd := exec.Command("false")
+	cmd := newHelperCommand(t, "exit")
+	cmd.Env = append(cmd.Env, agentTestHelperExitEnv+"=3")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatalf("Failed to create stdout pipe: %v", err)
@@ -111,7 +113,7 @@ func TestCmdReader_ExitCode_Failure(t *testing.T) {
 }
 
 func TestCmdReader_Close_Idempotent(t *testing.T) {
-	cmd := exec.Command("echo", "test")
+	cmd := newHelperCommand(t, "exit")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatalf("Failed to create stdout pipe: %v", err)
@@ -139,7 +141,7 @@ func TestCmdReader_Close_Idempotent(t *testing.T) {
 
 func TestCmdReader_CloseWithNilProcess(t *testing.T) {
 	// cmdReader with cmd set but Process is nil (Start() was never called)
-	cmd := exec.Command("true") // Don't start it
+	cmd := newHelperCommand(t, "exit") // Don't start it
 
 	reader := &cmdReader{
 		Reader: strings.NewReader(""),
@@ -156,14 +158,16 @@ func TestCmdReader_CloseWithNilProcess(t *testing.T) {
 
 func TestCmdReader_CloseWithContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
+	cmd := newHelperCommand(t, "sleep")
+	cmd.Env = append(cmd.Env, agentTestHelperSleepEnv+"=30s")
 
-	// Create a long-running command
-	cmd := exec.CommandContext(ctx, "sleep", "10")
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	stdout, _ := cmd.StdoutPipe()
-	_ = cmd.Start()
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("Failed to create stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start helper command: %v", err)
+	}
 
 	reader := &cmdReader{
 		Reader: stdout,
@@ -171,9 +175,79 @@ func TestCmdReader_CloseWithContextCancel(t *testing.T) {
 		ctx:    ctx,
 	}
 
-	// Should kill process group and not panic
-	err := reader.Close()
+	cancel()
+
+	// Should kill the helper process and not panic
+	err = reader.Close()
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCmdReader_CloseAfterCancelOnCompletedProcess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, helperBinaryPath(t))
+	cmd.Env = append(os.Environ(),
+		agentTestHelperEnv+"=1",
+		agentTestHelperModeEnv+"=exit",
+	)
+	configureCmdForPlatform(cmd)
+	cmd.Cancel = func() error {
+		return terminateProcessTree(cmd)
+	}
+	cmd.WaitDelay = cmdWaitDelay
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("Failed to create stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start helper command: %v", err)
+	}
+
+	reader := &cmdReader{
+		Reader: stdout,
+		cmd:    cmd,
+		ctx:    ctx,
+	}
+
+	if _, err := io.ReadAll(reader); err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	cancel()
+
+	if err := reader.Close(); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+	if got := reader.ExitCode(); got != 0 {
+		t.Fatalf("ExitCode() = %d, want 0", got)
+	}
+}
+
+func TestTerminateProcessTree_ReturnsErrProcessDoneForCompletedProcess(t *testing.T) {
+	cmd := newHelperCommand(t, "exit")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("Failed to create stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Failed to start helper command: %v", err)
+	}
+
+	if _, err := io.ReadAll(stdout); err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	err = terminateProcessTree(cmd)
+	if !errors.Is(err, os.ErrProcessDone) {
+		t.Fatalf("terminateProcessTree() error = %v, want os.ErrProcessDone", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v, want nil", err)
 	}
 }

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -27,26 +27,26 @@ func TestCodexAgent_Name(t *testing.T) {
 }
 
 func TestCodexAgent_IsAvailable(t *testing.T) {
-	agent := NewCodexAgent("")
-	err := agent.IsAvailable()
+	t.Run("available", func(t *testing.T) {
+		prepareMockCLI(t, "codex", "args")
+		agent := NewCodexAgent("")
+		if err := agent.IsAvailable(); err != nil {
+			t.Errorf("IsAvailable() unexpected error = %v", err)
+		}
+	})
 
-	// Check if codex is in PATH
-	_, lookPathErr := exec.LookPath("codex")
-
-	if lookPathErr != nil {
-		// Codex not in PATH - should return error
+	t.Run("missing", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		agent := NewCodexAgent("")
+		err := agent.IsAvailable()
 		if err == nil {
 			t.Error("IsAvailable() should return error when codex is not in PATH")
+			return
 		}
 		if !strings.Contains(err.Error(), "codex CLI not found") {
 			t.Errorf("IsAvailable() error = %v, want error containing 'codex CLI not found'", err)
 		}
-	} else {
-		// Codex is in PATH - should return nil
-		if err != nil {
-			t.Errorf("IsAvailable() unexpected error = %v", err)
-		}
-	}
+	})
 }
 
 func TestCodexAgent_ExecuteReview_CodexNotAvailable(t *testing.T) {
@@ -102,22 +102,13 @@ func TestCodexAgent_ExecuteSummary_CodexNotAvailable(t *testing.T) {
 }
 
 func TestCodexAgent_ExecuteReview_ArgsWithoutGuidance(t *testing.T) {
-	tmpDir := t.TempDir()
-	mockScript := filepath.Join(tmpDir, "codex")
-	err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"$arg\"; done\n"), 0755)
-	if err != nil {
-		t.Fatalf("failed to write mock script: %v", err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir)
+	prepareMockCLI(t, "codex", "args")
 
 	agent := NewCodexAgent("")
 	ctx := context.Background()
 	config := &ReviewConfig{
 		BaseRef: "main",
-		WorkDir: tmpDir,
+		WorkDir: t.TempDir(),
 	}
 
 	result, err := agent.ExecuteReview(ctx, config)
@@ -178,16 +169,7 @@ func TestCodexAgent_ExecuteReview_ArgsWithGuidance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Mock codex that prints args and stdin
-	mockScript := filepath.Join(tmpDir, "codex")
-	err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"ARG:$arg\"; done\ncat\n"), 0755)
-	if err != nil {
-		t.Fatalf("failed to write mock script: %v", err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "codex", "args-prefix-stdin")
 
 	agent := NewCodexAgent("")
 	ctx := context.Background()
@@ -228,16 +210,7 @@ func TestCodexAgent_ExecuteReview_ArgsWithGuidance(t *testing.T) {
 }
 
 func TestCodexAgent_ExecuteSummary_Args(t *testing.T) {
-	tmpDir := t.TempDir()
-	mockScript := filepath.Join(tmpDir, "codex")
-	err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"$arg\"; done\n"), 0755)
-	if err != nil {
-		t.Fatalf("failed to write mock script: %v", err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir)
+	prepareMockCLI(t, "codex", "args")
 
 	agent := NewCodexAgent("")
 	ctx := context.Background()

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"syscall"
+	"time"
 )
 
 // maxStderrSize is the maximum bytes captured from agent subprocess stderr.
 // Prevents unbounded memory growth from misbehaving CLI tools.
 const maxStderrSize = 1 << 20 // 1MB
+
+// cmdWaitDelay bounds how long Wait may block after cancellation before the
+// standard library closes pipes and force-kills the root process.
+const cmdWaitDelay = 5 * time.Second
 
 // stderrBuffer is the interface for stderr capture buffers.
 type stderrBuffer interface {
@@ -66,11 +70,12 @@ type executeOptions struct {
 	TempFilePath string
 }
 
-// executeCommand runs a CLI command with proper process group setup and resource management.
+// executeCommand runs a CLI command with platform-specific process handling.
 // This is the shared implementation used by all agent ExecuteReview/ExecuteSummary methods.
 //
 // It handles:
-//   - Setting process group for proper signal handling (Setpgid)
+//   - Applying platform-specific process configuration
+//   - Installing cancellation hooks for process tree cleanup
 //   - Capturing stderr for error diagnostics
 //   - Creating stdout pipe for streaming output
 //   - Starting the command and returning a managed ExecutionResult
@@ -88,8 +93,11 @@ func executeCommand(ctx context.Context, opts executeOptions) (*ExecutionResult,
 		cmd.Dir = opts.WorkDir
 	}
 
-	// Set process group for proper signal handling
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	configureCmdForPlatform(cmd)
+	cmd.Cancel = func() error {
+		return terminateProcessTree(cmd)
+	}
+	cmd.WaitDelay = cmdWaitDelay
 
 	// Capture stderr for error diagnostics (capped to prevent unbounded memory)
 	stderr := newCappedBuffer(maxStderrSize)

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -27,26 +27,26 @@ func TestGeminiAgent_Name(t *testing.T) {
 }
 
 func TestGeminiAgent_IsAvailable(t *testing.T) {
-	agent := NewGeminiAgent("")
-	err := agent.IsAvailable()
+	t.Run("available", func(t *testing.T) {
+		prepareMockCLI(t, "gemini", "args")
+		agent := NewGeminiAgent("")
+		if err := agent.IsAvailable(); err != nil {
+			t.Errorf("IsAvailable() unexpected error = %v", err)
+		}
+	})
 
-	// Check if gemini is in PATH
-	_, lookPathErr := exec.LookPath("gemini")
-
-	if lookPathErr != nil {
-		// Gemini not in PATH - should return error
+	t.Run("missing", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		agent := NewGeminiAgent("")
+		err := agent.IsAvailable()
 		if err == nil {
 			t.Error("IsAvailable() should return error when gemini is not in PATH")
+			return
 		}
 		if !strings.Contains(err.Error(), "gemini CLI not found") {
 			t.Errorf("IsAvailable() error = %v, want error containing 'gemini CLI not found'", err)
 		}
-	} else {
-		// Gemini is in PATH - should return nil
-		if err != nil {
-			t.Errorf("IsAvailable() unexpected error = %v", err)
-		}
-	}
+	})
 }
 
 func TestGeminiAgent_ExecuteReview_GeminiNotAvailable(t *testing.T) {
@@ -135,14 +135,7 @@ func TestGeminiAgent_ExecuteReview_Args(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockScript := filepath.Join(tmpDir, "gemini")
-	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"ARG:$arg\"; done\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "gemini", "args-prefix-stdin")
 
 	agent := NewGeminiAgent("")
 	ctx := context.Background()
@@ -209,14 +202,7 @@ func TestGeminiAgent_ExecuteReview_RefFileMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mockScript := filepath.Join(tmpDir, "gemini")
-	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\ncat\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "gemini", "stdin")
 
 	agent := NewGeminiAgent("")
 	ctx := context.Background()
@@ -249,15 +235,7 @@ func TestGeminiAgent_ExecuteReview_RefFileMode(t *testing.T) {
 }
 
 func TestGeminiAgent_ExecuteSummary_Args(t *testing.T) {
-	tmpDir := t.TempDir()
-	mockScript := filepath.Join(tmpDir, "gemini")
-	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"ARG:$arg\"; done\n"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	originalPath := os.Getenv("PATH")
-	defer os.Setenv("PATH", originalPath)
-	os.Setenv("PATH", tmpDir+":"+originalPath)
+	prepareMockCLI(t, "gemini", "args-prefix-stdin")
 
 	agent := NewGeminiAgent("")
 	ctx := context.Background()

--- a/internal/agent/process_unix.go
+++ b/internal/agent/process_unix.go
@@ -20,9 +20,6 @@ func terminateProcessTree(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
 	}
-	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		return os.ErrProcessDone
-	}
 
 	pid := cmd.Process.Pid
 	pgid, err := syscall.Getpgid(pid)

--- a/internal/agent/process_unix.go
+++ b/internal/agent/process_unix.go
@@ -1,0 +1,49 @@
+//go:build !windows
+
+package agent
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureCmdForPlatform(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func terminateProcessTree(cmd *exec.Cmd) error {
+	if cmd == nil {
+		return nil
+	}
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+		return os.ErrProcessDone
+	}
+
+	pid := cmd.Process.Pid
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+
+	target := -pid
+	if pgid != pid {
+		target = pid
+	}
+
+	err = syscall.Kill(target, syscall.SIGKILL)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.ESRCH) {
+		return os.ErrProcessDone
+	}
+	return err
+}

--- a/internal/agent/process_unix_test.go
+++ b/internal/agent/process_unix_test.go
@@ -1,0 +1,52 @@
+//go:build !windows
+
+package agent
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestTerminateProcessTree_KillsPlainCommandWithoutProcessGroup(t *testing.T) {
+	cmd := exec.Command(helperBinaryPath(t))
+	cmd.Env = append(os.Environ(),
+		agentTestHelperEnv+"=1",
+		agentTestHelperModeEnv+"=sleep",
+		agentTestHelperSleepEnv+"=30s",
+	)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("Getpgid(%d) error = %v", cmd.Process.Pid, err)
+	}
+	if pgid == cmd.Process.Pid {
+		t.Fatalf("expected helper process to inherit parent process group, got pgid == pid == %d", pgid)
+	}
+
+	if err := terminateProcessTree(cmd); err != nil {
+		t.Fatalf("terminateProcessTree() error = %v, want nil", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("Wait() error = %v, want *exec.ExitError after SIGKILL", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait() timed out; helper process was not terminated")
+	}
+}

--- a/internal/agent/process_windows.go
+++ b/internal/agent/process_windows.go
@@ -1,0 +1,73 @@
+//go:build windows
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"golang.org/x/sys/windows"
+)
+
+func configureCmdForPlatform(cmd *exec.Cmd) {}
+
+func terminateProcessTree(cmd *exec.Cmd) error {
+	if cmd == nil {
+		return nil
+	}
+	if cmd.Process == nil {
+		return os.ErrProcessDone
+	}
+	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+		return os.ErrProcessDone
+	}
+
+	pid := strconv.Itoa(cmd.Process.Pid)
+	taskkill := exec.Command("taskkill", "/T", "/F", "/PID", pid)
+	if err := taskkill.Run(); err == nil {
+		return nil
+	}
+	if exited, err := processExited(cmd.Process.Pid); err == nil && exited {
+		return os.ErrProcessDone
+	}
+
+	killErr := cmd.Process.Kill()
+	if killErr == nil {
+		return nil
+	}
+	if errors.Is(killErr, os.ErrProcessDone) {
+		return os.ErrProcessDone
+	}
+	if exited, err := processExited(cmd.Process.Pid); err == nil && exited {
+		return os.ErrProcessDone
+	}
+	return killErr
+}
+
+func processExited(pid int) (bool, error) {
+	access := uint32(windows.PROCESS_QUERY_LIMITED_INFORMATION) | uint32(windows.SYNCHRONIZE)
+	handle, err := windows.OpenProcess(access, false, uint32(pid))
+	if err != nil {
+		if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+			return true, nil
+		}
+		return false, err
+	}
+	defer windows.CloseHandle(handle)
+
+	waitResult, err := windows.WaitForSingleObject(handle, 0)
+	if err != nil {
+		return false, err
+	}
+	if waitResult == uint32(windows.WAIT_OBJECT_0) {
+		return true, nil
+	}
+	if waitResult == uint32(windows.WAIT_TIMEOUT) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("unexpected wait result: %d", waitResult)
+}

--- a/internal/agent/process_windows.go
+++ b/internal/agent/process_windows.go
@@ -21,9 +21,6 @@ func terminateProcessTree(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return os.ErrProcessDone
 	}
-	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-		return os.ErrProcessDone
-	}
 
 	pid := strconv.Itoa(cmd.Process.Pid)
 	taskkill := exec.Command("taskkill", "/T", "/F", "/PID", pid)

--- a/internal/agent/testhelpers_test.go
+++ b/internal/agent/testhelpers_test.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	agentTestHelperEnv      = "ACR_AGENT_TEST_HELPER"
+	agentTestHelperModeEnv  = "ACR_AGENT_TEST_HELPER_MODE"
+	agentTestHelperExitEnv  = "ACR_AGENT_TEST_HELPER_EXIT_CODE"
+	agentTestHelperSleepEnv = "ACR_AGENT_TEST_HELPER_SLEEP"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(agentTestHelperEnv) == "1" {
+		os.Exit(runAgentTestHelper())
+	}
+	os.Exit(m.Run())
+}
+
+func runAgentTestHelper() int {
+	mode := os.Getenv(agentTestHelperModeEnv)
+
+	switch mode {
+	case "args":
+		return emitArgs(false, false)
+	case "args-prefix-stdin":
+		return emitArgs(true, true)
+	case "stdin":
+		_, _ = io.Copy(os.Stdout, os.Stdin)
+		return 0
+	case "sleep":
+		sleepFor := 10 * time.Second
+		if v := os.Getenv(agentTestHelperSleepEnv); v != "" {
+			if d, err := time.ParseDuration(v); err == nil {
+				sleepFor = d
+			}
+		}
+		time.Sleep(sleepFor)
+		return 0
+	case "exit":
+		if v := os.Getenv(agentTestHelperExitEnv); v != "" {
+			if code, err := strconv.Atoi(v); err == nil {
+				_, _ = io.Copy(io.Discard, os.Stdin)
+				return code
+			}
+		}
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		return 0
+	default:
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		return 0
+	}
+}
+
+func emitArgs(prefix bool, copyStdin bool) int {
+	for _, arg := range os.Args[1:] {
+		if prefix {
+			fmt.Fprintf(os.Stdout, "ARG:%s\n", arg)
+			continue
+		}
+		fmt.Fprintln(os.Stdout, arg)
+	}
+	if copyStdin {
+		_, _ = io.Copy(os.Stdout, os.Stdin)
+	} else {
+		_, _ = io.Copy(io.Discard, os.Stdin)
+	}
+	return 0
+}
+
+func helperBinaryPath(t *testing.T) string {
+	t.Helper()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to determine test executable path: %v", err)
+	}
+	return exe
+}
+
+func copyHelperBinary(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	src := helperBinaryPath(t)
+	dst := filepath.Join(dir, helperBinaryName(name))
+
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("failed to open test executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		t.Fatalf("failed to create helper binary %s: %v", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		t.Fatalf("failed to copy helper binary to %s: %v", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("failed to close helper binary %s: %v", dst, err)
+	}
+
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(dst, 0o755); err != nil {
+			t.Fatalf("failed to mark helper binary executable: %v", err)
+		}
+	}
+
+	return dst
+}
+
+func helperBinaryName(name string) string {
+	if runtime.GOOS == "windows" && !strings.HasSuffix(strings.ToLower(name), ".exe") {
+		return name + ".exe"
+	}
+	return name
+}
+
+func prependPath(t *testing.T, dir string) {
+	t.Helper()
+
+	orig := os.Getenv("PATH")
+	if orig == "" {
+		t.Setenv("PATH", dir)
+		return
+	}
+
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+orig)
+}
+
+func newHelperCommand(t *testing.T, mode string, args ...string) *exec.Cmd {
+	t.Helper()
+
+	cmd := exec.Command(helperBinaryPath(t), args...)
+	configureCmdForPlatform(cmd)
+	cmd.Env = append(os.Environ(),
+		agentTestHelperEnv+"=1",
+		agentTestHelperModeEnv+"="+mode,
+	)
+	return cmd
+}
+
+func prepareMockCLI(t *testing.T, name, mode string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	copyHelperBinary(t, dir, name)
+	prependPath(t, dir)
+	t.Setenv(agentTestHelperEnv, "1")
+	t.Setenv(agentTestHelperModeEnv, mode)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -213,6 +214,9 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 	// Execute the review
 	execResult, err := selectedAgent.ExecuteReview(timeoutCtx, reviewConfig)
 	if err != nil {
+		if r.verbose() {
+			r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: execute error: %v", reviewerID, err)
+		}
 		result.ExitCode = -1
 		result.Duration = time.Since(start)
 		return result
@@ -292,6 +296,13 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 
 	// Detect auth failure from exit code and stderr
 	if result.ExitCode != 0 {
+		if r.verbose() {
+			stderr := strings.TrimSpace(execResult.Stderr())
+			if stderr != "" {
+				r.logger.Logf(terminal.StyleWarning, "Reviewer #%d stderr:%s\n%s",
+					reviewerID, terminal.Color(terminal.Reset), stderr)
+			}
+		}
 		result.AuthFailed = agent.IsAuthFailure(selectedAgent.Name(), result.ExitCode, execResult.Stderr())
 	}
 

--- a/internal/summarizer/summarizer_test.go
+++ b/internal/summarizer/summarizer_test.go
@@ -2,9 +2,7 @@ package summarizer
 
 import (
 	"context"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -71,26 +69,11 @@ func isCodexNotFound(stderr string) bool {
 }
 
 func TestSummarize_WithMockCodex(t *testing.T) {
-	// Create a temporary directory for our mock codex
-	tmpDir := t.TempDir()
-
-	// Create a mock codex script that returns valid JSONL (codex --json format)
-	mockCodex := filepath.Join(tmpDir, "codex")
-	mockScript := `#!/bin/sh
-cat << 'EOF'
-{"type":"thread.started","thread_id":"test"}
+	mockCodex := prepareMockCodex(t, `{"type":"thread.started","thread_id":"test"}
 {"type":"turn.started"}
 {"type":"item.completed","item":{"type":"agent_message","text":"{\"findings\": [{\"title\": \"Test Issue\", \"summary\": \"A test issue summary.\", \"messages\": [\"test message\"], \"reviewer_count\": 1, \"sources\": [0]}], \"info\": []}"}}
 {"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}
-EOF
-`
-	if err := os.WriteFile(mockCodex, []byte(mockScript), 0755); err != nil {
-		t.Fatalf("failed to create mock codex: %v", err)
-	}
-
-	// Save original PATH and restore after test
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", tmpDir+":"+origPath)
+`, "", 0)
 
 	// Verify our mock is being used
 	path, err := exec.LookPath("codex")
@@ -127,19 +110,7 @@ EOF
 }
 
 func TestSummarize_InvalidJSONOutput(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create a mock codex that returns invalid JSON
-	mockCodex := filepath.Join(tmpDir, "codex")
-	mockScript := `#!/bin/sh
-echo "this is not valid JSON"
-`
-	if err := os.WriteFile(mockCodex, []byte(mockScript), 0755); err != nil {
-		t.Fatalf("failed to create mock codex: %v", err)
-	}
-
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", tmpDir+":"+origPath)
+	prepareMockCodex(t, "this is not valid JSON\n", "", 0)
 
 	findings := []domain.AggregatedFinding{
 		{Text: "Test finding", Reviewers: []int{1}},
@@ -168,19 +139,7 @@ echo "this is not valid JSON"
 }
 
 func TestSummarize_EmptyOutput(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create a mock codex that returns empty output
-	mockCodex := filepath.Join(tmpDir, "codex")
-	mockScript := `#!/bin/sh
-# Return nothing
-`
-	if err := os.WriteFile(mockCodex, []byte(mockScript), 0755); err != nil {
-		t.Fatalf("failed to create mock codex: %v", err)
-	}
-
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", tmpDir+":"+origPath)
+	prepareMockCodex(t, "", "", 0)
 
 	findings := []domain.AggregatedFinding{
 		{Text: "Test finding", Reviewers: []int{1}},
@@ -203,20 +162,7 @@ func TestSummarize_EmptyOutput(t *testing.T) {
 }
 
 func TestSummarize_CodexFailure(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create a mock codex that exits with error
-	mockCodex := filepath.Join(tmpDir, "codex")
-	mockScript := `#!/bin/sh
-echo "error message" >&2
-exit 42
-`
-	if err := os.WriteFile(mockCodex, []byte(mockScript), 0755); err != nil {
-		t.Fatalf("failed to create mock codex: %v", err)
-	}
-
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", tmpDir+":"+origPath)
+	prepareMockCodex(t, "", "error message\n", 42)
 
 	findings := []domain.AggregatedFinding{
 		{Text: "Test finding", Reviewers: []int{1}},
@@ -238,23 +184,11 @@ exit 42
 }
 
 func TestSummarize_MultipleFindings(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	mockCodex := filepath.Join(tmpDir, "codex")
-	mockScript := `#!/bin/sh
-cat << 'EOF'
-{"type":"thread.started","thread_id":"test"}
+	prepareMockCodex(t, `{"type":"thread.started","thread_id":"test"}
 {"type":"turn.started"}
 {"type":"item.completed","item":{"type":"agent_message","text":"{\"findings\": [{\"title\": \"Issue 1\", \"summary\": \"First issue.\", \"messages\": [\"msg1\"], \"reviewer_count\": 2, \"sources\": [0, 1]}, {\"title\": \"Issue 2\", \"summary\": \"Second issue.\", \"messages\": [\"msg2\"], \"reviewer_count\": 1, \"sources\": [2]}], \"info\": [{\"title\": \"Info 1\", \"summary\": \"Some info.\", \"messages\": [\"info msg\"], \"reviewer_count\": 1, \"sources\": [3]}]}"}}
 {"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50}}
-EOF
-`
-	if err := os.WriteFile(mockCodex, []byte(mockScript), 0755); err != nil {
-		t.Fatalf("failed to create mock codex: %v", err)
-	}
-
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", tmpDir+":"+origPath)
+`, "", 0)
 
 	findings := []domain.AggregatedFinding{
 		{Text: "Finding 1", Reviewers: []int{1, 2}},

--- a/internal/summarizer/testhelpers_test.go
+++ b/internal/summarizer/testhelpers_test.go
@@ -1,0 +1,104 @@
+package summarizer
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	summarizerHelperEnv      = "ACR_SUMMARIZER_TEST_HELPER"
+	summarizerHelperStdoutEnv = "ACR_SUMMARIZER_TEST_STDOUT"
+	summarizerHelperStderrEnv = "ACR_SUMMARIZER_TEST_STDERR"
+	summarizerHelperExitEnv   = "ACR_SUMMARIZER_TEST_EXIT_CODE"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(summarizerHelperEnv) == "1" {
+		os.Exit(runSummarizerHelper())
+	}
+	os.Exit(m.Run())
+}
+
+func runSummarizerHelper() int {
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	if stderr := os.Getenv(summarizerHelperStderrEnv); stderr != "" {
+		_, _ = io.WriteString(os.Stderr, stderr)
+	}
+	if stdout := os.Getenv(summarizerHelperStdoutEnv); stdout != "" {
+		_, _ = io.WriteString(os.Stdout, stdout)
+	}
+	if exitCode := os.Getenv(summarizerHelperExitEnv); exitCode != "" {
+		if code, err := strconv.Atoi(exitCode); err == nil {
+			return code
+		}
+	}
+	return 0
+}
+
+func prepareMockCodex(t *testing.T, stdout, stderr string, exitCode int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := copySummarizerHelperBinary(t, dir, "codex")
+
+	origPath := os.Getenv("PATH")
+	if origPath == "" {
+		t.Setenv("PATH", dir)
+	} else {
+		t.Setenv("PATH", dir+string(os.PathListSeparator)+origPath)
+	}
+	t.Setenv(summarizerHelperEnv, "1")
+	t.Setenv(summarizerHelperStdoutEnv, stdout)
+	t.Setenv(summarizerHelperStderrEnv, stderr)
+	t.Setenv(summarizerHelperExitEnv, strconv.Itoa(exitCode))
+
+	return path
+}
+
+func copySummarizerHelperBinary(t *testing.T, dir, name string) string {
+	t.Helper()
+
+	src, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to determine test executable path: %v", err)
+	}
+
+	dst := filepath.Join(dir, summarizerHelperBinaryName(name))
+	in, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("failed to open test executable: %v", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		t.Fatalf("failed to create helper binary %s: %v", dst, err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		t.Fatalf("failed to copy helper binary to %s: %v", dst, err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("failed to close helper binary %s: %v", dst, err)
+	}
+
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(dst, 0o755); err != nil {
+			t.Fatalf("failed to mark helper binary executable: %v", err)
+		}
+	}
+
+	return dst
+}
+
+func summarizerHelperBinaryName(name string) string {
+	if runtime.GOOS == "windows" && !strings.HasSuffix(strings.ToLower(name), ".exe") {
+		return name + ".exe"
+	}
+	return name
+}

--- a/internal/summarizer/testhelpers_test.go
+++ b/internal/summarizer/testhelpers_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	summarizerHelperEnv      = "ACR_SUMMARIZER_TEST_HELPER"
+	summarizerHelperEnv       = "ACR_SUMMARIZER_TEST_HELPER"
 	summarizerHelperStdoutEnv = "ACR_SUMMARIZER_TEST_STDOUT"
 	summarizerHelperStderrEnv = "ACR_SUMMARIZER_TEST_STDERR"
 	summarizerHelperExitEnv   = "ACR_SUMMARIZER_TEST_EXIT_CODE"


### PR DESCRIPTION
## 概要
- Windows native 対応の追加実装を反映
- reviewer 実行周りの Windows 固有修正と診断改善を追加
- integration test の環境変数置換と AGENTS.md の運用方針を更新

## 変更内容
- Windows 向け signal / process 制御を追加し、終了済み判定と process tree terminate の扱いを修正
- reviewer 起動失敗時に `--verbose` で stderr を出すようにし、Windows 固有の失敗要因を可視化
- gemini の auth 判定ロジックと integration test の PATH 置換ロジックを修正
- Windows 向けビルド・実行手順を AGENTS.md に追記

## 確認
- `go test ./internal/agent ./internal/runner ./integration`
- `go build -o .\\acr.exe .\\cmd\\acr`
- `./acr.exe --local --reviewers 3 --base HEAD~1 --reviewer-agent codex,claude,gemini --verbose` を前回スレッドで実施
