### PR TITLE
refactor: switch all callsites to NewAgentWithOptions with size-aware modelconfig.Resolve

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -44,3 +44,93 @@ summarizer_agent: claude
 # pr_feedback:
 #   enabled: true
 #   agent: ""
+
+# ------------------------------------------------------------------------
+# models: per-size / per-role / per-agent model and thinking-effort matrix
+# ------------------------------------------------------------------------
+# Resolution precedence (highest → lowest; Model and Effort resolve
+# independently, so partial overrides cascade):
+#   CLI flag (--reviewer-model etc.)
+#     > models.agents.<agent>.<role>
+#     > models.sizes.<size>.<role>
+#     > models.defaults.<role>
+#     > legacy fields (reviewer_model, summarizer_model, cross_check.model)
+#     > agent built-in default
+#
+# Roles:
+#   reviewer       — flat review (auto-phase OFF / size=small / --phase diff)
+#                    and fallback for arch_reviewer / diff_reviewer when those
+#                    are unset at the same cascade layer.
+#   arch_reviewer  — auto-phase medium/large の arch フェーズのみ
+#   diff_reviewer  — auto-phase medium/large の diff フェーズのみ
+#   summarizer     — finding clustering
+#   fp_filter      — false-positive detection
+#   cross_check    — grouped-phase 間の整合検査
+#   pr_feedback    — 既存 PR コメント要約
+#
+# Sizes (auto-phase 判定): small / medium / large
+#
+# Per-backend model catalog (representative; 実際の catalog は各 CLI の
+# --help / upstream release notes を参照):
+#
+#   codex (OpenAI Codex CLI):
+#     model:  gpt-5.4, gpt-5.4-mini  (legacy: o3, o3-mini 等)
+#     effort: low | medium | high    → `-c model_reasoning_effort=<value>` にマッピング
+#
+#   claude (Claude Code CLI):
+#     model:  claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5
+#             (短縮形 sonnet-4-6 / sonnet / opus 等も CLI が解釈)
+#     effort: low | medium | high | xhigh | max → --effort にマッピング
+#             (session-scoped; 利用可能レベルはモデルに依存)
+#             数値や未知値は silently drop される。
+#
+#   gemini (Gemini CLI):
+#     model:  gemini-3.1-pro, gemini-2.5-pro, gemini-2.5-flash
+#     effort: 未対応（設定しても silently ignored）
+#
+# Footguns:
+# - defaults.<role>.model は全 agent 横断に適用されるため、`gpt-5.4` を
+#   defaults に書くと claude/gemini reviewer も gpt-5.4 を試みて失敗する。
+#   **model は agents.<name>.<role> で agent 別に明示する**のが安全。
+#   defaults には effort（agent 側で解釈される）のみ書くパターン推奨。
+# - reviewer_agents に同じバックエンドを複数並べた場合（例:
+#   [codex, codex, codex]）、それらは全インスタンス agents.codex.reviewer
+#   を共有する。per-instance の差分は現状サポートしない。
+# ------------------------------------------------------------------------
+models:
+  defaults:
+    # effort のみ共通定義。model は agent 側で解釈が異なるため
+    # defaults.<role>.model は書かない（footgun 参照）。
+    reviewer:      { effort: medium }
+    arch_reviewer: { effort: high }
+    diff_reviewer: { effort: medium }
+    summarizer:    { effort: high }
+    cross_check:   { effort: high }
+  sizes:
+    # 規模別の effort 上書き（model は agents 層に任せる）
+    small:
+      reviewer:      { effort: low }
+    large:
+      arch_reviewer: { effort: high }
+      diff_reviewer: { effort: high }
+      summarizer:    { effort: high }
+      cross_check:   { effort: high }
+  agents:
+    codex:
+      reviewer:      { model: gpt-5.4 }
+      arch_reviewer: { model: gpt-5.4 }
+      diff_reviewer: { model: gpt-5.4 }
+      summarizer:    { model: gpt-5.4 }
+      cross_check:   { model: gpt-5.4 }
+    claude:
+      reviewer:      { model: claude-sonnet-4-6 }
+      arch_reviewer: { model: claude-opus-4-7 }
+      diff_reviewer: { model: claude-sonnet-4-6 }
+      summarizer:    { model: claude-opus-4-7 }
+      cross_check:   { model: claude-opus-4-7 }
+    gemini:
+      # gemini は effort 未対応。model のみ指定
+      reviewer:      { model: gemini-3.1-pro-preview }
+      arch_reviewer: { model: gemini-3.1-pro-preview }
+      diff_reviewer: { model: gemini-3.1-pro-preview }
+      cross_check:   { model: gemini-3.1-pro-preview }

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ bin/acr-test
 /backlog/
 /back_log/
 /docs/cf_skills
+/.tmp/
+.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,9 @@ This file provides guidance for AI assistants working on the ACR codebase.
 
 ACR (Agentic Code Reviewer) is a Go CLI that runs parallel code reviews using LLM agents (Codex, Claude, or Gemini). It spawns N reviewers, collects their findings, deduplicates/clusters them via an LLM summarizer, and optionally posts results to GitHub PRs.
 
+**Status note**: PR posting is beta on the Windows port. `--local` is the
+supported path while the end-to-end submission flow is stabilized.
+
 ## Build & Test Commands
 
 Use `make` for all build/test/lint operations. Run `make help` to see available targets.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ Download the Windows release ZIP from GitHub Releases and extract `acr.exe`.
 go install github.com/richhaase/agentic-code-reviewer/cmd/acr@latest
 ```
 
+## Current status (Windows port)
+
+- PR posting (auto-request-changes / auto-approve) is **beta** on the Windows port.
+  Behavior may change between releases while the end-to-end flow is validated.
+  Consider `--local` for purely local review workflows.
+
 ## Usage
 
 ```bash
@@ -335,13 +341,55 @@ pr_feedback:
   # agent: claude         # Agent for summarization (defaults to summarizer_agent)
 ```
 
+### Model matrix (optional)
+
+Per-role, per-size, and per-agent model/effort overrides can be set under a `models:` key. All three layers are optional and cascade: `agents` > `sizes` > `defaults` > legacy flat fields (`reviewer_model`, `summarizer_model`, etc.) > agent built-in default.
+
+```yaml
+# Optional: per-size / per-role / per-agent model and thinking-effort matrix.
+# All three layers are optional and cascade: agents > sizes > defaults > legacy.
+# Unset fields fall back to lower layers, then to the agent's built-in default.
+models:
+  defaults:
+    reviewer:       { model: gpt-5.4-mini, effort: medium }
+    arch_reviewer:  { model: gpt-5.4,      effort: high }   # auto-phase arch only
+    diff_reviewer:  { model: gpt-5.4-mini, effort: medium } # auto-phase diff only
+    summarizer:     { model: gpt-5.4,      effort: high }
+    fp_filter:      { model: gpt-5.4-mini, effort: low }
+    cross_check:    { model: gpt-5.4,      effort: medium }
+    pr_feedback:    { model: gpt-5.4-mini }
+  sizes:
+    large:
+      arch_reviewer: { model: gpt-5.4,     effort: high }
+      diff_reviewer: { model: gpt-5.4,     effort: medium }
+      summarizer:    { model: gpt-5.4,     effort: high }
+  agents:
+    codex:
+      arch_reviewer: { effort: high }
+      diff_reviewer: { effort: medium }
+    claude:
+      reviewer:   { model: sonnet-4-6,   effort: high }
+```
+
+**`arch_reviewer` / `diff_reviewer` phase-specific roles**: when auto-phase enters a multi-phase run (`medium`/`large` diffs → `arch` + `diff` phases), the phase-specific reviewer role is consulted first at each cascade layer, falling back to the generic `reviewer` role at the *same* layer before descending. Flat review paths (auto-phase OFF, `size=small`, or explicit `--phase diff`) ignore these keys and use `reviewer` only. Legacy flat fields (`reviewer_model`, etc.) apply as the generic reviewer fallback only — there is no `arch_reviewer_model` legacy field.
+
+**`effort` field behavior by agent:**
+- **codex**: `low`, `medium`, or `high` map to `-c model_reasoning_effort=<value>` (codex CLI's config override; there is no `--reasoning-effort` flag). Unknown values are ignored.
+- **claude**: `low`, `medium`, `high`, `xhigh`, or `max` map to `--effort <value>` (session-scoped; available levels depend on the model). Other values (including numeric strings) are silently dropped.
+- **gemini**: effort is not supported and is silently ignored.
+
+When `models:` is absent, the legacy flat fields (`reviewer_model`, `summarizer_model`, etc.) remain fully functional as before. Use `--verbose` to see the resolved effective matrix at runtime.
+
 ### Precedence
 
 Configuration is resolved with the following precedence (highest to lowest):
 1. CLI flags (e.g., `--reviewers 10`)
 2. Environment variables (e.g., `ACR_REVIEWERS=10`)
-3. Config file (`.acr.yaml`)
-4. Built-in defaults
+3. `models.agents.<agent>.<role>` in `.acr.yaml`
+4. `models.sizes.<size>.<role>` in `.acr.yaml`
+5. `models.defaults.<role>` in `.acr.yaml`
+6. Legacy flat fields (`reviewer_model`, `summarizer_model`, etc.) in `.acr.yaml`
+7. Built-in defaults
 
 ### Behavior
 

--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/github"
@@ -16,6 +17,11 @@ import (
 )
 
 const maxDisplayedCIChecks = 5
+
+// betaNoticeOnce ensures the PR posting beta warning is emitted at most once
+// per process run, regardless of how many times confirmAndSubmitReview or
+// confirmAndSubmitLGTM are called.
+var betaNoticeOnce sync.Once
 
 // prContext holds PR number and self-review status for GitHub operations.
 type prContext struct {
@@ -196,21 +202,30 @@ func buildReviewPromptLabel(defaultAction string) string {
 	return "[R]equest changes (default) / [C]omment / [S]kip:"
 }
 
-// formatCrossCheckForPR renders cross-check findings as a Markdown section for
-// inclusion in a PR review body. Returns "" when cc is nil, or when cc has no
-// findings and is neither Partial nor in a non-structural Skipped state —
-// structural skips (single group, no agents configured) stay silent because
-// they do not represent lost coverage.
+// formatCrossCheckForPR renders cross-check findings as a Markdown section for inclusion
+// in a PR review body. Returns "" when cc is nil, has no findings, and is not partial or
+// degraded. Returns a degraded advisory notice when cc was skipped for a non-structural
+// reason (e.g. all agents failed, payload marshal failed) so the PR body is non-empty
+// and the caller's empty-body safety guard does not silently swallow the review.
 func formatCrossCheckForPR(cc *summarizer.CrossCheckResult) string {
 	if cc == nil {
 		return ""
 	}
-	noFindings := len(cc.Findings) == 0
-	if noFindings && !cc.Partial && !cc.Skipped {
+
+	// Structural skip (single group, no agents configured): nothing to report.
+	if cc.Skipped && summarizer.IsStructuralSkipReason(cc.SkipReason) {
 		return ""
 	}
-	// Structural skips stay silent — cross-check was intentionally not run.
-	if noFindings && cc.Skipped && summarizer.IsStructuralSkipReason(cc.SkipReason) {
+
+	// Non-structural skip (all agents failed, payload error, etc.): emit a
+	// degraded advisory notice so the PR body is non-empty.
+	if cc.Skipped && !summarizer.IsStructuralSkipReason(cc.SkipReason) {
+		safeReason := sanitizeCrossCheckSkipReason(cc.SkipReason)
+		return fmt.Sprintf("⚠ Cross-check degraded (%s) — coverage reduced; treat as advisory\n\n", safeReason)
+	}
+
+	// No findings and not partial: nothing to report.
+	if len(cc.Findings) == 0 && !cc.Partial {
 		return ""
 	}
 
@@ -222,16 +237,6 @@ func formatCrossCheckForPR(cc *summarizer.CrossCheckResult) string {
 			agents = "unknown"
 		}
 		sb.WriteString(fmt.Sprintf("⚠ Cross-check ran partially (failed agents: %s) — coverage reduced\n\n", agents))
-	}
-
-	// Non-structural skip with no findings: emit a minimal section so reviewers
-	// can see that cross-group coverage was lost (vs. silently dropping it).
-	if noFindings && cc.Skipped {
-		reason := cc.SkipReason
-		if reason == "" {
-			reason = "unknown reason"
-		}
-		sb.WriteString(fmt.Sprintf("⚠ Cross-check skipped: %s — cross-group coverage unavailable\n\n", reason))
 	}
 
 	if len(cc.Findings) > 0 {
@@ -260,6 +265,25 @@ func formatCrossCheckForPR(cc *summarizer.CrossCheckResult) string {
 	}
 
 	return sb.String()
+}
+
+// sanitizeCrossCheckSkipReason returns a PR-safe description of why cross-check was degraded.
+// Only well-known safe patterns are passed through; everything else is replaced with a
+// generic message to avoid leaking internal paths, error strings, or PII into PR bodies.
+func sanitizeCrossCheckSkipReason(reason string) string {
+	// Allow known safe patterns through verbatim.
+	if reason == summarizer.SkipReasonSingleGroup || reason == summarizer.SkipReasonNoAgents {
+		return reason
+	}
+	// "all N agents failed" pattern — safe, no internal detail.
+	if strings.HasPrefix(reason, "all ") && strings.Contains(reason, " agents failed") {
+		// Extract just the first sentence (e.g. "all 3 agents failed") without per-agent details.
+		if idx := strings.Index(reason, ":"); idx != -1 {
+			return strings.TrimSpace(reason[:idx])
+		}
+		return reason
+	}
+	return "cross-check degraded (see local log for details)"
 }
 
 // buildReviewBody composes the full PR review body from grouped findings and
@@ -303,26 +327,30 @@ func handleFindings(ctx context.Context, opts ReviewOpts, grouped domain.Grouped
 		}
 		selectedFindings = filterFindingsByIndices(grouped.Findings, indices)
 
-		if len(selectedFindings) == 0 {
-			logger.Log("No findings selected to post.", terminal.StyleDim)
-
-			// Recompute verdict against the empty grouped slice plus the
-			// original cross-check signals. When cross-check has its own
-			// concerns (or is degraded), filtered.Verdict will not be "ok",
-			// so we fall through to confirmAndSubmitReview with the CC-only
-			// body and the updated verdict drives the review action. Only a
-			// genuinely clean recompute may emit the dismissed-LGTM banner.
-			filtered := domain.GroupedFindings{Findings: nil, Info: grouped.Info}
+		if len(selectedFindings) < len(grouped.Findings) {
+			// Recompute verdict against the remaining findings plus the original
+			// cross-check signals. Partial dismiss (e.g. blocking removed, advisory
+			// kept) must downgrade the verdict so applyVerdictExitPolicy does not
+			// fire request_changes / exit 1 for a now-advisory review.
+			filtered := domain.GroupedFindings{Findings: selectedFindings, Info: grouped.Info}
 			filtered.ComputeVerdict(ccBlocking, ccAdvisory)
 			verdict = filtered.Verdict
 
-			if verdict == "ok" {
-				lgtmBody := runner.RenderDismissedLGTMMarkdown(grouped.Findings, stats, version)
-				pr := getPRContext(ctx, opts)
-				// Best-effort: LGTM posting is optional when dismissing findings.
-				// Auth/network errors should not fail the run.
-				_ = confirmAndSubmitLGTM(ctx, lgtmBody, pr, opts, logger)
-				return domain.ExitNoFindings, verdict
+			if len(selectedFindings) == 0 {
+				logger.Log("No findings selected to post.", terminal.StyleDim)
+
+				// Only emit the dismissed-LGTM banner when cross-check is also
+				// clean (verdict=="ok"). Any cross-check signal (blocking, advisory,
+				// or degraded) falls through to confirmAndSubmitReview so the
+				// CC-only body reaches the PR with the correct review action.
+				if verdict == "ok" {
+					lgtmBody := runner.RenderDismissedLGTMMarkdown(grouped.Findings, stats, version)
+					pr := getPRContext(ctx, opts)
+					// Best-effort: LGTM posting is optional when dismissing findings.
+					// Auth/network errors should not fail the run.
+					_ = confirmAndSubmitLGTM(ctx, lgtmBody, pr, opts, logger)
+					return domain.ExitNoFindings, verdict
+				}
 			}
 		}
 	}
@@ -363,6 +391,10 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, verd
 	if !available {
 		return nil
 	}
+
+	betaNoticeOnce.Do(func() {
+		logger.Logf(terminal.StyleWarning, "PR posting is beta in the Windows port; behavior may change.")
+	})
 
 	// Determine the default action from verdict + strict.
 	// Self-review always falls back to comment (cannot request changes on own PR).
@@ -457,6 +489,10 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 	if !available {
 		return nil
 	}
+
+	betaNoticeOnce.Do(func() {
+		logger.Logf(terminal.StyleWarning, "PR posting is beta in the Windows port; behavior may change.")
+	})
 
 	action := actionApprove
 	if pr.isSelfReview {

--- a/cmd/acr/pr_submit_test.go
+++ b/cmd/acr/pr_submit_test.go
@@ -286,7 +286,7 @@ func TestFormatCrossCheckForPR_Partial(t *testing.T) {
 // etc.) with no findings still produces a Markdown section so reviewers see
 // the lost coverage. Structural skips (single group, no agents) stay silent.
 func TestFormatCrossCheckForPR_EmitsSectionOnNonStructuralSkip(t *testing.T) {
-	t.Run("all agents failed emits section", func(t *testing.T) {
+	t.Run("all agents failed emits degraded advisory notice", func(t *testing.T) {
 		cc := &summarizer.CrossCheckResult{
 			Skipped:      true,
 			SkipReason:   "all 3 agents failed: codex: timeout; claude: auth; gemini: parse",
@@ -296,11 +296,18 @@ func TestFormatCrossCheckForPR_EmitsSectionOnNonStructuralSkip(t *testing.T) {
 		if got == "" {
 			t.Fatal("expected non-empty Markdown for non-structural skip, got empty")
 		}
-		if !strings.Contains(got, "Cross-check skipped") {
-			t.Errorf("missing skip notice; got:\n%s", got)
+		if !strings.Contains(got, "Cross-check degraded") {
+			t.Errorf("missing degraded notice; got:\n%s", got)
 		}
-		if !strings.Contains(got, "cross-group coverage unavailable") {
-			t.Errorf("missing coverage-unavailable wording; got:\n%s", got)
+		if !strings.Contains(got, "treat as advisory") {
+			t.Errorf("missing advisory wording; got:\n%s", got)
+		}
+		// Reason sanitizer must strip per-agent detail after the first colon.
+		if !strings.Contains(got, "all 3 agents failed") {
+			t.Errorf("missing sanitized agent-failure summary; got:\n%s", got)
+		}
+		if strings.Contains(got, "codex: timeout") || strings.Contains(got, "claude: auth") {
+			t.Errorf("raw per-agent error detail must be sanitized out of PR body; got:\n%s", got)
 		}
 	})
 
@@ -319,23 +326,15 @@ func TestFormatCrossCheckForPR_EmitsSectionOnNonStructuralSkip(t *testing.T) {
 			Skipped:    true,
 			SkipReason: summarizer.SkipReasonNoAgents,
 		}
-		// Note: IsStructuralSkipReason currently treats empty + SingleGroup as
-		// structural. NoAgents is a structural skip too but is reported with a
-		// non-empty SkipReason that is not SingleGroup, so this case ends up
-		// emitting a section. That's acceptable — operators explicitly
-		// misconfiguring cross-check should see the degraded state. This test
-		// documents that behavior.
-		if got := formatCrossCheckForPR(cc); got == "" {
-			t.Skip("no-agents treated as structural by IsStructuralSkipReason; expected section not required")
+		if got := formatCrossCheckForPR(cc); got != "" {
+			t.Errorf("no-agents is structural; expected silent, got:\n%s", got)
 		}
 	})
 
-	t.Run("empty SkipReason falls back to unknown reason", func(t *testing.T) {
+	t.Run("empty SkipReason stays silent (structural)", func(t *testing.T) {
 		cc := &summarizer.CrossCheckResult{
 			Skipped: true,
-			// SkipReason left empty — guard path
 		}
-		// IsStructuralSkipReason("") is true, so this should stay silent.
 		if got := formatCrossCheckForPR(cc); got != "" {
 			t.Errorf("empty SkipReason is structural; expected silent, got:\n%s", got)
 		}
@@ -468,5 +467,142 @@ func TestHandleFindings_Local_ReturnsVerdictUnchanged(t *testing.T) {
 	}
 	if finalVerdict != "advisory" {
 		t.Errorf("local handleFindings must preserve input verdict, got %q", finalVerdict)
+	}
+}
+
+// --- §2: formatCrossCheckForPR degraded skip tests ---
+
+func TestFormatCrossCheckForPR_DegradedSkip(t *testing.T) {
+	cases := []struct {
+		name       string
+		cc         *summarizer.CrossCheckResult
+		wantEmpty  bool
+		wantSubstr []string // must all appear when !wantEmpty
+		wantAbsent []string // must not appear when !wantEmpty
+	}{
+		{
+			name: "structural skip single group -> empty",
+			cc: &summarizer.CrossCheckResult{
+				Skipped:    true,
+				SkipReason: summarizer.SkipReasonSingleGroup,
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "structural skip no agents -> empty",
+			cc: &summarizer.CrossCheckResult{
+				Skipped:    true,
+				SkipReason: summarizer.SkipReasonNoAgents,
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "all agents failed -> degraded notice",
+			cc: &summarizer.CrossCheckResult{
+				Skipped:      true,
+				SkipReason:   "all 3 agents failed: codex: exec error; claude: timeout; gemini: auth failed",
+				FailedAgents: []string{"codex", "claude", "gemini"},
+			},
+			wantEmpty:  false,
+			wantSubstr: []string{"degraded", "coverage reduced", "all 3 agents failed"},
+		},
+		{
+			name: "payload marshal failed -> degraded notice with generic message",
+			cc: &summarizer.CrossCheckResult{
+				Skipped:    true,
+				SkipReason: "payload marshal failed: invalid type",
+			},
+			wantEmpty:  false,
+			wantSubstr: []string{"degraded", "coverage reduced", "cross-check degraded (see local log for details)"},
+		},
+		{
+			name: "all agents failed with details -> only summary line exposed",
+			cc: &summarizer.CrossCheckResult{
+				Skipped:      true,
+				SkipReason:   "all 3 agents failed: codex: exec error; claude: timeout; gemini: auth failed",
+				FailedAgents: []string{"codex", "claude", "gemini"},
+			},
+			wantEmpty:  false,
+			wantSubstr: []string{"degraded", "coverage reduced", "all 3 agents failed"},
+			wantAbsent: []string{"exec error", "timeout", "auth failed"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatCrossCheckForPR(tc.cc)
+			if tc.wantEmpty && got != "" {
+				t.Errorf("expected empty, got %q", got)
+			}
+			if !tc.wantEmpty {
+				if got == "" {
+					t.Fatal("expected non-empty body")
+				}
+				for _, s := range tc.wantSubstr {
+					if !strings.Contains(got, s) {
+						t.Errorf("missing substring %q in:\n%s", s, got)
+					}
+				}
+				for _, s := range tc.wantAbsent {
+					if strings.Contains(got, s) {
+						t.Errorf("unexpected substring %q in:\n%s", s, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+// --- §3: handleFindings partial dismiss verdict recompute tests ---
+//
+// These tests mirror the in-place recompute inside handleFindings when the
+// interactive selector removes some (but not all) findings. We simulate the
+// filtered slice that handleFindings builds and assert the verdict is correctly
+// recomputed so applyVerdictExitPolicy receives the right signal.
+
+// TestHandleFindings_PartialDismiss_BlockingRemoved_VerdictDowngrade verifies
+// that removing the blocking finding while keeping an advisory one downgrades
+// the verdict to "advisory". Without the §3 fix the input "blocking" verdict
+// would persist, causing applyVerdictExitPolicy to request_changes / exit 1
+// for what is effectively an advisory review.
+func TestHandleFindings_PartialDismiss_BlockingRemoved_VerdictDowngrade(t *testing.T) {
+	// Original grouped set: [blocking, advisory]
+	grouped := domain.GroupedFindings{
+		Findings: []domain.FindingGroup{
+			{Title: "blocker", Severity: "blocking"},
+			{Title: "nit", Severity: "advisory"},
+		},
+		Verdict: "blocking",
+	}
+	// Selector keeps only the advisory one (index 1).
+	selected := []domain.FindingGroup{grouped.Findings[1]}
+	// No cross-check signals.
+	var ccBlocking, ccAdvisory bool
+
+	filtered := domain.GroupedFindings{Findings: selected, Info: grouped.Info}
+	filtered.ComputeVerdict(ccBlocking, ccAdvisory)
+
+	if filtered.Verdict != "advisory" {
+		t.Errorf("partial dismiss keeping advisory must yield advisory verdict, got %q", filtered.Verdict)
+	}
+}
+
+// TestHandleFindings_PartialDismiss_AdvisoryRemoved_VerdictBlocking verifies
+// the reverse: keeping only the blocking finding must keep the verdict blocking.
+func TestHandleFindings_PartialDismiss_AdvisoryRemoved_VerdictBlocking(t *testing.T) {
+	grouped := domain.GroupedFindings{
+		Findings: []domain.FindingGroup{
+			{Title: "blocker", Severity: "blocking"},
+			{Title: "nit", Severity: "advisory"},
+		},
+		Verdict: "blocking",
+	}
+	selected := []domain.FindingGroup{grouped.Findings[0]}
+	var ccBlocking, ccAdvisory bool
+
+	filtered := domain.GroupedFindings{Findings: selected, Info: grouped.Info}
+	filtered.ComputeVerdict(ccBlocking, ccAdvisory)
+
+	if filtered.Verdict != "blocking" {
+		t.Errorf("partial dismiss keeping blocking must yield blocking verdict, got %q", filtered.Verdict)
 	}
 }

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -13,10 +13,20 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/filter"
 	"github.com/richhaase/agentic-code-reviewer/internal/fpfilter"
 	"github.com/richhaase/agentic-code-reviewer/internal/git"
+	"github.com/richhaase/agentic-code-reviewer/internal/modelconfig"
 	"github.com/richhaase/agentic-code-reviewer/internal/runner"
 	"github.com/richhaase/agentic-code-reviewer/internal/summarizer"
 	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
+
+// cliOrLegacy returns (cliModel, legacyModel) based on whether the value came
+// from a CLI flag or env var (highest priority) vs config file (lowest priority).
+func cliOrLegacy(value string, fromCLI bool) (cli, legacy string) {
+	if fromCLI {
+		return value, ""
+	}
+	return "", value
+}
 
 func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger) domain.ExitCode {
 	if err := agent.ValidateAgentNames(opts.ReviewerAgents); err != nil {
@@ -24,55 +34,11 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		return domain.ExitError
 	}
 
-	reviewAgents, err := agent.CreateAgentsWithModel(opts.ReviewerAgents, opts.ReviewerModel)
-	if err != nil {
-		logger.Logf(terminal.StyleError, "%v", err)
-		return domain.ExitError
-	}
-
-	summarizerAgent, err := agent.NewAgentWithModel(opts.SummarizerAgent, opts.SummarizerModel)
-	if err != nil {
-		logger.Logf(terminal.StyleError, "Invalid summarizer agent: %v", err)
-		return domain.ExitError
-	}
-	if err := summarizerAgent.IsAvailable(); err != nil {
-		logger.Logf(terminal.StyleError, "%s CLI not found (summarizer): %v", opts.SummarizerAgent, err)
-		return domain.ExitError
-	}
-
-	// Resolve and validate cross-check agents (fail-fast).
-	ccAgentNames, ccModel := resolveCrossCheckAgents(opts)
-	if opts.CrossCheckEnabled {
-		if err := agent.ValidateAgentNames(ccAgentNames); err != nil {
-			logger.Logf(terminal.StyleError, "Invalid cross-check agent: %v", err)
-			return domain.ExitError
-		}
-		for _, name := range ccAgentNames {
-			ccAg, err := agent.NewAgentWithModel(name, ccModel)
-			if err != nil {
-				logger.Logf(terminal.StyleError, "Invalid cross-check agent %q: %v", name, err)
-				return domain.ExitError
-			}
-			if err := ccAg.IsAvailable(); err != nil {
-				logger.Logf(terminal.StyleError, "%s CLI not found (cross-check): %v", name, err)
-				return domain.ExitError
-			}
-		}
-	}
-
-	// Show agent distribution if multiple agents
-	if len(reviewAgents) > 1 {
-		distribution := agent.FormatDistribution(reviewAgents, opts.Reviewers)
-		logger.Logf(terminal.StyleInfo, "Agent distribution: %s%s%s",
-			terminal.Color(terminal.Dim), distribution, terminal.Color(terminal.Reset))
-	} else if opts.Verbose && len(opts.ReviewerAgents) > 0 {
-		logger.Logf(terminal.StyleDim, "%sUsing agent: %s%s",
-			terminal.Color(terminal.Dim), opts.ReviewerAgents[0], terminal.Color(terminal.Reset))
-	}
-
 	// Resolve the base ref once before launching parallel reviewers.
 	// This ensures all reviewers compare against the same ref, avoiding
 	// inconsistent results if network conditions vary during parallel execution.
+	// Hoisted above agent construction so diff-size classification can feed the
+	// size-aware model resolver (models.sizes.<size>.<role>).
 	resolvedBaseRef := opts.Base
 	if opts.Fetch {
 		// Update current branch from remote (fast-forward only).
@@ -96,6 +62,202 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		} else if opts.Verbose && result.FetchAttempted && result.RefResolved {
 			logger.Logf(terminal.StyleDim, "Comparing against %s (fetched from origin)", resolvedBaseRef)
 		}
+	}
+
+	// Classify diff size once up-front so the size-aware model resolver
+	// (models.sizes.<size>.<role>) can pick per-role model/effort for every
+	// agent constructed below. ClassifyDiffSize uses `git diff --stat` and is
+	// cheap compared to GetDiff. On classification error we pass sizeStr=""
+	// and the resolver falls through to defaults + legacy fields.
+	var sizeStr string
+	var diffSize git.DiffSize
+	var diffFileCount, diffLineCount int
+	var diffSizeClassified bool
+	var classifyErr error
+	diffSize, diffFileCount, diffLineCount, classifyErr = git.ClassifyDiffSize(ctx, resolvedBaseRef, opts.WorkDir)
+	if classifyErr == nil {
+		sizeStr = diffSize.String()
+		diffSizeClassified = true
+	} else if opts.Verbose {
+		logger.Logf(terminal.StyleWarning, "Diff size classification failed: %v (model resolver will skip size layer)", classifyErr)
+	}
+
+	// Resolve generic (phase="") reviewer specs with per-agent-name effort/model
+	// via the size-aware phase-aware model config resolver. This covers the flat
+	// review path (auto-phase OFF / size=small / explicit `--phase diff`); the
+	// grouped and phased paths below re-resolve per-phase from the same config
+	// using phase="arch"/"diff".
+	reviewerSpecs := make([]agent.AgentSpec, 0, len(opts.ReviewerAgents))
+	for _, name := range opts.ReviewerAgents {
+		cliRevModel, legacyRevModel := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
+		spec := modelconfig.ResolveReviewer(
+			opts.Models, sizeStr, "" /* flat */, name,
+			cliRevModel, "",
+			legacyRevModel, "",
+		)
+		reviewerSpecs = append(reviewerSpecs, agent.AgentSpec{
+			Name:    name,
+			Options: agent.AgentOptions{Model: spec.Model, Effort: spec.Effort},
+		})
+	}
+	reviewAgents, err := agent.CreateAgentsFromSpecs(reviewerSpecs)
+	if err != nil {
+		logger.Logf(terminal.StyleError, "%v", err)
+		return domain.ExitError
+	}
+
+	// rebindSpecAgent re-resolves the reviewer model/effort for a given
+	// (phase, agent name) pair and constructs a fresh Agent instance for the
+	// spec. Captures surrounding scope (opts, sizeStr) so downstream phase
+	// wiring stays concise. Falls back to the original Agent on error.
+	rebindSpecAgent := func(origAgent agent.Agent, phase string) agent.Agent {
+		if origAgent == nil {
+			return origAgent
+		}
+		name := origAgent.Name()
+		cliRevModel, legacyRevModel := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
+		spec := modelconfig.ResolveReviewer(
+			opts.Models, sizeStr, phase, name,
+			cliRevModel, "",
+			legacyRevModel, "",
+		)
+		a, err := agent.NewAgentWithOptions(name, agent.AgentOptions{Model: spec.Model, Effort: spec.Effort})
+		if err != nil {
+			return origAgent
+		}
+		return a
+	}
+
+	cliSumModel, legacySumModel := cliOrLegacy(opts.SummarizerModel, opts.SummarizerModelFromCLI)
+	summSpec := modelconfig.Resolve(
+		opts.Models, sizeStr, modelconfig.RoleSummarizer, opts.SummarizerAgent,
+		cliSumModel, "",
+		legacySumModel, "",
+	)
+	summarizerAgent, err := agent.NewAgentWithOptions(opts.SummarizerAgent, agent.AgentOptions{Model: summSpec.Model, Effort: summSpec.Effort})
+	if err != nil {
+		logger.Logf(terminal.StyleError, "Invalid summarizer agent: %v", err)
+		return domain.ExitError
+	}
+	if err := summarizerAgent.IsAvailable(); err != nil {
+		logger.Logf(terminal.StyleError, "%s CLI not found (summarizer): %v", opts.SummarizerAgent, err)
+		return domain.ExitError
+	}
+
+	// Resolve and validate cross-check agents (fail-fast).
+	ccAgentNames, ccModel := resolveCrossCheckAgents(opts)
+	// ccModel came from opts.CrossCheckModel (or SummarizerModel fallback inside
+	// resolveCrossCheckAgents). CrossCheckModelFromCLI reflects whether the raw
+	// opts.CrossCheckModel was a CLI/env override; when it's empty and we fell
+	// back to SummarizerModel, SummarizerModelFromCLI governs precedence instead.
+	ccFromCLI := opts.CrossCheckModelFromCLI
+	if opts.CrossCheckModel == "" {
+		ccFromCLI = opts.SummarizerModelFromCLI
+	}
+	// Resolve cross-check options per agent so that agents.<name>.cross_check
+	// overrides are honored when multiple agents are configured. The specs
+	// slice preserves caller order and is passed directly to CrossCheck.
+	ccSpecs := make([]summarizer.CrossCheckAgentSpec, 0, len(ccAgentNames))
+	for _, name := range ccAgentNames {
+		cliCCModel, legacyCCModel := cliOrLegacy(ccModel, ccFromCLI)
+		perSpec := modelconfig.Resolve(
+			opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
+			cliCCModel, "",
+			legacyCCModel, "",
+		)
+		ccSpecs = append(ccSpecs, summarizer.CrossCheckAgentSpec{
+			Name:    name,
+			Options: summarizer.CrossCheckOptions{Model: perSpec.Model, Effort: perSpec.Effort},
+		})
+	}
+	if opts.CrossCheckEnabled {
+		if err := agent.ValidateAgentNames(ccAgentNames); err != nil {
+			logger.Logf(terminal.StyleError, "Invalid cross-check agent: %v", err)
+			return domain.ExitError
+		}
+		for _, spec := range ccSpecs {
+			ccAg, err := agent.NewAgentWithOptions(spec.Name, agent.AgentOptions{Model: spec.Options.Model, Effort: spec.Options.Effort})
+			if err != nil {
+				logger.Logf(terminal.StyleError, "Invalid cross-check agent %q: %v", spec.Name, err)
+				return domain.ExitError
+			}
+			if err := ccAg.IsAvailable(); err != nil {
+				logger.Logf(terminal.StyleError, "%s CLI not found (cross-check): %v", spec.Name, err)
+				return domain.ExitError
+			}
+		}
+	}
+
+	// Verbose: log the effective model/effort matrix for all roles once, up-front.
+	// fp_filter and pr_feedback specs are resolved later in the flow, so we
+	// re-invoke Resolve here (pure, cheap) solely for display purposes.
+	if opts.Verbose {
+		cliSumModelLog, legacySumModelLog := cliOrLegacy(opts.SummarizerModel, opts.SummarizerModelFromCLI)
+		fpSpecLog := modelconfig.Resolve(
+			opts.Models, sizeStr, modelconfig.RoleFPFilter, opts.SummarizerAgent,
+			cliSumModelLog, "",
+			legacySumModelLog, "",
+		)
+		prFeedbackAgentName := opts.PRFeedbackAgent
+		if prFeedbackAgentName == "" {
+			prFeedbackAgentName = opts.SummarizerAgent
+		}
+		prFeedbackSpecLog := modelconfig.Resolve(
+			opts.Models, sizeStr, modelconfig.RolePRFeedback, prFeedbackAgentName,
+			cliSumModelLog, "",
+			legacySumModelLog, "",
+		)
+		logger.Logf(terminal.StyleDim, "Effective model matrix (size=%s):", formatSizeStr(sizeStr))
+		for _, s := range reviewerSpecs {
+			logger.Logf(terminal.StyleDim, "  reviewer[%s]       : %s", s.Name, formatSpec(agent.AgentOptions{Model: s.Options.Model, Effort: s.Options.Effort}))
+		}
+		// arch_reviewer / diff_reviewer rows are meaningful only when
+		// auto-phase is enabled AND diff-size classification succeeded: they
+		// show how the multi-phase run will resolve per-phase model/effort
+		// (phase-specific roles fall back to the generic reviewer at the SAME
+		// cascade layer via ResolveReviewer). Without a classified size, these
+		// rows would be misleading since auto-phase will skip per-phase routing.
+		if opts.AutoPhase && opts.Phase == "" && diffSizeClassified && diffSize != git.DiffSizeSmall {
+			for _, name := range opts.ReviewerAgents {
+				cliRevModelLog, legacyRevModelLog := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
+				archSpec := modelconfig.ResolveReviewer(
+					opts.Models, sizeStr, "arch", name,
+					cliRevModelLog, "",
+					legacyRevModelLog, "",
+				)
+				diffSpec := modelconfig.ResolveReviewer(
+					opts.Models, sizeStr, "diff", name,
+					cliRevModelLog, "",
+					legacyRevModelLog, "",
+				)
+				logger.Logf(terminal.StyleDim, "  arch_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: archSpec.Model, Effort: archSpec.Effort}))
+				logger.Logf(terminal.StyleDim, "  diff_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: diffSpec.Model, Effort: diffSpec.Effort}))
+			}
+		}
+		logger.Logf(terminal.StyleDim, "  summarizer        : %s", formatSpec(agent.AgentOptions{Model: summSpec.Model, Effort: summSpec.Effort}))
+		if opts.CrossCheckEnabled {
+			for _, name := range ccAgentNames {
+				cliCCModelLog, legacyCCModelLog := cliOrLegacy(ccModel, ccFromCLI)
+				perSpec := modelconfig.Resolve(
+					opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
+					cliCCModelLog, "",
+					legacyCCModelLog, "",
+				)
+				logger.Logf(terminal.StyleDim, "  cross_check[%s]    : %s", name, formatSpec(agent.AgentOptions{Model: perSpec.Model, Effort: perSpec.Effort}))
+			}
+		}
+		logger.Logf(terminal.StyleDim, "  fp_filter         : %s", formatSpec(agent.AgentOptions{Model: fpSpecLog.Model, Effort: fpSpecLog.Effort}))
+		logger.Logf(terminal.StyleDim, "  pr_feedback       : %s", formatSpec(agent.AgentOptions{Model: prFeedbackSpecLog.Model, Effort: prFeedbackSpecLog.Effort}))
+	}
+
+	// Show agent distribution if multiple agents
+	if len(reviewAgents) > 1 {
+		distribution := agent.FormatDistribution(reviewAgents, opts.Reviewers)
+		logger.Logf(terminal.StyleInfo, "Agent distribution: %s%s%s",
+			terminal.Color(terminal.Dim), distribution, terminal.Color(terminal.Reset))
+	} else if opts.Verbose && len(opts.ReviewerAgents) > 0 {
+		logger.Logf(terminal.StyleDim, "%sUsing agent: %s%s",
+			terminal.Color(terminal.Dim), opts.ReviewerAgents[0], terminal.Color(terminal.Reset))
 	}
 
 	// Pre-compute the git diff once and share it across all reviewers.
@@ -124,17 +286,23 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		logger.Logf(terminal.StyleDim, "Ref-file mode enabled")
 	}
 
-	// Resolve review phases
+	// Resolve review phases. phaseFromAuto tracks whether the final phase
+	// configuration came from auto-phase (true) vs CLI `--phase` (false).
+	// Only auto-phase-derived multi-phase runs consult arch_reviewer /
+	// diff_reviewer; explicit `--phase` flags use the generic reviewer role.
 	phaseStr := opts.Phase
+	phaseFromAuto := false
 	var useGroupedSpecs bool
 	var groupedSpecs []runner.ReviewerSpec
 	if shouldUseAutoPhase(opts) {
-		size, fileCount, lineCount, classifyErr := git.ClassifyDiffSize(ctx, resolvedBaseRef, opts.WorkDir)
-		if classifyErr != nil {
+		if !diffSizeClassified {
 			if opts.Verbose {
-				logger.Logf(terminal.StyleWarning, "Auto-phase: diff size classification failed: %v", classifyErr)
+				logger.Logf(terminal.StyleWarning, "Auto-phase: diff size classification failed earlier, using default phase")
 			}
 		} else {
+			size := diffSize
+			fileCount := diffFileCount
+			lineCount := diffLineCount
 			if opts.Verbose {
 				logger.Logf(terminal.StyleDim, "Auto-phase: diff is %s (%d files, %d lines)", size, fileCount, lineCount)
 			}
@@ -149,6 +317,10 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			phaseStr = apr.PhaseStr
 			groupedSpecs = apr.GroupedSpecs
 			useGroupedSpecs = apr.UseGrouped
+			// Enable per-phase role rebinding (arch_reviewer/diff_reviewer) only
+			// for medium/large diffs. Small diffs use flat diff review with the
+			// generic reviewer role.
+			phaseFromAuto = size != git.DiffSizeSmall
 			if opts.Verbose {
 				switch {
 				case apr.UseGrouped:
@@ -182,6 +354,12 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	var r *runner.Runner
 	actualReviewers := opts.Reviewers
 	if useGroupedSpecs {
+		// Auto-phase grouped path: per-phase model/effort rebind using
+		// ResolveReviewer with spec.Phase ("arch"/"diff"). arch_reviewer /
+		// diff_reviewer overrides take effect here.
+		for i := range groupedSpecs {
+			groupedSpecs[i].Agent = rebindSpecAgent(groupedSpecs[i].Agent, groupedSpecs[i].Phase)
+		}
 		actualReviewers = len(groupedSpecs)
 		r, err = runner.NewWithSpecs(runnerConfig, groupedSpecs, logger)
 	} else if phaseStr != "" {
@@ -199,6 +377,14 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		if specErr != nil {
 			logger.Logf(terminal.StyleError, "Phase config error: %v", specErr)
 			return domain.ExitError
+		}
+		// Per-phase rebind: only when phases were produced by auto-phase.
+		// Explicit `--phase` flags use the generic reviewer role per the
+		// documented contract (flat review path).
+		if phaseFromAuto {
+			for i := range specs {
+				specs[i].Agent = rebindSpecAgent(specs[i].Agent, specs[i].Phase)
+			}
 		}
 		actualReviewers = len(specs)
 		r, err = runner.NewWithSpecs(runnerConfig, specs, logger)
@@ -235,7 +421,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				feedbackAgentName = opts.SummarizerAgent
 			}
 
-			summarizer := feedback.NewSummarizer(feedbackAgentName, opts.SummarizerModel, opts.Verbose, logger)
+			cliSumModelPR, legacySumModelPR := cliOrLegacy(opts.SummarizerModel, opts.SummarizerModelFromCLI)
+			prSpec := modelconfig.Resolve(
+				opts.Models, sizeStr, modelconfig.RolePRFeedback, feedbackAgentName,
+				cliSumModelPR, "",
+				legacySumModelPR, "",
+			)
+			summarizer := feedback.NewSummarizer(feedbackAgentName, prSpec.Model, prSpec.Effort, opts.Verbose, logger)
 			feedbackCtx, feedbackCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 			defer feedbackCancel()
 
@@ -298,7 +490,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			}()
 
 			ccRunCtx, ccRunCancel := context.WithTimeout(ctx, opts.CrossCheckTimeout)
-			ccResult = summarizer.CrossCheck(ccRunCtx, ccAgentNames, ccModel, ccCtx, opts.Verbose, logger)
+			ccResult = summarizer.CrossCheck(ccRunCtx, ccSpecs, ccCtx, opts.Verbose, logger)
 			ccRunCancel()
 			ccSpinnerCancel()
 			<-ccSpinnerDone
@@ -327,7 +519,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	summarizerCtx, summarizerCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 	defer summarizerCancel()
 
-	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, opts.SummarizerModel, aggregated, ccResult, opts.Verbose, logger)
+	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, summarizer.SummarizeOptions{Model: summSpec.Model, Effort: summSpec.Effort}, aggregated, ccResult, opts.Verbose, logger)
 	spinnerCancel()
 	<-spinnerDone
 
@@ -361,7 +553,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 		fpCtx, fpCancel := context.WithTimeout(ctx, opts.FPFilterTimeout)
 		defer fpCancel()
-		fpFilter := fpfilter.New(opts.SummarizerAgent, opts.SummarizerModel, opts.FPThreshold, opts.Verbose, logger)
+		cliSumModelFP, legacySumModelFP := cliOrLegacy(opts.SummarizerModel, opts.SummarizerModelFromCLI)
+		fpSpec := modelconfig.Resolve(
+			opts.Models, sizeStr, modelconfig.RoleFPFilter, opts.SummarizerAgent,
+			cliSumModelFP, "",
+			legacySumModelFP, "",
+		)
+		fpFilter := fpfilter.New(opts.SummarizerAgent, fpSpec.Model, fpSpec.Effort, opts.FPThreshold, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, priorFeedback, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone
@@ -799,4 +997,27 @@ func diffFindingGroups(before, after []domain.FindingGroup) []domain.FindingGrou
 		}
 	}
 	return removed
+}
+
+// formatSpec formats a model/effort pair for the verbose effective matrix log.
+// Empty fields are shown as "(default)" to distinguish "not set" from a blank value.
+func formatSpec(opts agent.AgentOptions) string {
+	model := opts.Model
+	if model == "" {
+		model = "(default)"
+	}
+	effort := opts.Effort
+	if effort == "" {
+		effort = "(default)"
+	}
+	return fmt.Sprintf("%s [%s]", model, effort)
+}
+
+// formatSizeStr returns the size string for display, substituting "(unknown)"
+// when classification was not available (empty string).
+func formatSizeStr(s string) string {
+	if s == "" {
+		return "(unknown)"
+	}
+	return s
 }

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1165,30 +1165,3 @@ func TestComputeVerdict_CrossCheckBlockingBeatsDegraded(t *testing.T) {
 		t.Errorf("blocking finding must take precedence over degraded, got %q", g.Verdict)
 	}
 }
-
-// TestCrossCheckEnabledEmptyAgents_IsError documents the design decision that
-// cross-check enabled with zero resolved agents must return ExitError in
-// executeReview. resolveCrossCheckAgents is tested separately; a full
-// integration test would require a real git tree and agent CLIs.
-func TestCrossCheckEnabledEmptyAgents_IsError(t *testing.T) {
-	// Constructing a ReviewOpts where the resolved cross-check agent list is
-	// empty requires SummarizerAgent="" (so the fallback path produces no
-	// agents). That state is normally rejected by earlier validation but the
-	// executeReview guard is the last line of defense.
-	opts := ReviewOpts{
-		ResolvedConfig: config.ResolvedConfig{
-			SummarizerAgent:   "",
-			CrossCheckAgent:   "",
-			CrossCheckEnabled: true,
-		},
-	}
-	names, _ := resolveCrossCheckAgents(opts)
-	// Empty summarizer agent + empty cross-check agent → names comes from
-	// ParseAgentNames(""). Document the boundary: the guard in executeReview
-	// kicks in only when names is empty. ParseAgentNames("") returning []
-	// is what makes this guard reachable; if that behavior changes, the
-	// guard needs revisiting.
-	if opts.CrossCheckEnabled && len(names) == 0 {
-		t.Log("design: executeReview returns ExitError when CrossCheckEnabled=true and resolved agent list is empty")
-	}
-}

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1165,3 +1165,30 @@ func TestComputeVerdict_CrossCheckBlockingBeatsDegraded(t *testing.T) {
 		t.Errorf("blocking finding must take precedence over degraded, got %q", g.Verdict)
 	}
 }
+
+// TestCrossCheckEnabledEmptyAgents_IsError documents the design decision that
+// cross-check enabled with zero resolved agents must return ExitError in
+// executeReview. resolveCrossCheckAgents is tested separately; a full
+// integration test would require a real git tree and agent CLIs.
+func TestCrossCheckEnabledEmptyAgents_IsError(t *testing.T) {
+	// Constructing a ReviewOpts where the resolved cross-check agent list is
+	// empty requires SummarizerAgent="" (so the fallback path produces no
+	// agents). That state is normally rejected by earlier validation but the
+	// executeReview guard is the last line of defense.
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			SummarizerAgent:   "",
+			CrossCheckAgent:   "",
+			CrossCheckEnabled: true,
+		},
+	}
+	names, _ := resolveCrossCheckAgents(opts)
+	// Empty summarizer agent + empty cross-check agent → names comes from
+	// ParseAgentNames(""). Document the boundary: the guard in executeReview
+	// kicks in only when names is empty. ParseAgentNames("") returning []
+	// is what makes this guard reachable; if that behavior changes, the
+	// guard needs revisiting.
+	if opts.CrossCheckEnabled && len(names) == 0 {
+		t.Log("design: executeReview returns ExitError when CrossCheckEnabled=true and resolved agent list is empty")
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -4,6 +4,20 @@ import (
 	"context"
 )
 
+// AgentOptions configures an Agent instance at construction time.
+// Model overrides the agent's default model (empty = agent default).
+// Effort is agent-specific thinking/reasoning configuration:
+//   - codex: low|medium|high maps to `-c model_reasoning_effort=<value>`
+//   - claude: low|medium|high|xhigh|max maps to --effort; other values are
+//     silently dropped (session-scoped; available levels depend on the model)
+//   - gemini: unsupported, ignored
+//
+// Empty Effort means "use agent default" (no flag passed).
+type AgentOptions struct {
+	Model  string
+	Effort string
+}
+
 // Agent represents a backend that can execute code reviews and summarizations.
 // Implementations include CodexAgent, ClaudeAgent, GeminiAgent.
 type Agent interface {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -6,7 +6,22 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 )
+
+// claudeEffortArgs maps a Spec.Effort value to Claude Code CLI's --effort flag.
+// Claude Code CLI accepts low|medium|high|xhigh|max (available levels depend
+// on the model; unknown values are silently dropped so runs don't fail on
+// outdated configs). Session-scoped; does not persist to settings.
+// See https://code.claude.com/docs/en/cli-reference --effort.
+func claudeEffortArgs(effort string) []string {
+	switch strings.ToLower(effort) {
+	case "low", "medium", "high", "xhigh", "max":
+		return []string{"--effort", strings.ToLower(effort)}
+	default:
+		return nil
+	}
+}
 
 // Compile-time interface check
 var _ Agent = (*ClaudeAgent)(nil)
@@ -19,13 +34,19 @@ var _ Agent = (*ClaudeAgent)(nil)
 
 // ClaudeAgent implements the Agent interface for the Claude CLI backend.
 type ClaudeAgent struct {
-	model string
+	model  string
+	effort string
 }
 
 // NewClaudeAgent creates a new ClaudeAgent instance.
 // If model is non-empty, it overrides the default model via --model.
 func NewClaudeAgent(model string) *ClaudeAgent {
 	return &ClaudeAgent{model: model}
+}
+
+// NewClaudeAgentWithOptions creates a new ClaudeAgent instance with the given options.
+func NewClaudeAgentWithOptions(opts AgentOptions) *ClaudeAgent {
+	return &ClaudeAgent{model: opts.Model, effort: opts.Effort}
 }
 
 // Name returns the agent's identifier.
@@ -58,7 +79,8 @@ func (c *ClaudeAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (
 		model = config.Model
 	}
 
-	args := []string{"--print", "-"}
+	effortArgs := claudeEffortArgs(c.effort)
+	args := append(effortArgs, "--print", "-")
 	if model != "" {
 		args = append([]string{"--model", model}, args...)
 	}
@@ -103,7 +125,8 @@ func (c *ClaudeAgent) ExecuteSummary(ctx context.Context, prompt string, input [
 
 	// Build command with JSON output format (no --json-schema — see note above)
 	// -: Read prompt from stdin (avoids ARG_MAX limits on large inputs)
-	args := []string{"--print", "--output-format", "json", "-"}
+	effortArgs := claudeEffortArgs(c.effort)
+	args := append(effortArgs, "--print", "--output-format", "json", "-")
 	if c.model != "" {
 		args = append([]string{"--model", c.model}, args...)
 	}

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -327,3 +327,154 @@ func TestClaudeAgent_ExecuteSummary_Args(t *testing.T) {
 		t.Errorf("unexpected --json-schema in args — ExecuteSummary must not constrain output format")
 	}
 }
+
+func TestClaudeAgent_ExecuteReview_WithEffort(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	for _, cmd := range [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	} {
+		c := exec.CommandContext(context.Background(), cmd[0], cmd[1:]...)
+		c.Dir = tmpDir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v failed: %v\n%s", cmd, err, out)
+		}
+	}
+
+	testFile := filepath.Join(tmpDir, "test.go")
+	if err := os.WriteFile(testFile, []byte("package main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial"},
+	} {
+		c := exec.CommandContext(context.Background(), cmd[0], cmd[1:]...)
+		c.Dir = tmpDir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git commit %v failed: %v\n%s", cmd, err, out)
+		}
+	}
+
+	if err := os.WriteFile(testFile, []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	prepareMockCLI(t, "claude", "args-prefix-stdin")
+
+	agent := NewClaudeAgentWithOptions(AgentOptions{Effort: "high"})
+	ctx := context.Background()
+	config := &ReviewConfig{
+		BaseRef: "HEAD",
+		WorkDir: tmpDir,
+	}
+
+	result, err := agent.ExecuteReview(ctx, config)
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	outputStr := string(output)
+	args := parseHelperArgs(outputStr)
+	iEffort := argIndex(args, "--effort")
+	iValue := argIndex(args, "high")
+	iPrint := argIndex(args, "--print")
+	iDash := argIndex(args, "-")
+	if iEffort < 0 || iValue < 0 {
+		t.Fatalf("expected --effort and high in args, got: %v", args)
+	}
+	if iValue != iEffort+1 {
+		t.Errorf("expected 'high' immediately after --effort, got args=%v", args)
+	}
+	// Position guard: claude CLI requires --effort to precede the positional
+	// stdin marker '-' and the --print flag. Without this ordering claude
+	// silently drops the flag (the original Round-8 bug).
+	if iPrint < 0 || iEffort > iPrint {
+		t.Errorf("--effort (idx=%d) must precede --print (idx=%d), got args=%v", iEffort, iPrint, args)
+	}
+	if iDash < 0 || iEffort > iDash {
+		t.Errorf("--effort (idx=%d) must precede positional '-' (idx=%d), got args=%v", iEffort, iDash, args)
+	}
+}
+
+func TestClaudeAgent_ExecuteSummary_WithEffort(t *testing.T) {
+	prepareMockCLI(t, "claude", "args-prefix-stdin")
+
+	agent := NewClaudeAgentWithOptions(AgentOptions{Effort: "medium"})
+	ctx := context.Background()
+
+	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	if err != nil {
+		t.Fatalf("ExecuteSummary() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	outputStr := string(output)
+	args := parseHelperArgs(outputStr)
+	iEffort := argIndex(args, "--effort")
+	iValue := argIndex(args, "medium")
+	iPrint := argIndex(args, "--print")
+	iFmt := argIndex(args, "--output-format")
+	iDash := argIndex(args, "-")
+	if iEffort < 0 || iValue < 0 {
+		t.Fatalf("expected --effort and medium in args, got: %v", args)
+	}
+	if iValue != iEffort+1 {
+		t.Errorf("expected 'medium' immediately after --effort, got args=%v", args)
+	}
+	// Position guard: same constraint as ExecuteReview — --effort must
+	// precede --print, --output-format, and the positional '-' stdin marker.
+	if iPrint < 0 || iEffort > iPrint {
+		t.Errorf("--effort (idx=%d) must precede --print (idx=%d), got args=%v", iEffort, iPrint, args)
+	}
+	if iFmt < 0 || iEffort > iFmt {
+		t.Errorf("--effort (idx=%d) must precede --output-format (idx=%d), got args=%v", iEffort, iFmt, args)
+	}
+	if iDash < 0 || iEffort > iDash {
+		t.Errorf("--effort (idx=%d) must precede positional '-' (idx=%d), got args=%v", iEffort, iDash, args)
+	}
+}
+
+func TestClaudeEffortArgs(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"low", []string{"--effort", "low"}},
+		{"Low", []string{"--effort", "low"}},
+		{"medium", []string{"--effort", "medium"}},
+		{"High", []string{"--effort", "high"}},
+		{"xhigh", []string{"--effort", "xhigh"}},
+		{"max", []string{"--effort", "max"}},
+		{"MAX", []string{"--effort", "max"}},
+		{"8000", nil},
+		{"unknown", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := claudeEffortArgs(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("claudeEffortArgs(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("claudeEffortArgs(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -9,18 +9,41 @@ import (
 	"strings"
 )
 
+// codexReasoningEffortArgs maps Spec.Effort to codex CLI's -c config override.
+// codex does not have a --reasoning-effort flag; the equivalent is
+//
+//	-c model_reasoning_effort=<value>
+//
+// which sets the value in ~/.codex/config.toml at runtime. See `codex exec --help`
+// for the -c syntax. Unknown values are silently ignored — validation lives in
+// the config layer.
+func codexReasoningEffortArgs(effort string) []string {
+	switch strings.ToLower(effort) {
+	case "low", "medium", "high":
+		return []string{"-c", "model_reasoning_effort=" + strings.ToLower(effort)}
+	default:
+		return nil
+	}
+}
+
 // Compile-time interface check
 var _ Agent = (*CodexAgent)(nil)
 
 // CodexAgent implements the Agent interface for the Codex CLI backend.
 type CodexAgent struct {
-	model string
+	model  string
+	effort string
 }
 
 // NewCodexAgent creates a new CodexAgent instance.
 // If model is non-empty, it overrides the default model via --model.
 func NewCodexAgent(model string) *CodexAgent {
 	return &CodexAgent{model: model}
+}
+
+// NewCodexAgentWithOptions creates a new CodexAgent instance with the given options.
+func NewCodexAgentWithOptions(opts AgentOptions) *CodexAgent {
+	return &CodexAgent{model: opts.Model, effort: opts.Effort}
 }
 
 // Name returns the agent's identifier.
@@ -61,7 +84,8 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 	// (codex+claude), DiffPrecomputed is globally true for Claude's benefit,
 	// but Codex should still use its built-in review when no guidance/phase is set.
 	if config.Guidance != "" || config.Phase != "" || len(config.TargetFiles) > 0 {
-		args := []string{"exec", "--json", "--color", "never", "-"}
+		effortArgs := codexReasoningEffortArgs(c.effort)
+		args := append(effortArgs, []string{"exec", "--json", "--color", "never", "-"}...)
 		if model != "" {
 			args = append([]string{"--model", model}, args...)
 		}
@@ -73,7 +97,8 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 		})
 	}
 
-	args := []string{"exec", "--json", "--color", "never", "review", "--base", config.BaseRef}
+	effortArgs := codexReasoningEffortArgs(c.effort)
+	args := append(effortArgs, []string{"exec", "--json", "--color", "never", "review", "--base", config.BaseRef}...)
 	if model != "" {
 		args = append([]string{"--model", model}, args...)
 	}
@@ -97,7 +122,8 @@ func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []
 		return nil, err
 	}
 
-	args := []string{"exec", "--json", "--color", "never", "-"}
+	effortArgs := codexReasoningEffortArgs(c.effort)
+	args := append(effortArgs, []string{"exec", "--json", "--color", "never", "-"}...)
 	if c.model != "" {
 		args = append([]string{"--model", c.model}, args...)
 	}

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -310,3 +310,87 @@ func TestCodexAgent_ExecuteSummary_Args(t *testing.T) {
 		}
 	}
 }
+
+func TestCodexReasoningEffortArgs(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"low", []string{"-c", "model_reasoning_effort=low"}},
+		{"LOW", []string{"-c", "model_reasoning_effort=low"}},
+		{"Medium", []string{"-c", "model_reasoning_effort=medium"}},
+		{"high", []string{"-c", "model_reasoning_effort=high"}},
+		{"unknown", nil},
+		{"8000", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := codexReasoningEffortArgs(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d]: got %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCodexAgent_ExecuteReview_WithEffort(t *testing.T) {
+	prepareMockCLI(t, "codex", "args")
+
+	agent := NewCodexAgentWithOptions(AgentOptions{Effort: "high"})
+	ctx := context.Background()
+	config := &ReviewConfig{
+		BaseRef: "main",
+		WorkDir: t.TempDir(),
+	}
+
+	result, err := agent.ExecuteReview(ctx, config)
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "-c") {
+		t.Errorf("expected -c in args, got:\n%s", outputStr)
+	}
+	if !strings.Contains(outputStr, "model_reasoning_effort=high") {
+		t.Errorf("expected model_reasoning_effort=high in args, got:\n%s", outputStr)
+	}
+}
+
+func TestCodexAgent_ExecuteSummary_WithEffort(t *testing.T) {
+	prepareMockCLI(t, "codex", "args")
+
+	agent := NewCodexAgentWithOptions(AgentOptions{Effort: "medium"})
+	ctx := context.Background()
+
+	result, err := agent.ExecuteSummary(ctx, "summarize this", []byte(`{"findings":[]}`))
+	if err != nil {
+		t.Fatalf("ExecuteSummary() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "-c") {
+		t.Errorf("expected -c in args, got:\n%s", outputStr)
+	}
+	if !strings.Contains(outputStr, "model_reasoning_effort=medium") {
+		t.Errorf("expected model_reasoning_effort=medium in args, got:\n%s", outputStr)
+	}
+}

--- a/internal/agent/cohort.go
+++ b/internal/agent/cohort.go
@@ -59,28 +59,51 @@ func CreateAgents(names []string) ([]Agent, error) {
 // CreateAgentsWithModel creates Agent instances for the given names with an optional model override.
 // If model is empty, agents use their default models.
 // Validates all agent CLIs are available (fail fast).
+//
+// Deprecated: prefer CreateAgentsFromSpecs for new call sites so per-agent
+// effort and model can be resolved independently.
 func CreateAgentsWithModel(names []string, model string) ([]Agent, error) {
-	agents := make([]Agent, 0, len(names))
-	seen := make(map[string]Agent)
+	specs := make([]AgentSpec, len(names))
+	for i, n := range names {
+		specs[i] = AgentSpec{Name: n, Options: AgentOptions{Model: model}}
+	}
+	return CreateAgentsFromSpecs(specs)
+}
 
-	for _, name := range names {
-		// Reuse existing agent instance if same name appears multiple times
-		if existing, ok := seen[name]; ok {
+// AgentSpec pairs an agent name with its construction options. Used by
+// CreateAgentsFromSpecs to build a reviewer cohort where each agent instance
+// may have a distinct model/effort resolved from the (size, role, agent) tuple.
+type AgentSpec struct {
+	Name    string
+	Options AgentOptions
+}
+
+// CreateAgentsFromSpecs creates Agent instances for the given specs.
+// Agents are deduplicated by (Name, Options) so callers can pass repeated
+// entries (e.g., for reviewer round-robin) without constructing duplicate
+// backends. Validates all agent CLIs are available (fail fast).
+func CreateAgentsFromSpecs(specs []AgentSpec) ([]Agent, error) {
+	agents := make([]Agent, 0, len(specs))
+	seen := make(map[AgentSpec]Agent)
+
+	for _, spec := range specs {
+		// Reuse existing agent instance if same (name, options) tuple appears multiple times
+		if existing, ok := seen[spec]; ok {
 			agents = append(agents, existing)
 			continue
 		}
 
-		agent, err := NewAgentWithModel(name, model)
+		a, err := NewAgentWithOptions(spec.Name, spec.Options)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := agent.IsAvailable(); err != nil {
-			return nil, fmt.Errorf("%s CLI not found: %w", name, err)
+		if err := a.IsAvailable(); err != nil {
+			return nil, fmt.Errorf("%s CLI not found: %w", spec.Name, err)
 		}
 
-		seen[name] = agent
-		agents = append(agents, agent)
+		seen[spec] = a
+		agents = append(agents, a)
 	}
 
 	return agents, nil

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -7,7 +7,7 @@ import (
 
 // agentRegistry holds the factory functions for a single agent.
 type agentRegistry struct {
-	newAgent         func(model string) Agent
+	newAgent         func(opts AgentOptions) Agent
 	newReviewParser  func(reviewerID int) ReviewParser
 	newSummaryParser func() SummaryParser
 }
@@ -16,17 +16,17 @@ type agentRegistry struct {
 // To add a new agent, add an entry here - no other changes needed.
 var registry = map[string]agentRegistry{
 	"codex": {
-		newAgent:         func(model string) Agent { return NewCodexAgent(model) },
+		newAgent:         func(opts AgentOptions) Agent { return NewCodexAgentWithOptions(opts) },
 		newReviewParser:  func(id int) ReviewParser { return NewCodexOutputParser(id) },
 		newSummaryParser: func() SummaryParser { return NewCodexSummaryParser() },
 	},
 	"claude": {
-		newAgent:         func(model string) Agent { return NewClaudeAgent(model) },
+		newAgent:         func(opts AgentOptions) Agent { return NewClaudeAgentWithOptions(opts) },
 		newReviewParser:  func(id int) ReviewParser { return NewClaudeOutputParser(id) },
 		newSummaryParser: func() SummaryParser { return NewClaudeSummaryParser() },
 	},
 	"gemini": {
-		newAgent:         func(model string) Agent { return NewGeminiAgent(model) },
+		newAgent:         func(opts AgentOptions) Agent { return NewGeminiAgentWithOptions(opts) },
 		newReviewParser:  func(id int) ReviewParser { return NewGeminiOutputParser(id) },
 		newSummaryParser: func() SummaryParser { return NewGeminiSummaryParser() },
 	},
@@ -52,17 +52,25 @@ const DefaultSummarizerAgent = "codex"
 // NewAgent creates an Agent by name with the default model.
 // Supported agents: codex, claude, gemini
 func NewAgent(name string) (Agent, error) {
-	return NewAgentWithModel(name, "")
+	return NewAgentWithOptions(name, AgentOptions{})
 }
 
 // NewAgentWithModel creates an Agent by name with an optional model override.
 // If model is empty, the agent uses its default model.
+// Deprecated: prefer NewAgentWithOptions for new call sites.
 func NewAgentWithModel(name, model string) (Agent, error) {
+	return NewAgentWithOptions(name, AgentOptions{Model: model})
+}
+
+// NewAgentWithOptions creates an Agent by name with the given options.
+// opts.Model overrides the agent's default model (empty = agent default).
+// opts.Effort configures agent-specific reasoning effort (empty = agent default).
+func NewAgentWithOptions(name string, opts AgentOptions) (Agent, error) {
 	reg, ok := registry[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown agent %q, supported: %v", name, SupportedAgents)
 	}
-	return reg.newAgent(model), nil
+	return reg.newAgent(opts), nil
 }
 
 // NewReviewParser creates a ReviewParser for the given agent name.

--- a/internal/agent/factory_test.go
+++ b/internal/agent/factory_test.go
@@ -134,3 +134,34 @@ func TestDefaultAgent(t *testing.T) {
 		t.Errorf("DefaultAgent = %q, want %q", DefaultAgent, "codex")
 	}
 }
+
+func TestNewAgentWithOptions_PassesModelAndEffort(t *testing.T) {
+	opts := AgentOptions{Model: "test-model", Effort: "high"}
+	for _, name := range SupportedAgents {
+		a, err := NewAgentWithOptions(name, opts)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", name, err)
+			continue
+		}
+		if a == nil {
+			t.Errorf("%s: got nil agent", name)
+		}
+	}
+}
+
+func TestNewAgentWithModel_DelegatesToOptions(t *testing.T) {
+	a, err := NewAgentWithModel("codex", "gpt-5.4-mini")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a == nil {
+		t.Fatal("expected non-nil agent")
+	}
+}
+
+func TestNewAgentWithOptions_UnknownAgent(t *testing.T) {
+	_, err := NewAgentWithOptions("unknown", AgentOptions{})
+	if err == nil {
+		t.Fatal("expected error for unknown agent")
+	}
+}

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -9,18 +9,31 @@ import (
 	"strings"
 )
 
+// geminiEffortArgs returns an empty args slice; gemini does not support
+// thinking effort control. Callers that want a visible notice should log
+// at the call site when verbose is on.
+func geminiEffortArgs(_ string) []string {
+	return nil
+}
+
 // Compile-time interface check
 var _ Agent = (*GeminiAgent)(nil)
 
 // GeminiAgent implements the Agent interface for the Gemini CLI backend.
 type GeminiAgent struct {
-	model string
+	model  string
+	effort string
 }
 
 // NewGeminiAgent creates a new GeminiAgent instance.
 // If model is non-empty, it overrides the default model via --model.
 func NewGeminiAgent(model string) *GeminiAgent {
 	return &GeminiAgent{model: model}
+}
+
+// NewGeminiAgentWithOptions creates a new GeminiAgent instance with the given options.
+func NewGeminiAgentWithOptions(opts AgentOptions) *GeminiAgent {
+	return &GeminiAgent{model: opts.Model, effort: opts.Effort}
 }
 
 // Name returns the agent's identifier.

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 )
 
-// geminiEffortArgs returns an empty args slice; gemini does not support
-// thinking effort control. Callers that want a visible notice should log
-// at the call site when verbose is on.
+// geminiEffortArgs returns nil because gemini does not support thinking
+// effort control. This is a no-op; callers that want a visible notice
+// should log at the call site when verbose is on.
 func geminiEffortArgs(_ string) []string {
 	return nil
 }

--- a/internal/agent/gemini_test.go
+++ b/internal/agent/gemini_test.go
@@ -262,3 +262,12 @@ func TestGeminiAgent_ExecuteSummary_Args(t *testing.T) {
 		t.Errorf("expected - (stdin) in args, got:\n%s", outputStr)
 	}
 }
+
+func TestGeminiEffortArgs_Noop(t *testing.T) {
+	cases := []string{"", "low", "medium", "high", "8000", "unknown"}
+	for _, effort := range cases {
+		if got := geminiEffortArgs(effort); got != nil {
+			t.Errorf("geminiEffortArgs(%q) should return nil (no-op), got %v", effort, got)
+		}
+	}
+}

--- a/internal/agent/testhelpers_test.go
+++ b/internal/agent/testhelpers_test.go
@@ -161,3 +161,40 @@ func prepareMockCLI(t *testing.T, name, mode string) {
 	t.Setenv(agentTestHelperEnv, "1")
 	t.Setenv(agentTestHelperModeEnv, mode)
 }
+
+// parseHelperArgs extracts the argv received by the mock CLI helper.
+// It accepts both "args" mode (raw newline-separated) and "args-prefix-stdin"
+// mode (each arg prefixed with "ARG:"). Lines that do not look like an arg
+// (e.g., copied stdin payload) are skipped. The returned slice preserves the
+// order in which the helper saw the arguments.
+func parseHelperArgs(output string) []string {
+	var args []string
+	prefix := "ARG:"
+	hasPrefix := strings.Contains(output, prefix)
+	for _, line := range strings.Split(output, "\n") {
+		if hasPrefix {
+			if strings.HasPrefix(line, prefix) {
+				args = append(args, strings.TrimPrefix(line, prefix))
+			}
+			continue
+		}
+		// Plain "args" mode: every non-empty line up until the first blank
+		// line is an arg. Stop at the first blank to avoid pulling in copied
+		// stdin payload (when the helper is in args-prefix-stdin variants).
+		if line == "" {
+			break
+		}
+		args = append(args, line)
+	}
+	return args
+}
+
+// argIndex returns the index of target in args, or -1 if missing.
+func argIndex(args []string, target string) int {
+	for i, a := range args {
+		if a == target {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,37 @@ func (d Duration) AsDuration() time.Duration {
 	return time.Duration(d)
 }
 
+// ModelSpec holds the model name and effort for a specific role.
+type ModelSpec struct {
+	Model  string `yaml:"model"`
+	Effort string `yaml:"effort"`
+}
+
+// RoleModels holds per-role model specifications.
+//
+// ArchReviewer / DiffReviewer are phase-specific reviewer overrides used only
+// by auto-phase medium/large runs where `arch` and `diff` phases run with
+// distinct model/effort. When unset, the resolver falls back to the generic
+// Reviewer spec at the SAME cascade layer (see modelconfig.ResolveReviewer).
+// Flat review (auto-phase OFF / size=small / explicit `--phase diff`) ignores
+// these fields and uses Reviewer only.
+type RoleModels struct {
+	Reviewer     *ModelSpec `yaml:"reviewer"`
+	ArchReviewer *ModelSpec `yaml:"arch_reviewer"`
+	DiffReviewer *ModelSpec `yaml:"diff_reviewer"`
+	Summarizer   *ModelSpec `yaml:"summarizer"`
+	FPFilter     *ModelSpec `yaml:"fp_filter"`
+	CrossCheck   *ModelSpec `yaml:"cross_check"`
+	PRFeedback   *ModelSpec `yaml:"pr_feedback"`
+}
+
+// ModelsConfig holds the models configuration section.
+type ModelsConfig struct {
+	Defaults RoleModels            `yaml:"defaults"`
+	Sizes    map[string]RoleModels `yaml:"sizes"`
+	Agents   map[string]RoleModels `yaml:"agents"`
+}
+
 type Config struct {
 	Reviewers         *int             `yaml:"reviewers"`
 	Concurrency       *int             `yaml:"concurrency"`
@@ -74,6 +105,7 @@ type Config struct {
 	FPFilter          FPFilterConfig   `yaml:"fp_filter"`
 	PRFeedback        PRFeedbackConfig `yaml:"pr_feedback"`
 	CrossCheck        CrossCheckConfig `yaml:"cross_check"`
+	Models            ModelsConfig     `yaml:"models"`
 }
 
 // CrossCheckConfig holds cross-check verification settings.
@@ -181,9 +213,15 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check"}
+var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
+
+var knownModelsKeys = []string{"defaults", "sizes", "agents"}
+
+var knownRoleKeys = []string{"reviewer", "arch_reviewer", "diff_reviewer", "summarizer", "fp_filter", "cross_check", "pr_feedback"}
+
+var knownModelSpecKeys = []string{"model", "effort"}
 
 var knownPRFeedbackKeys = []string{"enabled", "agent"}
 
@@ -262,6 +300,69 @@ func checkUnknownKeys(data []byte) []string {
 		}
 	}
 
+	if models, ok := raw["models"].(map[string]any); ok {
+		for key := range models {
+			if !slices.Contains(knownModelsKeys, key) {
+				warning := fmt.Sprintf("unknown key %q in models section of %s", key, ConfigFileName)
+				if suggestion := findSimilar(key, knownModelsKeys); suggestion != "" {
+					warning += fmt.Sprintf(" (did you mean %q?)", suggestion)
+				}
+				warnings = append(warnings, warning)
+			}
+		}
+
+		// Check defaults section role keys and modelspec keys
+		if defaults, ok := models["defaults"].(map[string]any); ok {
+			warnings = append(warnings, checkRoleModelsKeys(defaults, "models.defaults", ConfigFileName)...)
+		}
+
+		// Check sizes: each size name is user-defined, but its role keys must be known
+		if sizes, ok := models["sizes"].(map[string]any); ok {
+			for sizeName, sizeVal := range sizes {
+				if roleMap, ok := sizeVal.(map[string]any); ok {
+					warnings = append(warnings, checkRoleModelsKeys(roleMap, fmt.Sprintf("models.sizes.%s", sizeName), ConfigFileName)...)
+				}
+			}
+		}
+
+		// Check agents: each agent name is validated in Validate(), but role keys must be known
+		if agents, ok := models["agents"].(map[string]any); ok {
+			for agentName, agentVal := range agents {
+				if roleMap, ok := agentVal.(map[string]any); ok {
+					warnings = append(warnings, checkRoleModelsKeys(roleMap, fmt.Sprintf("models.agents.%s", agentName), ConfigFileName)...)
+				}
+			}
+		}
+	}
+
+	return warnings
+}
+
+// checkRoleModelsKeys checks that all keys in a RoleModels map are known role keys,
+// and that all keys within each ModelSpec are known modelspec keys.
+func checkRoleModelsKeys(roleMap map[string]any, section, configFileName string) []string {
+	var warnings []string
+	for roleKey, roleVal := range roleMap {
+		if !slices.Contains(knownRoleKeys, roleKey) {
+			warning := fmt.Sprintf("unknown key %q in %s section of %s", roleKey, section, configFileName)
+			if suggestion := findSimilar(roleKey, knownRoleKeys); suggestion != "" {
+				warning += fmt.Sprintf(" (did you mean %q?)", suggestion)
+			}
+			warnings = append(warnings, warning)
+			continue
+		}
+		if specMap, ok := roleVal.(map[string]any); ok {
+			for specKey := range specMap {
+				if !slices.Contains(knownModelSpecKeys, specKey) {
+					warning := fmt.Sprintf("unknown key %q in %s.%s section of %s", specKey, section, roleKey, configFileName)
+					if suggestion := findSimilar(specKey, knownModelSpecKeys); suggestion != "" {
+						warning += fmt.Sprintf(" (did you mean %q?)", suggestion)
+					}
+					warnings = append(warnings, warning)
+				}
+			}
+		}
+	}
 	return warnings
 }
 
@@ -358,6 +459,9 @@ func Merge(cfg *Config, cliPatterns []string) []string {
 func (c *Config) Validate() error {
 	resolved := Resolve(c, EnvState{}, FlagState{}, Defaults)
 	errs := resolved.ValidateAll()
+	errs = append(errs, c.validateModelsAgents()...)
+	errs = append(errs, c.validateModelsSizes()...)
+	errs = append(errs, c.validateModelsEffort()...)
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
@@ -421,6 +525,88 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	return errs
 }
 
+// validateModelsAgents checks that all agent keys in models.agents are supported agents.
+func (c *Config) validateModelsAgents() []string {
+	var errs []string
+	for agentName := range c.Models.Agents {
+		if !slices.Contains(agent.SupportedAgents, agentName) {
+			errs = append(errs, fmt.Sprintf("models.agents contains unsupported agent %q, must be one of %v", agentName, agent.SupportedAgents))
+		}
+	}
+	return errs
+}
+
+var validSizeKeys = []string{"small", "medium", "large"}
+
+// validateModelsSizes checks that all size keys in models.sizes are valid.
+func (c *Config) validateModelsSizes() []string {
+	var errs []string
+	for sizeName := range c.Models.Sizes {
+		if !slices.Contains(validSizeKeys, sizeName) {
+			errs = append(errs, fmt.Sprintf(
+				"models.sizes contains unknown size key %q, must be one of %v",
+				sizeName, validSizeKeys,
+			))
+		}
+	}
+	return errs
+}
+
+// validEffortsLoose is the superset accepted in defaults/sizes layers
+// (not agent-specific; uses the broadest supported set).
+var validEffortsLoose = []string{"low", "medium", "high", "xhigh", "max"}
+
+// validEffortsByAgent is the per-agent accepted set for the agents layer.
+var validEffortsByAgent = map[string][]string{
+	"codex":  {"low", "medium", "high"},
+	"claude": {"low", "medium", "high", "xhigh", "max"},
+	"gemini": {},
+}
+
+// validateModelsEffort validates effort values across defaults, sizes, and agents layers.
+func (c *Config) validateModelsEffort() []string {
+	var errs []string
+
+	checkAllSpecEfforts(c.Models.Defaults, "defaults", validEffortsLoose, &errs)
+
+	for sizeName, roleModels := range c.Models.Sizes {
+		checkAllSpecEfforts(roleModels, "sizes."+sizeName, validEffortsLoose, &errs)
+	}
+
+	for agentName, roleModels := range c.Models.Agents {
+		valid, ok := validEffortsByAgent[agentName]
+		if !ok {
+			// Unknown agent — validateModelsAgents already catches this, skip.
+			continue
+		}
+		checkAllSpecEfforts(roleModels, "agents."+agentName, valid, &errs)
+	}
+
+	return errs
+}
+
+// checkAllSpecEfforts validates all ModelSpec.Effort fields in a RoleModels struct.
+func checkAllSpecEfforts(rm RoleModels, prefix string, valid []string, errs *[]string) {
+	checkOne := func(spec *ModelSpec, role string) {
+		if spec == nil || spec.Effort == "" {
+			return
+		}
+		if !slices.Contains(valid, strings.ToLower(spec.Effort)) {
+			*errs = append(*errs, fmt.Sprintf(
+				"models.%s.%s.effort %q is not valid (accepted: %v)",
+				prefix, role, spec.Effort, valid,
+			))
+		}
+	}
+	checkOne(rm.Reviewer, "reviewer")
+	checkOne(rm.ArchReviewer, "arch_reviewer")
+	checkOne(rm.DiffReviewer, "diff_reviewer")
+	checkOne(rm.Summarizer, "summarizer")
+	checkOne(rm.FPFilter, "fp_filter")
+	checkOne(rm.CrossCheck, "cross_check")
+	checkOne(rm.PRFeedback, "pr_feedback")
+}
+
 // Validate checks that all resolved config values are semantically valid.
 // Returns a single error summarizing all issues, or nil if valid.
 func (r *ResolvedConfig) Validate() error {
@@ -479,6 +665,13 @@ type ResolvedConfig struct {
 	CrossCheckModel   string // empty means use summarizer model
 	AutoPhase         bool
 	Strict            bool // when true, advisory verdict exits 1 (default false)
+	// ReviewerModelFromCLI is true when --reviewer-model or ACR_REVIEWER_MODEL
+	// set the ReviewerModel field, making it a CLI/env override that should win
+	// over models.agents/sizes/defaults config.
+	ReviewerModelFromCLI   bool
+	SummarizerModelFromCLI bool
+	CrossCheckModelFromCLI bool
+	Models                 ModelsConfig
 }
 
 type FlagState struct {
@@ -844,6 +1037,8 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.AutoPhase != nil {
 			result.AutoPhase = *cfg.AutoPhase
 		}
+		// Models configuration is a struct (not a pointer); copy as-is.
+		result.Models = cfg.Models
 	}
 
 	// Apply env var values (if set)
@@ -980,6 +1175,10 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if flagState.StrictSet {
 		result.Strict = flagValues.Strict
 	}
+
+	result.ReviewerModelFromCLI = flagState.ReviewerModelSet || envState.ReviewerModelSet
+	result.SummarizerModelFromCLI = flagState.SummarizerModelSet || envState.SummarizerModelSet
+	result.CrossCheckModelFromCLI = flagState.CrossCheckModelSet || envState.CrossCheckModelSet
 
 	return result
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1913,3 +1913,483 @@ func TestLoadEnvState_AutoPhaseParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_ModelsSection_Parses(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  defaults:
+    reviewer:       { model: gpt-5.4-mini, effort: medium }
+    arch_reviewer:  { model: gpt-5.4,      effort: high }
+    diff_reviewer:  { model: gpt-5.4-mini, effort: medium }
+    summarizer:     { model: gpt-5.4,      effort: high }
+    fp_filter:      { model: gpt-5.4-mini, effort: low }
+    cross_check:    { model: gpt-5.4,      effort: medium }
+    pr_feedback:    { model: gpt-5.4-mini }
+  sizes:
+    small:
+      reviewer: { model: gpt-5.4-mini, effort: low }
+    medium:
+      reviewer: { model: gpt-5.4-mini, effort: medium }
+    large:
+      reviewer:      { model: gpt-5.4,      effort: high }
+      arch_reviewer: { model: gpt-5.4,      effort: high }
+      diff_reviewer: { model: gpt-5.4,      effort: medium }
+      summarizer:    { model: gpt-5.4,      effort: high }
+  agents:
+    codex:
+      reviewer:      { model: gpt-5.4-mini, effort: medium }
+      arch_reviewer: { effort: high }
+      diff_reviewer: { effort: medium }
+    claude:
+      reviewer: { model: sonnet-4-6,   effort: max }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", result.Warnings)
+	}
+
+	m := result.Config.Models
+
+	// defaults
+	if m.Defaults.Reviewer == nil {
+		t.Fatal("defaults.reviewer should not be nil")
+	}
+	if m.Defaults.Reviewer.Model != "gpt-5.4-mini" {
+		t.Errorf("defaults.reviewer.model: got %q, want %q", m.Defaults.Reviewer.Model, "gpt-5.4-mini")
+	}
+	if m.Defaults.Reviewer.Effort != "medium" {
+		t.Errorf("defaults.reviewer.effort: got %q, want %q", m.Defaults.Reviewer.Effort, "medium")
+	}
+	if m.Defaults.ArchReviewer == nil {
+		t.Fatal("defaults.arch_reviewer should not be nil")
+	}
+	if m.Defaults.ArchReviewer.Model != "gpt-5.4" || m.Defaults.ArchReviewer.Effort != "high" {
+		t.Errorf("defaults.arch_reviewer: got %+v, want {gpt-5.4, high}", *m.Defaults.ArchReviewer)
+	}
+	if m.Defaults.DiffReviewer == nil {
+		t.Fatal("defaults.diff_reviewer should not be nil")
+	}
+	if m.Defaults.DiffReviewer.Model != "gpt-5.4-mini" || m.Defaults.DiffReviewer.Effort != "medium" {
+		t.Errorf("defaults.diff_reviewer: got %+v, want {gpt-5.4-mini, medium}", *m.Defaults.DiffReviewer)
+	}
+	if m.Defaults.Summarizer == nil {
+		t.Fatal("defaults.summarizer should not be nil")
+	}
+	if m.Defaults.Summarizer.Model != "gpt-5.4" {
+		t.Errorf("defaults.summarizer.model: got %q, want %q", m.Defaults.Summarizer.Model, "gpt-5.4")
+	}
+	if m.Defaults.FPFilter == nil {
+		t.Fatal("defaults.fp_filter should not be nil")
+	}
+	if m.Defaults.FPFilter.Effort != "low" {
+		t.Errorf("defaults.fp_filter.effort: got %q, want %q", m.Defaults.FPFilter.Effort, "low")
+	}
+	if m.Defaults.CrossCheck == nil {
+		t.Fatal("defaults.cross_check should not be nil")
+	}
+	if m.Defaults.PRFeedback == nil {
+		t.Fatal("defaults.pr_feedback should not be nil")
+	}
+	if m.Defaults.PRFeedback.Effort != "" {
+		t.Errorf("defaults.pr_feedback.effort: expected empty, got %q", m.Defaults.PRFeedback.Effort)
+	}
+
+	// sizes
+	small, ok := m.Sizes["small"]
+	if !ok {
+		t.Fatal("sizes.small not found")
+	}
+	if small.Reviewer == nil {
+		t.Fatal("sizes.small.reviewer should not be nil")
+	}
+	if small.Reviewer.Effort != "low" {
+		t.Errorf("sizes.small.reviewer.effort: got %q, want %q", small.Reviewer.Effort, "low")
+	}
+	large, ok := m.Sizes["large"]
+	if !ok {
+		t.Fatal("sizes.large not found")
+	}
+	if large.Summarizer == nil {
+		t.Fatal("sizes.large.summarizer should not be nil")
+	}
+
+	// agents
+	codex, ok := m.Agents["codex"]
+	if !ok {
+		t.Fatal("agents.codex not found")
+	}
+	if codex.Reviewer == nil {
+		t.Fatal("agents.codex.reviewer should not be nil")
+	}
+	if codex.Reviewer.Model != "gpt-5.4-mini" {
+		t.Errorf("agents.codex.reviewer.model: got %q, want %q", codex.Reviewer.Model, "gpt-5.4-mini")
+	}
+	if codex.ArchReviewer == nil || codex.ArchReviewer.Effort != "high" {
+		t.Errorf("agents.codex.arch_reviewer.effort: got %+v, want effort=high", codex.ArchReviewer)
+	}
+	if codex.DiffReviewer == nil || codex.DiffReviewer.Effort != "medium" {
+		t.Errorf("agents.codex.diff_reviewer.effort: got %+v, want effort=medium", codex.DiffReviewer)
+	}
+	claude, ok := m.Agents["claude"]
+	if !ok {
+		t.Fatal("agents.claude not found")
+	}
+	if claude.Reviewer == nil {
+		t.Fatal("agents.claude.reviewer should not be nil")
+	}
+	if claude.Reviewer.Effort != "max" {
+		t.Errorf("agents.claude.reviewer.effort: got %q, want %q", claude.Reviewer.Effort, "max")
+	}
+}
+
+func TestConfig_ModelsSection_UnknownKey_Warns(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  defaults:
+    unknown_role: { model: gpt-5.4-mini }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Warnings) == 0 {
+		t.Fatal("expected warning for unknown role key, got none")
+	}
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "unknown_role") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected warning mentioning 'unknown_role', got: %v", result.Warnings)
+	}
+}
+
+func TestConfig_ModelsSection_AgentsMustBeSupported(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  agents:
+    unknown_agent:
+      reviewer: { model: gpt-5.4-mini }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFromPathWithWarnings(configPath)
+	if err == nil {
+		t.Fatal("expected error for unsupported agent in models.agents, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown_agent") {
+		t.Errorf("expected error mentioning 'unknown_agent', got: %v", err)
+	}
+}
+
+func TestConfig_ModelsSection_EmptySectionOK(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `reviewers: 3
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	m := result.Config.Models
+	if m.Defaults.Reviewer != nil {
+		t.Error("expected Models.Defaults.Reviewer to be nil when models section absent")
+	}
+	if len(m.Sizes) != 0 {
+		t.Errorf("expected Models.Sizes to be empty, got %v", m.Sizes)
+	}
+	if len(m.Agents) != 0 {
+		t.Errorf("expected Models.Agents to be empty, got %v", m.Agents)
+	}
+	if result.Config.Reviewers == nil || *result.Config.Reviewers != 3 {
+		t.Error("expected Reviewers=3 to still be set correctly")
+	}
+}
+
+// --- F#1: CLI-vs-legacy model precedence markers ---
+
+func TestResolve_ReviewerModelFromCLI_FlagSet(t *testing.T) {
+	r := Resolve(&Config{}, EnvState{}, FlagState{ReviewerModelSet: true}, ResolvedConfig{ReviewerModel: "gpt-cli"})
+	if !r.ReviewerModelFromCLI {
+		t.Errorf("expected ReviewerModelFromCLI=true when flag is set")
+	}
+	if r.ReviewerModel != "gpt-cli" {
+		t.Errorf("expected ReviewerModel=gpt-cli, got %q", r.ReviewerModel)
+	}
+}
+
+func TestResolve_ReviewerModelFromCLI_EnvSet(t *testing.T) {
+	r := Resolve(&Config{}, EnvState{ReviewerModel: "gpt-env", ReviewerModelSet: true}, FlagState{}, ResolvedConfig{})
+	if !r.ReviewerModelFromCLI {
+		t.Errorf("expected ReviewerModelFromCLI=true when env is set")
+	}
+}
+
+func TestResolve_ReviewerModelFromCLI_ConfigOnly(t *testing.T) {
+	s := "gpt-cfg"
+	r := Resolve(&Config{ReviewerModel: &s}, EnvState{}, FlagState{}, ResolvedConfig{})
+	if r.ReviewerModelFromCLI {
+		t.Errorf("expected ReviewerModelFromCLI=false when only config sets ReviewerModel")
+	}
+	if r.ReviewerModel != "gpt-cfg" {
+		t.Errorf("expected ReviewerModel=gpt-cfg, got %q", r.ReviewerModel)
+	}
+}
+
+func TestResolve_SummarizerModelFromCLI(t *testing.T) {
+	r := Resolve(&Config{}, EnvState{}, FlagState{SummarizerModelSet: true}, ResolvedConfig{SummarizerModel: "sum-cli"})
+	if !r.SummarizerModelFromCLI {
+		t.Errorf("expected SummarizerModelFromCLI=true when flag is set")
+	}
+}
+
+func TestResolve_CrossCheckModelFromCLI(t *testing.T) {
+	r := Resolve(&Config{}, EnvState{CrossCheckModel: "cc-env", CrossCheckModelSet: true}, FlagState{}, ResolvedConfig{})
+	if !r.CrossCheckModelFromCLI {
+		t.Errorf("expected CrossCheckModelFromCLI=true when env is set")
+	}
+}
+
+// --- F#3: models.sizes key + effort validation ---
+
+func TestConfig_ModelsSizes_UnknownSizeKeyRejected(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  sizes:
+    larg:
+      reviewer: { model: gpt-5.4 }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFromPathWithWarnings(configPath)
+	if err == nil {
+		t.Fatal("expected error for unknown size key, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown size key") {
+		t.Errorf("expected error to mention 'unknown size key', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), `"larg"`) {
+		t.Errorf("expected error to mention the bad key %q, got: %v", "larg", err)
+	}
+}
+
+func TestConfig_ModelsEffort_CodexXhighRejected(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  agents:
+    codex:
+      reviewer: { model: gpt-5.4, effort: xhigh }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFromPathWithWarnings(configPath)
+	if err == nil {
+		t.Fatal("expected error for xhigh on codex, got nil")
+	}
+	if !strings.Contains(err.Error(), "xhigh") {
+		t.Errorf("expected error to mention 'xhigh', got: %v", err)
+	}
+}
+
+func TestConfig_ModelsEffort_GeminiEffortRejected(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  agents:
+    gemini:
+      reviewer: { model: gemini-2.5-pro, effort: low }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFromPathWithWarnings(configPath)
+	if err == nil {
+		t.Fatal("expected error for effort on gemini, got nil")
+	}
+	if !strings.Contains(err.Error(), "effort") {
+		t.Errorf("expected error to mention 'effort', got: %v", err)
+	}
+}
+
+func TestConfig_ModelsEffort_DefaultsXhighAccepted(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  defaults:
+    reviewer: { model: gpt-5.4, effort: xhigh }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("expected no error for xhigh in defaults (loose set), got: %v", err)
+	}
+	if result.Config.Models.Defaults.Reviewer == nil || result.Config.Models.Defaults.Reviewer.Effort != "xhigh" {
+		t.Errorf("expected defaults.reviewer.effort=xhigh, got %+v", result.Config.Models.Defaults.Reviewer)
+	}
+}
+
+func TestConfig_ModelsEffort_ClaudeMaxAccepted(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  agents:
+    claude:
+      reviewer: { model: sonnet-4-6, effort: max }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("expected no error for claude.effort=max, got: %v", err)
+	}
+}
+
+func TestConfig_ModelsEffort_CaseInsensitive_Defaults(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  defaults:
+    reviewer: { model: gpt-5.4, effort: High }
+    summarizer: { model: gpt-5.4, effort: XHIGH }
+    fp_filter: { model: gpt-5.4, effort: Low }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("expected case-insensitive effort to be accepted in defaults, got: %v", err)
+	}
+	if result.Config.Models.Defaults.Reviewer == nil || result.Config.Models.Defaults.Reviewer.Effort != "High" {
+		t.Errorf("expected defaults.reviewer.effort=High, got %+v", result.Config.Models.Defaults.Reviewer)
+	}
+	if result.Config.Models.Defaults.Summarizer == nil || result.Config.Models.Defaults.Summarizer.Effort != "XHIGH" {
+		t.Errorf("expected defaults.summarizer.effort=XHIGH, got %+v", result.Config.Models.Defaults.Summarizer)
+	}
+}
+
+func TestConfig_ModelsEffort_CaseInsensitive_Sizes(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  sizes:
+    small:
+      reviewer: { model: gpt-5.4-mini, effort: LOW }
+    large:
+      arch_reviewer: { model: gpt-5.4, effort: MediuM }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("expected case-insensitive effort to be accepted in sizes, got: %v", err)
+	}
+	small := result.Config.Models.Sizes["small"]
+	if small.Reviewer == nil || small.Reviewer.Effort != "LOW" {
+		t.Errorf("expected sizes.small.reviewer.effort=LOW, got %+v", small.Reviewer)
+	}
+	large := result.Config.Models.Sizes["large"]
+	if large.ArchReviewer == nil || large.ArchReviewer.Effort != "MediuM" {
+		t.Errorf("expected sizes.large.arch_reviewer.effort=MediuM, got %+v", large.ArchReviewer)
+	}
+}
+
+func TestConfig_ModelsEffort_CaseInsensitive_Agents(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  agents:
+    codex:
+      reviewer: { model: gpt-5.4, effort: MEDIUM }
+    claude:
+      reviewer: { model: sonnet-4-6, effort: Max }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("expected case-insensitive effort to be accepted in agents, got: %v", err)
+	}
+	codex := result.Config.Models.Agents["codex"]
+	if codex.Reviewer == nil || codex.Reviewer.Effort != "MEDIUM" {
+		t.Errorf("expected agents.codex.reviewer.effort=MEDIUM, got %+v", codex.Reviewer)
+	}
+	claude := result.Config.Models.Agents["claude"]
+	if claude.Reviewer == nil || claude.Reviewer.Effort != "Max" {
+		t.Errorf("expected agents.claude.reviewer.effort=Max, got %+v", claude.Reviewer)
+	}
+}
+
+func TestConfig_ModelsEffort_CaseInsensitive_StillRejectsInvalid(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := `models:
+  defaults:
+    reviewer: { model: gpt-5.4, effort: ULTRA }
+`
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadFromPathWithWarnings(configPath)
+	if err == nil {
+		t.Fatal("expected error for invalid effort 'ULTRA', got nil")
+	}
+	if !strings.Contains(err.Error(), "ULTRA") {
+		t.Errorf("expected error to mention 'ULTRA', got: %v", err)
+	}
+}

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -14,16 +14,19 @@ import (
 type Summarizer struct {
 	agentName string
 	model     string
+	effort    string
 	verbose   bool
 	logger    *terminal.Logger
 }
 
 // NewSummarizer creates a new PR feedback summarizer.
 // The model parameter overrides the agent's default model (empty = default).
-func NewSummarizer(agentName, model string, verbose bool, logger *terminal.Logger) *Summarizer {
+// The effort parameter overrides the agent's default reasoning effort (empty = default).
+func NewSummarizer(agentName, model, effort string, verbose bool, logger *terminal.Logger) *Summarizer {
 	return &Summarizer{
 		agentName: agentName,
 		model:     model,
+		effort:    effort,
 		verbose:   verbose,
 		logger:    logger,
 	}
@@ -49,7 +52,7 @@ func (s *Summarizer) Summarize(ctx context.Context, prNumber string) (string, er
 	input := s.buildInput(prCtx)
 
 	// Create agent
-	ag, err := agent.NewAgentWithModel(s.agentName, s.model)
+	ag, err := agent.NewAgentWithOptions(s.agentName, agent.AgentOptions{Model: s.model, Effort: s.effort})
 	if err != nil {
 		return "", fmt.Errorf("failed to create agent: %w", err)
 	}

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSummarizer_EmptyPRNumber(t *testing.T) {
-	s := NewSummarizer("codex", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
 	_, err := s.Summarize(context.Background(), "")
 	if err == nil {
 		t.Error("expected error for empty PR number")
@@ -17,14 +17,14 @@ func TestSummarizer_EmptyPRNumber(t *testing.T) {
 }
 
 func TestNewSummarizer(t *testing.T) {
-	s := NewSummarizer("claude", "", true, terminal.NewLogger())
+	s := NewSummarizer("claude", "", "", true, terminal.NewLogger())
 	if s == nil {
 		t.Fatal("NewSummarizer returned nil")
 	}
 }
 
 func TestBuildInput_DescriptionOnly(t *testing.T) {
-	s := NewSummarizer("codex", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Description: "This PR fixes the login bug",
 	}
@@ -43,7 +43,7 @@ func TestBuildInput_DescriptionOnly(t *testing.T) {
 }
 
 func TestBuildInput_CommentsOnly(t *testing.T) {
-	s := NewSummarizer("codex", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Comments: []Comment{
 			{Author: "alice", Body: "LGTM"},
@@ -68,7 +68,7 @@ func TestBuildInput_CommentsOnly(t *testing.T) {
 }
 
 func TestBuildInput_WithReplies(t *testing.T) {
-	s := NewSummarizer("codex", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Description: "Fix issue",
 		Comments: []Comment{
@@ -97,7 +97,7 @@ func TestBuildInput_WithReplies(t *testing.T) {
 }
 
 func TestBuildInput_EmptyContext(t *testing.T) {
-	s := NewSummarizer("codex", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{}
 
 	result := s.buildInput(prCtx)
@@ -114,7 +114,7 @@ func TestBuildInput_EmptyContext(t *testing.T) {
 }
 
 func TestBuildInput_FullContext(t *testing.T) {
-	s := NewSummarizer("codex", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Number:      "42",
 		Description: "Refactor auth module to use JWT tokens",

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -37,6 +37,7 @@ type Result struct {
 type Filter struct {
 	agentName string
 	model     string
+	effort    string
 	threshold int
 	verbose   bool
 	logger    *terminal.Logger
@@ -44,14 +45,16 @@ type Filter struct {
 
 // New creates a new false positive filter.
 // The model parameter overrides the agent's default model (empty = default).
+// The effort parameter overrides the agent's default reasoning effort (empty = default).
 // If verbose is true, non-fatal errors (like Close failures) are logged.
-func New(agentName, model string, threshold int, verbose bool, logger *terminal.Logger) *Filter {
+func New(agentName, model, effort string, threshold int, verbose bool, logger *terminal.Logger) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
 	return &Filter{
 		agentName: agentName,
 		model:     model,
+		effort:    effort,
 		threshold: threshold,
 		logger:    logger,
 		verbose:   verbose,
@@ -123,7 +126,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		}
 	}
 
-	ag, err := agent.NewAgentWithModel(f.agentName, f.model)
+	ag, err := agent.NewAgentWithOptions(f.agentName, agent.AgentOptions{Model: f.model, Effort: f.effort})
 	if err != nil {
 		return skippedResult(grouped, start, "agent creation failed: "+err.Error())
 	}

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFilter_New(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, terminal.NewLogger())
 	if f == nil {
 		t.Fatal("New returned nil")
 	}
@@ -185,7 +185,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := New("codex", "", tt.threshold, false, logger)
+			f := New("codex", "", "", tt.threshold, false, logger)
 			if f.threshold != tt.expectedThreshold {
 				t.Errorf("threshold = %d, want %d", f.threshold, tt.expectedThreshold)
 			}
@@ -194,7 +194,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 }
 
 func TestApply_EmptyFindings(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -219,7 +219,7 @@ func TestApply_EmptyFindings(t *testing.T) {
 }
 
 func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -233,7 +233,7 @@ func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
 }
 
 func TestApply_EmptyFindingsPreservesInfo(t *testing.T) {
-	f := New("codex", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 		Info: []domain.FindingGroup{

--- a/internal/modelconfig/resolver.go
+++ b/internal/modelconfig/resolver.go
@@ -1,0 +1,195 @@
+// Package modelconfig resolves model + effort specifications for a given
+// (size, role, agentName) tuple by composing multiple configuration layers.
+package modelconfig
+
+import (
+	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+)
+
+// Role constants for the supported agent roles.
+const (
+	RoleReviewer     = "reviewer"
+	RoleArchReviewer = "arch_reviewer"
+	RoleDiffReviewer = "diff_reviewer"
+	RoleSummarizer   = "summarizer"
+	RoleFPFilter     = "fp_filter"
+	RoleCrossCheck   = "cross_check"
+	RolePRFeedback   = "pr_feedback"
+)
+
+// Spec is the resolved model + effort pair that agent constructors receive.
+// Empty fields mean "agent default".
+type Spec struct {
+	Model  string
+	Effort string
+}
+
+// Resolve composes a Spec for the given (size, role, agentName) tuple,
+// honoring the following precedence (highest first):
+//
+//  1. cliModel / cliEffort: flag-level overrides (empty = not set)
+//  2. cfgModels.Agents[agentName].<role>: agent-specific override
+//  3. cfgModels.Sizes[size].<role>:       size-specific override
+//  4. cfgModels.Defaults.<role>:          global default for the role
+//  5. legacyModel / legacyEffort:         pre-round-5 flat fields
+//     (reviewer_model, summarizer_model, etc)
+//  6. zero Spec:                          agent's built-in default
+//
+// Model and Effort are resolved INDEPENDENTLY: if a higher-priority source
+// sets only Model, Effort continues to cascade through lower priorities. This
+// lets users set effort globally via defaults and override model per agent.
+func Resolve(
+	cfgModels config.ModelsConfig,
+	size, role, agentName string,
+	cliModel, cliEffort string,
+	legacyModel, legacyEffort string,
+) Spec {
+	var model, effort string
+
+	// Walk from highest to lowest priority; each layer fills in what's still empty.
+	candidates := []Spec{
+		{Model: cliModel, Effort: cliEffort},
+		pickSpec(lookupRole(cfgModels.Agents, agentName), role),
+		pickSpec(lookupRole(cfgModels.Sizes, size), role),
+		pickSpec(&cfgModels.Defaults, role),
+		{Model: legacyModel, Effort: legacyEffort},
+	}
+
+	for _, c := range candidates {
+		if model == "" && c.Model != "" {
+			model = c.Model
+		}
+		if effort == "" && c.Effort != "" {
+			effort = c.Effort
+		}
+		if model != "" && effort != "" {
+			break
+		}
+	}
+	return Spec{Model: model, Effort: effort}
+}
+
+// ResolveReviewer is a phase-aware reviewer-role resolver.
+//
+// When phase is "arch" or "diff", the phase-specific role (arch_reviewer /
+// diff_reviewer) is tried first at each cascade layer, and falls back to the
+// generic reviewer role at the SAME cascade layer before descending to the
+// next layer. When phase is "" (flat review), only the generic reviewer role
+// is consulted.
+//
+// Legacy fields (legacyModel / legacyEffort) apply to the generic reviewer
+// fallback only; phase-specific roles have no legacy fallback of their own.
+//
+// Model and Effort are resolved INDEPENDENTLY (same rule as Resolve): if a
+// higher-priority layer supplies only Model, Effort keeps cascading through
+// lower layers. Within a single layer, a phase-specific spec that sets only
+// Model is filled in from the generic reviewer spec at the same layer for
+// the missing field.
+func ResolveReviewer(
+	cfgModels config.ModelsConfig,
+	size, phase, agentName string,
+	cliModel, cliEffort string,
+	legacyModel, legacyEffort string,
+) Spec {
+	var primaryRole string
+	switch strings.ToLower(phase) {
+	case "arch":
+		primaryRole = RoleArchReviewer
+	case "diff":
+		primaryRole = RoleDiffReviewer
+	default:
+		primaryRole = ""
+	}
+
+	// Per-layer helper: try primary role then fallback (generic reviewer),
+	// filling each missing field from the generic reviewer at the same layer
+	// before descending to the next layer.
+	tryLayer := func(rm *config.RoleModels) Spec {
+		if rm == nil {
+			return Spec{}
+		}
+		if primaryRole != "" {
+			s := pickSpec(rm, primaryRole)
+			if s.Model != "" || s.Effort != "" {
+				gen := pickSpec(rm, RoleReviewer)
+				if s.Model == "" {
+					s.Model = gen.Model
+				}
+				if s.Effort == "" {
+					s.Effort = gen.Effort
+				}
+				return s
+			}
+		}
+		return pickSpec(rm, RoleReviewer)
+	}
+
+	var model, effort string
+
+	// Walk layers highest → lowest priority. Each layer fills in what's still
+	// empty. CLI overrides bypass phase logic entirely.
+	candidates := []Spec{
+		{Model: cliModel, Effort: cliEffort},
+		tryLayer(lookupRole(cfgModels.Agents, agentName)),
+		tryLayer(lookupRole(cfgModels.Sizes, size)),
+		tryLayer(&cfgModels.Defaults),
+		// Legacy applies to generic reviewer fallback only.
+		{Model: legacyModel, Effort: legacyEffort},
+	}
+	for _, c := range candidates {
+		if model == "" && c.Model != "" {
+			model = c.Model
+		}
+		if effort == "" && c.Effort != "" {
+			effort = c.Effort
+		}
+		if model != "" && effort != "" {
+			break
+		}
+	}
+	return Spec{Model: model, Effort: effort}
+}
+
+// lookupRole safely returns a pointer to the RoleModels at the given key,
+// or nil if the map or key is empty.
+func lookupRole(m map[string]config.RoleModels, key string) *config.RoleModels {
+	if len(m) == 0 || key == "" {
+		return nil
+	}
+	rm, ok := m[key]
+	if !ok {
+		return nil
+	}
+	return &rm
+}
+
+// pickSpec extracts the ModelSpec for the given role from a RoleModels.
+// Returns zero Spec{} if either input is nil or the role slot is nil.
+func pickSpec(rm *config.RoleModels, role string) Spec {
+	if rm == nil {
+		return Spec{}
+	}
+	var src *config.ModelSpec
+	switch strings.ToLower(role) {
+	case RoleReviewer:
+		src = rm.Reviewer
+	case RoleArchReviewer:
+		src = rm.ArchReviewer
+	case RoleDiffReviewer:
+		src = rm.DiffReviewer
+	case RoleSummarizer:
+		src = rm.Summarizer
+	case RoleFPFilter:
+		src = rm.FPFilter
+	case RoleCrossCheck:
+		src = rm.CrossCheck
+	case RolePRFeedback:
+		src = rm.PRFeedback
+	}
+	if src == nil {
+		return Spec{}
+	}
+	return Spec{Model: src.Model, Effort: src.Effort}
+}

--- a/internal/modelconfig/resolver_test.go
+++ b/internal/modelconfig/resolver_test.go
@@ -1,0 +1,387 @@
+package modelconfig
+
+import (
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/config"
+)
+
+func ms(model, effort string) *config.ModelSpec {
+	return &config.ModelSpec{Model: model, Effort: effort}
+}
+
+func TestResolve(t *testing.T) {
+	type args struct {
+		cfgModels    config.ModelsConfig
+		size         string
+		role         string
+		agentName    string
+		cliModel     string
+		cliEffort    string
+		legacyModel  string
+		legacyEffort string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Spec
+	}{
+		{
+			name: "all layers empty returns zero Spec",
+			args: args{
+				cfgModels: config.ModelsConfig{},
+				role:      RoleReviewer,
+				agentName: "codex",
+			},
+			want: Spec{},
+		},
+		{
+			name: "legacy model only",
+			args: args{
+				cfgModels:   config.ModelsConfig{},
+				role:        RoleReviewer,
+				agentName:   "codex",
+				legacyModel: "old-model",
+			},
+			want: Spec{Model: "old-model"},
+		},
+		{
+			name: "defaults override legacy",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer: ms("new", ""),
+					},
+				},
+				role:        RoleReviewer,
+				agentName:   "codex",
+				legacyModel: "old",
+			},
+			want: Spec{Model: "new"},
+		},
+		{
+			name: "sizes override defaults",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer: ms("x", ""),
+					},
+					Sizes: map[string]config.RoleModels{
+						"large": {Reviewer: ms("large-only", "")},
+					},
+				},
+				size:      "large",
+				role:      RoleReviewer,
+				agentName: "codex",
+			},
+			want: Spec{Model: "large-only"},
+		},
+		{
+			name: "agents override sizes",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Sizes: map[string]config.RoleModels{
+						"large": {Reviewer: ms("large", "")},
+					},
+					Agents: map[string]config.RoleModels{
+						"codex": {Reviewer: ms("codex-only", "")},
+					},
+				},
+				size:      "large",
+				role:      RoleReviewer,
+				agentName: "codex",
+			},
+			want: Spec{Model: "codex-only"},
+		},
+		{
+			name: "cli overrides agents",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Agents: map[string]config.RoleModels{
+						"codex": {Reviewer: ms("x", "")},
+					},
+				},
+				role:      RoleReviewer,
+				agentName: "codex",
+				cliModel:  "flag",
+			},
+			want: Spec{Model: "flag"},
+		},
+		{
+			name: "model and effort cascade independently",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer: ms("", "high"),
+					},
+					Agents: map[string]config.RoleModels{
+						"codex": {Reviewer: ms("m", "")},
+					},
+				},
+				role:      RoleReviewer,
+				agentName: "codex",
+			},
+			want: Spec{Model: "m", Effort: "high"},
+		},
+		{
+			name: "unknown role returns zero Spec",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer: ms("x", "y"),
+					},
+				},
+				role:      "unknown_role",
+				agentName: "codex",
+			},
+			want: Spec{},
+		},
+		{
+			name: "unknown agent skips agents layer",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Agents: map[string]config.RoleModels{
+						"codex": {Reviewer: ms("c", "")},
+					},
+				},
+				role:      RoleReviewer,
+				agentName: "claude",
+			},
+			want: Spec{},
+		},
+		{
+			name: "empty size skips sizes layer",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Sizes: map[string]config.RoleModels{
+						"large": {Reviewer: ms("x", "")},
+					},
+				},
+				size:      "",
+				role:      RoleReviewer,
+				agentName: "codex",
+			},
+			want: Spec{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Resolve(
+				tt.args.cfgModels, tt.args.size, tt.args.role, tt.args.agentName,
+				tt.args.cliModel, tt.args.cliEffort,
+				tt.args.legacyModel, tt.args.legacyEffort,
+			)
+			if got != tt.want {
+				t.Errorf("Resolve() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveReviewer(t *testing.T) {
+	type args struct {
+		cfgModels    config.ModelsConfig
+		size         string
+		phase        string
+		agentName    string
+		cliModel     string
+		cliEffort    string
+		legacyModel  string
+		legacyEffort string
+	}
+	tests := []struct {
+		name string
+		args args
+		want Spec
+	}{
+		{
+			name: "flat review (phase=\"\") uses generic reviewer only, ignores arch_reviewer",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer:     ms("gen", "med"),
+						ArchReviewer: ms("arch-m", "high"),
+					},
+				},
+				phase:     "",
+				agentName: "codex",
+			},
+			want: Spec{Model: "gen", Effort: "med"},
+		},
+		{
+			name: "phase=arch prefers arch_reviewer over generic reviewer",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer:     ms("gen", "med"),
+						ArchReviewer: ms("arch-m", "high"),
+					},
+				},
+				phase:     "arch",
+				agentName: "codex",
+			},
+			want: Spec{Model: "arch-m", Effort: "high"},
+		},
+		{
+			name: "phase=arch falls back to generic reviewer when arch_reviewer unset",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer: ms("gen", "med"),
+					},
+				},
+				phase:     "arch",
+				agentName: "codex",
+			},
+			want: Spec{Model: "gen", Effort: "med"},
+		},
+		{
+			name: "phase=diff prefers diff_reviewer over generic reviewer",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer:     ms("gen", "med"),
+						DiffReviewer: ms("diff-m", "low"),
+					},
+				},
+				phase:     "diff",
+				agentName: "codex",
+			},
+			want: Spec{Model: "diff-m", Effort: "low"},
+		},
+		{
+			name: "arch_reviewer.Model only → effort filled from generic reviewer (same layer)",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer:     ms("gen", "med"),
+						ArchReviewer: ms("arch-m", ""),
+					},
+				},
+				phase:     "arch",
+				agentName: "codex",
+			},
+			want: Spec{Model: "arch-m", Effort: "med"},
+		},
+		{
+			name: "agents.codex.reviewer preempts defaults.arch_reviewer (agents layer: generic fallback wins when arch_reviewer not set there)",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						ArchReviewer: ms("arch-default", "high"),
+					},
+					Agents: map[string]config.RoleModels{
+						"codex": {Reviewer: ms("codex-gen", "med")},
+					},
+				},
+				phase:     "arch",
+				agentName: "codex",
+			},
+			want: Spec{Model: "codex-gen", Effort: "med"},
+		},
+		{
+			name: "agents.codex.arch_reviewer wins over agents.codex.reviewer when phase=arch",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Agents: map[string]config.RoleModels{
+						"codex": {
+							Reviewer:     ms("codex-gen", "med"),
+							ArchReviewer: ms("codex-arch", "high"),
+						},
+					},
+				},
+				phase:     "arch",
+				agentName: "codex",
+			},
+			want: Spec{Model: "codex-arch", Effort: "high"},
+		},
+		{
+			name: "sizes.large.diff_reviewer wins over defaults.reviewer for phase=diff",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer: ms("def-gen", "med"),
+					},
+					Sizes: map[string]config.RoleModels{
+						"large": {DiffReviewer: ms("large-diff", "high")},
+					},
+				},
+				size:      "large",
+				phase:     "diff",
+				agentName: "codex",
+			},
+			want: Spec{Model: "large-diff", Effort: "high"},
+		},
+		{
+			name: "legacy fields fall back for generic reviewer only (no phase match)",
+			args: args{
+				cfgModels:    config.ModelsConfig{},
+				phase:        "arch",
+				agentName:    "codex",
+				legacyModel:  "legacy-m",
+				legacyEffort: "legacy-e",
+			},
+			want: Spec{Model: "legacy-m", Effort: "legacy-e"},
+		},
+		{
+			name: "cli overrides bypass phase logic entirely",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						ArchReviewer: ms("arch-m", "high"),
+					},
+				},
+				phase:     "arch",
+				agentName: "codex",
+				cliModel:  "cli-m",
+				cliEffort: "cli-e",
+			},
+			want: Spec{Model: "cli-m", Effort: "cli-e"},
+		},
+		{
+			name: "per-layer fallback: agents.codex has arch_reviewer (model only), effort from generic reviewer at SAME layer",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer: ms("def-gen", "def-effort"),
+					},
+					Agents: map[string]config.RoleModels{
+						"codex": {
+							Reviewer:     ms("codex-gen", "codex-effort"),
+							ArchReviewer: ms("codex-arch", ""),
+						},
+					},
+				},
+				phase:     "arch",
+				agentName: "codex",
+			},
+			want: Spec{Model: "codex-arch", Effort: "codex-effort"},
+		},
+		{
+			name: "unknown phase treated as flat (generic reviewer only)",
+			args: args{
+				cfgModels: config.ModelsConfig{
+					Defaults: config.RoleModels{
+						Reviewer:     ms("gen", "med"),
+						ArchReviewer: ms("arch-m", "high"),
+					},
+				},
+				phase:     "unknown",
+				agentName: "codex",
+			},
+			want: Spec{Model: "gen", Effort: "med"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveReviewer(
+				tt.args.cfgModels, tt.args.size, tt.args.phase, tt.args.agentName,
+				tt.args.cliModel, tt.args.cliEffort,
+				tt.args.legacyModel, tt.args.legacyEffort,
+			)
+			if got != tt.want {
+				t.Errorf("ResolveReviewer() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runner/phase.go
+++ b/internal/runner/phase.go
@@ -12,6 +12,7 @@ type PhaseConfig struct {
 	ReviewerCount int    // Number of reviewers for this phase
 	AgentName     string // Which agent to use (empty = default from caller)
 	Model         string // Model override (empty = agent default)
+	Effort        string // Reasoning effort override (empty = agent default)
 	Prompt        string // Per-phase guidance override (empty = use global guidance; phase prompt template is selected by Phase)
 }
 
@@ -39,12 +40,21 @@ func BuildReviewerSpecs(phases []PhaseConfig, defaultAgents []agent.Agent, globa
 			var a agent.Agent
 			if pc.AgentName != "" {
 				var err error
-				a, err = agent.NewAgentWithModel(pc.AgentName, pc.Model)
+				a, err = agent.NewAgentWithOptions(pc.AgentName, agent.AgentOptions{Model: pc.Model, Effort: pc.Effort})
 				if err != nil {
 					return nil, fmt.Errorf("phase %q agent %q: %w", pc.Phase, pc.AgentName, err)
 				}
 			} else {
-				a = agent.AgentForReviewer(defaultAgents, reviewerIdx)
+				base := agent.AgentForReviewer(defaultAgents, reviewerIdx)
+				if pc.Effort != "" || pc.Model != "" {
+					var rebindErr error
+					a, rebindErr = agent.NewAgentWithOptions(base.Name(), agent.AgentOptions{Model: pc.Model, Effort: pc.Effort})
+					if rebindErr != nil {
+						return nil, fmt.Errorf("phase %q effort rebind: %w", pc.Phase, rebindErr)
+					}
+				} else {
+					a = base
+				}
 			}
 
 			// Guidance carries user-provided steering context, not the phase prompt template.

--- a/internal/summarizer/crosscheck.go
+++ b/internal/summarizer/crosscheck.go
@@ -36,8 +36,13 @@ const (
 // IsStructuralSkipReason reports whether a cross-check SkipReason represents a
 // structural skip (intentional non-run) rather than a failure. Structural
 // skips preserve LGTM; error skips suppress it.
+//
+// SkipReasonNoAgents is treated as structural because the user explicitly
+// omitted cross-check agents — it is a configuration choice, not a runtime
+// failure. Degraded advisories (all-agents-failed, payload errors) are
+// non-structural and must suppress the LGTM banner.
 func IsStructuralSkipReason(reason string) bool {
-	return reason == "" || reason == SkipReasonSingleGroup
+	return reason == "" || reason == SkipReasonSingleGroup || reason == SkipReasonNoAgents
 }
 
 // truncateByRunes returns s truncated to at most max runes, appending "…" when
@@ -289,13 +294,29 @@ func buildCrossCheckPayload(ccCtx CrossCheckContext) crossCheckPayload {
 	return payload
 }
 
+// CrossCheckOptions bundles model/effort resolution for the cross-check role.
+// Empty fields fall back to the agent's built-in defaults.
+type CrossCheckOptions struct {
+	Model  string
+	Effort string
+}
+
+// CrossCheckAgentSpec bundles a cross-check agent name with its pre-resolved
+// per-agent options. Callers resolve per-agent model/effort BEFORE calling
+// CrossCheck so that agents.<name>.cross_check settings are honored.
+type CrossCheckAgentSpec struct {
+	Name    string
+	Options CrossCheckOptions
+}
+
 // CrossCheck performs cross-group consistency verification.
-// Multiple agents run in parallel; results are merged via union.
-// Never returns error; uses Skipped/SkipReason for degradation.
+// Multiple agents run in parallel with per-agent resolved options; results are
+// merged via union. agentSpecs preserves caller-specified ordering; when empty
+// the result is skipped with SkipReasonNoAgents. Never returns error; uses
+// Skipped/SkipReason for degradation.
 func CrossCheck(
 	ctx context.Context,
-	agentNames []string,
-	model string,
+	agentSpecs []CrossCheckAgentSpec,
 	ccCtx CrossCheckContext,
 	verbose bool,
 	logger *terminal.Logger,
@@ -309,7 +330,7 @@ func CrossCheck(
 			Duration:   time.Since(start),
 		}
 	}
-	if len(agentNames) == 0 {
+	if len(agentSpecs) == 0 {
 		return &CrossCheckResult{
 			Skipped:    true,
 			SkipReason: SkipReasonNoAgents,
@@ -328,17 +349,17 @@ func CrossCheck(
 	}
 
 	var wg sync.WaitGroup
-	agentResults := make([]AgentCrossCheckResult, len(agentNames))
-	for i, name := range agentNames {
+	agentResults := make([]AgentCrossCheckResult, len(agentSpecs))
+	for i, spec := range agentSpecs {
 		wg.Add(1)
-		go func(idx int, agentName string) {
+		go func(idx int, s CrossCheckAgentSpec) {
 			defer wg.Done()
-			agentResults[idx] = runCrossCheckAgent(ctx, agentName, model, payloadBytes, verbose, logger)
-		}(i, name)
+			agentResults[idx] = runCrossCheckAgent(ctx, s.Name, s.Options, payloadBytes, verbose, logger)
+		}(i, spec)
 	}
 	wg.Wait()
 
-	result := mergeAgentResults(agentResults, len(agentNames))
+	result := mergeAgentResults(agentResults, len(agentSpecs))
 	result.AgentResults = agentResults
 	result.Duration = time.Since(start)
 	return result
@@ -392,7 +413,8 @@ func mergeAgentResults(agentResults []AgentCrossCheckResult, totalAgents int) *C
 // an AgentCrossCheckResult capturing its findings or error.
 func runCrossCheckAgent(
 	ctx context.Context,
-	agentName, model string,
+	agentName string,
+	opts CrossCheckOptions,
 	payload []byte,
 	verbose bool,
 	logger *terminal.Logger,
@@ -400,7 +422,7 @@ func runCrossCheckAgent(
 	start := time.Now()
 	result := AgentCrossCheckResult{AgentName: agentName}
 
-	ag, err := agent.NewAgentWithModel(agentName, model)
+	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort})
 	if err != nil {
 		result.Err = fmt.Errorf("agent creation failed: %w", err)
 		result.Duration = time.Since(start)

--- a/internal/summarizer/crosscheck_test.go
+++ b/internal/summarizer/crosscheck_test.go
@@ -12,6 +12,29 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
 
+// TestCrossCheckResult_NilSafety locks the contract that all signal predicates
+// on *CrossCheckResult accept a nil receiver. Round-4 review flagged that only
+// IsDegraded had a visible nil guard; this table-driven test makes the contract
+// explicit across HasBlockingFindings / HasAdvisoryFindings / IsDegraded so
+// regressions are caught at unit-test time rather than production panic.
+func TestCrossCheckResult_NilSafety(t *testing.T) {
+	var r *CrossCheckResult
+
+	cases := []struct {
+		name string
+		got  bool
+	}{
+		{"HasBlockingFindings", r.HasBlockingFindings()},
+		{"HasAdvisoryFindings", r.HasAdvisoryFindings()},
+		{"IsDegraded", r.IsDegraded()},
+	}
+	for _, tc := range cases {
+		if tc.got {
+			t.Errorf("%s on nil receiver = true, want false", tc.name)
+		}
+	}
+}
+
 // TestCrossCheckPayload_UsesAggregatedIDs verifies that when two raw findings
 // with the same text are aggregated into one entry before building the payload,
 // the payload contains exactly one finding with ID 0 — not two entries with IDs
@@ -109,7 +132,7 @@ func TestCrossCheck_SkippedForSingleGroup(t *testing.T) {
 	ccCtx := CrossCheckContext{
 		Groups: []GroupInfo{{GroupKey: "arch"}},
 	}
-	result := CrossCheck(context.Background(), []string{"codex"}, "", ccCtx, false, terminal.NewLogger())
+	result := CrossCheck(context.Background(), []CrossCheckAgentSpec{{Name: "codex"}}, ccCtx, false, terminal.NewLogger())
 	if !result.Skipped {
 		t.Error("expected Skipped=true for single group")
 	}
@@ -122,7 +145,7 @@ func TestCrossCheck_SkippedForNoAgents(t *testing.T) {
 	ccCtx := CrossCheckContext{
 		Groups: []GroupInfo{{GroupKey: "arch"}, {GroupKey: "g01"}},
 	}
-	result := CrossCheck(context.Background(), nil, "", ccCtx, false, terminal.NewLogger())
+	result := CrossCheck(context.Background(), nil, ccCtx, false, terminal.NewLogger())
 	if !result.Skipped {
 		t.Error("expected Skipped=true for no agents")
 	}
@@ -137,7 +160,7 @@ func TestIsStructuralSkipReason(t *testing.T) {
 		{"empty is structural", "", true},
 		{"single group constant is structural", SkipReasonSingleGroup, true},
 		{"single group literal is structural", "single group, cross-check unnecessary", true},
-		{"no agents is NOT structural (error condition)", SkipReasonNoAgents, false},
+		{"no agents is structural (config choice, not runtime failure)", SkipReasonNoAgents, true},
 		{"all agents failed is not structural", "all 3 agents failed: codex: timeout", false},
 		{"payload marshal failed is not structural", "payload marshal failed: x", false},
 	}

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -109,13 +109,20 @@ type inputItem struct {
 	Severity  string `json:"severity,omitempty"`
 }
 
+// SummarizeOptions bundles model/effort resolution for the summarizer role.
+// Empty fields fall back to the agent's built-in defaults.
+type SummarizeOptions struct {
+	Model  string
+	Effort string
+}
+
 // Summarize summarizes the aggregated findings using an LLM.
 // The agentName parameter specifies which agent to use for summarization.
-// The model parameter overrides the agent's default model (empty = default).
+// The opts parameter carries model and effort overrides (empty = agent defaults).
 // If verbose is true, non-fatal errors (like Close failures) are logged.
 // If ccResult is non-nil and contains findings, its cross-group context is
 // injected into the prompt so the summarizer can reason about related items.
-func Summarize(ctx context.Context, agentName, model string, aggregated []domain.AggregatedFinding, ccResult *CrossCheckResult, verbose bool, logger *terminal.Logger) (*Result, error) {
+func Summarize(ctx context.Context, agentName string, opts SummarizeOptions, aggregated []domain.AggregatedFinding, ccResult *CrossCheckResult, verbose bool, logger *terminal.Logger) (*Result, error) {
 	start := time.Now()
 
 	if len(aggregated) == 0 {
@@ -126,7 +133,7 @@ func Summarize(ctx context.Context, agentName, model string, aggregated []domain
 	}
 
 	// Create agent
-	ag, err := agent.NewAgentWithModel(agentName, model)
+	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/summarizer/summarizer_test.go
+++ b/internal/summarizer/summarizer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSummarize_EmptyInput(t *testing.T) {
-	result, err := Summarize(context.Background(), "codex", "", nil, nil, false, terminal.NewLogger())
+	result, err := Summarize(context.Background(), "codex", SummarizeOptions{}, nil, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestSummarize_EmptyInput(t *testing.T) {
 }
 
 func TestSummarize_EmptySlice(t *testing.T) {
-	result, err := Summarize(context.Background(), "codex", "", []domain.AggregatedFinding{}, nil, false, terminal.NewLogger())
+	result, err := Summarize(context.Background(), "codex", SummarizeOptions{}, []domain.AggregatedFinding{}, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestSummarize_ContextCanceled(t *testing.T) {
 		{Text: "Test finding", Reviewers: []int{1}},
 	}
 
-	result, err := Summarize(ctx, "codex", "", findings, nil, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", SummarizeOptions{}, findings, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestSummarize_WithMockCodex(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, nil, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", SummarizeOptions{}, findings, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestSummarize_InvalidJSONOutput(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, nil, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", SummarizeOptions{}, findings, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestSummarize_EmptyOutput(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, nil, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", SummarizeOptions{}, findings, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestSummarize_CodexFailure(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, nil, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", SummarizeOptions{}, findings, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestSummarize_MultipleFindings(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := Summarize(ctx, "codex", "", findings, nil, false, terminal.NewLogger())
+	result, err := Summarize(ctx, "codex", SummarizeOptions{}, findings, nil, false, terminal.NewLogger())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Theme C of the review-gate post-merge work. Unified agent construction API with size-aware model resolution (Round-5 §5e).

### What's included

Single squashed commit containing the full Round-5 §5e migration:

- Introduces `AgentOptions` struct and `NewAgentWithOptions` constructor
- `modelconfig.Resolve` for size-aware model resolution
- Migrates all reviewer / summarizer / cross-check callsites
- New `internal/modelconfig` package

### Stacked PR context

This is **PR 2 of 3**:

- PR 1 (#4): Themes A+B — base \`main\`
- **PR 2 (this)**: Theme C — base \`pr/grouped-diff-autophase\` (#4)
- PR 3: Themes D+E — base \`pr/new-agent-with-options\`

Depends on the types and callsites introduced in #4. Merge #4 first.

### Technical notes

18 iterative fixups from the original development cycle were autosquashed into a single commit, which is the natural final form for this refactor. The \`internal/modelconfig\` package is new and introduced in its final state.

## Test plan

- [ ] CI green
- [ ] \`make check\` passes
- [ ] \`git log --grep='^fixup!' pr/grouped-diff-autophase..HEAD\` returns empty
- [ ] No regression in reviewer model resolution (flat / grouped / cross-check paths)