### PR TITLE
feat: per-phase agent routing, reviewer-count knobs, cross-check hardening, and config updates

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -25,6 +25,18 @@ reviewer_agents:
   - claude
   - gemini
 
+# NEW (Round-9): per-phase agent override for auto-phase grouped diff path.
+# - arch_reviewer_agent: single agent for the arch phase (sees full diff).
+#   If unset, falls back to the first entry of reviewer_agents.
+# - diff_reviewer_agents: list for the grouped diff phase (round-robin per group).
+#   If unset, falls back to reviewer_agents.
+# Use this to route unreliable backends (e.g., capacity-throttled providers)
+# away from grouped diff while keeping them in flat review.
+# arch_reviewer_agent: claude
+# diff_reviewer_agents:
+#   - codex
+#   - claude
+
 # Agent for summarization: codex, claude, gemini
 summarizer_agent: claude
 # Path to file containing review guidance
@@ -39,6 +51,13 @@ summarizer_agent: claude
 # fp_filter:
 #   enabled: true
 #   threshold: 75
+
+# Cross-check configuration (Round-9 contract: model is REQUIRED when enabled,
+# comma-separated count must match agent list, paired positionally).
+cross_check:
+  enabled: true
+  agent: "codex,claude,gemini"
+  model: "gpt-5.4,claude-opus-4-7,gemini-3.1-pro-preview"
 
 # PR feedback summarization
 # pr_feedback:
@@ -109,7 +128,7 @@ models:
   sizes:
     # 規模別の effort 上書き（model は agents 層に任せる）
     small:
-      reviewer:      { effort: low }
+      reviewer:      { effort: medium }
     large:
       arch_reviewer: { effort: high }
       diff_reviewer: { effort: high }

--- a/.acr.yaml
+++ b/.acr.yaml
@@ -10,7 +10,7 @@ reviewers: 5
 # Number of diff groups in auto-phase grouped path (large diff). Default: 4.
 # Each group reviews a subset of changed files. arch reviewer is always 1
 # (sees full diff). Total reviewers in grouped path = 1 + diff_groups.
-# diff_groups: 4
+diff_groups: 4
 
 # Number of diff reviewers in auto-phase medium path. Default: 2.
 # arch reviewer is always 1. Total reviewers in medium path =
@@ -45,9 +45,9 @@ reviewer_agents:
 #   If unset, falls back to reviewer_agents.
 # Use this to route unreliable backends (e.g., capacity-throttled providers)
 # away from grouped diff while keeping them in flat review.
-# arch_reviewer_agent: claude
-# diff_reviewer_agents:
-#   - codex
+arch_reviewer_agent: claude
+diff_reviewer_agents:
+  - codex
 #   - claude
 
 # Agent for summarization: codex, claude, gemini
@@ -155,8 +155,9 @@ models:
       cross_check:   { model: gpt-5.4 }
     claude:
       reviewer:      { model: claude-sonnet-4-6 }
+      arch_reviewer: { model: claude-sonnet-4-6 }
       summarizer:    { model: claude-opus-4-7 }
-      cross_check:   { model: claude-opus-4-7 }
+      cross_check:   { model: claude-opus-4-6 }
     gemini:
       # gemini は effort 未対応。model のみ指定
       reviewer:      { model: gemini-3.1-pro-preview }

--- a/.acr.yaml
+++ b/.acr.yaml
@@ -1,8 +1,21 @@
 # acr configuration file
 # See https://github.com/richhaase/agentic-code-reviewer for documentation.
 
-# Number of parallel reviewers to run (default: 5)
-reviewers: 6
+# Number of parallel reviewers (default: 5)
+# This applies ONLY to flat review path (auto-phase OFF / size=small /
+# explicit --phase). Auto-phase grouped/medium use diff_groups /
+# medium_diff_reviewers below.
+reviewers: 5
+
+# Number of diff groups in auto-phase grouped path (large diff). Default: 4.
+# Each group reviews a subset of changed files. arch reviewer is always 1
+# (sees full diff). Total reviewers in grouped path = 1 + diff_groups.
+# diff_groups: 4
+
+# Number of diff reviewers in auto-phase medium path. Default: 2.
+# arch reviewer is always 1. Total reviewers in medium path =
+# 1 + medium_diff_reviewers.
+# medium_diff_reviewers: 2
 
 # Maximum concurrent reviewers (default: same as reviewers)
 # concurrency: 0
@@ -139,17 +152,12 @@ models:
       reviewer:      { model: gpt-5.4 }
       arch_reviewer: { model: gpt-5.4 }
       diff_reviewer: { model: gpt-5.4 }
-      summarizer:    { model: gpt-5.4 }
       cross_check:   { model: gpt-5.4 }
     claude:
       reviewer:      { model: claude-sonnet-4-6 }
-      arch_reviewer: { model: claude-opus-4-7 }
-      diff_reviewer: { model: claude-sonnet-4-6 }
       summarizer:    { model: claude-opus-4-7 }
       cross_check:   { model: claude-opus-4-7 }
     gemini:
       # gemini は effort 未対応。model のみ指定
       reviewer:      { model: gemini-3.1-pro-preview }
-      arch_reviewer: { model: gemini-3.1-pro-preview }
-      diff_reviewer: { model: gemini-3.1-pro-preview }
       cross_check:   { model: gemini-3.1-pro-preview }

--- a/.acr.yaml
+++ b/.acr.yaml
@@ -155,9 +155,9 @@ models:
       cross_check:   { model: gpt-5.4 }
     claude:
       reviewer:      { model: claude-sonnet-4-6 }
-      arch_reviewer: { model: claude-sonnet-4-6 }
+      arch_reviewer: { model: claude-opus-4-7 }
       summarizer:    { model: claude-opus-4-7 }
-      cross_check:   { model: claude-opus-4-6 }
+      cross_check:   { model: claude-opus-4-7 }
     gemini:
       # gemini は effort 未対応。model のみ指定
       reviewer:      { model: gemini-3.1-pro-preview }

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,3 @@ bin/acr-test
 /.tmp/
 .claude/settings.json
 .claude/scheduled_tasks.lock
-/.tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ bin/acr-test
 /docs/cf_skills
 /.tmp/
 .claude/settings.json
+.claude/scheduled_tasks.lock
+/.tmp/

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -136,6 +136,12 @@ func newConfigInitCmd() *cobra.Command {
 # pr_feedback:
 #   enabled: true
 #   agent: ""
+
+# Cross-check for grouped review consistency (model is REQUIRED when enabled)
+# cross_check:
+#   enabled: true
+#   agent: codex
+#   model: gpt-5
 `
 			if err := os.WriteFile(configPath, []byte(starter), 0644); err != nil {
 				return fmt.Errorf("failed to write %s: %w", configPath, err)

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -160,14 +160,34 @@ func newConfigValidateCmd() *cobra.Command {
 			var errors []string
 			var warnings []string
 
-			// Load and validate config file (don't early-return so env var issues are also reported)
+			// Load and validate config file (don't early-return so env var issues are also reported).
+			//
+			// LoadWithWarnings returns two distinct error shapes:
+			//   (1) syntax / regex / IO error → (nil, err). cfg is unusable; we fall
+			//       back to Defaults for the rest of validation and skip
+			//       ValidateRuntime (running it against synthetic defaults would
+			//       false-positive on cross_check.model when the user's actual
+			//       intent is hidden behind the broken YAML).
+			//   (2) semantic error (cfg.Validate failure) → (result, err) where
+			//       result.Config has the user's parseable cfg. We DO want to run
+			//       ValidateRuntime against cfg+env here so env-only cross_check
+			//       issues are not masked by the semantic-error branch (Round-13 F#2).
+			//
+			// Round-12 had a single `configFileError` flag that conflated both
+			// shapes, which made `config validate` silently skip runtime checks in
+			// case (2). Round-13 splits the two and keeps ValidateAll's behavior
+			// (use empty resolveConfig in case 2 to avoid duplicating cfg's
+			// semantic errors that already appear in the lump "config file: ..."
+			// line) while restoring ValidateRuntime for case (2).
 			cfg := &config.Config{}
 			configDir := ""
-			configFileError := false
+			syntaxError := false
 			result, err := config.LoadWithWarnings()
 			if err != nil {
 				errors = append(errors, fmt.Sprintf("config file: %v", err))
-				configFileError = true
+				if result == nil {
+					syntaxError = true
+				}
 			}
 			if result != nil {
 				cfg = result.Config
@@ -181,22 +201,35 @@ func newConfigValidateCmd() *cobra.Command {
 			envState, envWarnings := config.LoadEnvState()
 			errors = append(errors, envWarnings...)
 
-			// Resolve full config and validate semantically.
-			// When the config file has errors, resolve env vars against defaults only
-			// (skip the broken config) to avoid duplicating config-file errors while
-			// still catching env-var semantic issues like ACR_REVIEWERS=0.
+			// ValidateAll path: when the config file has semantic errors we use an
+			// empty config so the individual semantic errors (already surfaced in
+			// the lump "config file: ..." line above) are not re-enumerated here.
+			// Syntax-error case behaves identically: empty config, env still
+			// validated against Defaults.
 			resolveConfig := cfg
-			if configFileError {
+			if syntaxError || (err != nil && result != nil) {
 				resolveConfig = &config.Config{}
 			}
 			resolved := config.Resolve(resolveConfig, envState, config.FlagState{}, config.Defaults)
 			validationErrs := resolved.ValidateAll()
 			errors = append(errors, validationErrs...)
-			// Round-9: enforce runtime-only contracts (cross-check model
-			// requirement when enabled) so `config validate` mirrors what
-			// the actual review run will reject.
-			runtimeErrs := resolved.ValidateRuntime()
-			errors = append(errors, runtimeErrs...)
+			// Round-13 F#2: run ValidateRuntime against cfg+env whenever cfg is at
+			// least parseable (result != nil), so env-only cross_check issues are
+			// caught even when the YAML has unrelated semantic errors. Skip only
+			// on true syntax error where we have no usable cfg — ValidateRuntime
+			// against Defaults would false-positive (e.g. cross_check.enabled=true
+			// default + cross_check.model="" default).
+			if !syntaxError {
+				runtimeResolved := resolved
+				if err != nil && result != nil {
+					// Semantic-error case: ValidateAll ran against empty cfg to
+					// avoid duplication, but ValidateRuntime needs the real cfg
+					// to honour user intent for cross_check config.
+					runtimeResolved = config.Resolve(cfg, envState, config.FlagState{}, config.Defaults)
+				}
+				runtimeErrs := runtimeResolved.ValidateRuntime()
+				errors = append(errors, runtimeErrs...)
+			}
 
 			// Validate guidance file is readable (uses same resolution logic as runtime)
 			_, guidanceErr := config.ResolveGuidance(cfg, envState, config.FlagState{}, config.Defaults, configDir)

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -230,7 +230,7 @@ func newConfigValidateCmd() *cobra.Command {
 				if err != nil && result != nil {
 					// Semantic-error case: ValidateAll ran against empty cfg to
 					// avoid duplication, but ValidateRuntime needs the real cfg
-					// to honour user intent for cross_check config.
+					// to honor user intent for cross_check config.
 					runtimeResolved = config.Resolve(cfg, envState, config.FlagState{}, config.Defaults)
 				}
 				runtimeErrs := runtimeResolved.ValidateRuntime()

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -192,6 +192,11 @@ func newConfigValidateCmd() *cobra.Command {
 			resolved := config.Resolve(resolveConfig, envState, config.FlagState{}, config.Defaults)
 			validationErrs := resolved.ValidateAll()
 			errors = append(errors, validationErrs...)
+			// Round-9: enforce runtime-only contracts (cross-check model
+			// requirement when enabled) so `config validate` mirrors what
+			// the actual review run will reject.
+			runtimeErrs := resolved.ValidateRuntime()
+			errors = append(errors, runtimeErrs...)
 
 			// Validate guidance file is readable (uses same resolution logic as runtime)
 			_, guidanceErr := config.ResolveGuidance(cfg, envState, config.FlagState{}, config.Defaults, configDir)

--- a/cmd/acr/config_cmd_test.go
+++ b/cmd/acr/config_cmd_test.go
@@ -90,6 +90,11 @@ func TestConfigValidate_ValidConfig(t *testing.T) {
 	chdir(t, dir)
 	initGitRepo(t, dir)
 
+	// Round-9: cross_check defaults to enabled and now requires a model.
+	// Supply via env so this test exercises the "valid" path it claims to
+	// test, not the cross-check guard.
+	t.Setenv("ACR_CROSS_CHECK_MODEL", "test-cc-model")
+
 	cmd := newConfigCmd()
 	buf := new(bytes.Buffer)
 	cmd.SetOut(buf)
@@ -213,6 +218,8 @@ func TestConfigValidate_ValidGuidanceFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("ACR_GUIDANCE_FILE", guidancePath)
+	// Round-9: cross-check guard requires a model when enabled (default on).
+	t.Setenv("ACR_CROSS_CHECK_MODEL", "test-cc-model")
 
 	cmd := newConfigCmd()
 	buf := new(bytes.Buffer)

--- a/cmd/acr/config_cmd_test.go
+++ b/cmd/acr/config_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -230,5 +231,89 @@ func TestConfigValidate_ValidGuidanceFile(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("expected valid guidance file to pass, got: %v", err)
+	}
+}
+
+// TestConfigValidate_SemanticErrorDoesNotMaskRuntimeError verifies that when
+// .acr.yaml has semantic errors (e.g. reviewers: 0), ValidateRuntime still
+// runs so env-driven cross_check runtime issues are reported.
+//
+// Round-12 conflated "cfg syntax error" and "cfg semantic error" under a single
+// configFileError flag that skipped ValidateRuntime in BOTH cases, masking
+// cross_check issues whenever a user had any unrelated cfg semantic error.
+// Round-13 F#2 split the two: ValidateRuntime is skipped only on true syntax /
+// regex / IO errors where cfg is unparseable.
+func TestConfigValidate_SemanticErrorDoesNotMaskRuntimeError(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	initGitRepo(t, dir)
+
+	// Semantic error in cfg: reviewers must be >= 1.
+	configPath := filepath.Join(dir, config.ConfigFileName)
+	if err := os.WriteFile(configPath, []byte("reviewers: 0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Leave ACR_CROSS_CHECK_MODEL unset so ValidateRuntime fires the
+	// cross_check.model-required error on top of the cfg semantic error.
+
+	cmd := newConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"validate"})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error when config has semantic issues AND cross_check.model is missing")
+	}
+	// Before F#2 fix: count == 1 (only the lump "config file: ..." line;
+	// ValidateRuntime was skipped entirely).
+	// After fix: count >= 2 (lump + cross_check runtime error).
+	var n int
+	if _, scanErr := fmt.Sscanf(err.Error(), "configuration has %d error(s)", &n); scanErr != nil {
+		t.Fatalf("could not parse error count from %q: %v", err.Error(), scanErr)
+	}
+	if n < 2 {
+		t.Errorf("expected at least 2 errors (semantic cfg + cross_check runtime), got %d: %q", n, err.Error())
+	}
+}
+
+// TestConfigValidate_SyntaxErrorSkipsRuntime verifies the complementary case:
+// when .acr.yaml fails to parse (syntax / regex / IO error), ValidateRuntime
+// is still skipped because cfg is unusable and running ValidateRuntime against
+// Defaults would false-positive on cross_check.model (Defaults leaves it
+// empty while cross_check.enabled=true). The user's intent is hidden behind
+// the broken YAML.
+func TestConfigValidate_SyntaxErrorSkipsCrossCheckRuntimeFalsePositive(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	initGitRepo(t, dir)
+
+	// Syntax error: malformed YAML.
+	configPath := filepath.Join(dir, config.ConfigFileName)
+	if err := os.WriteFile(configPath, []byte("reviewers: [not a number\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{"validate"})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error on YAML syntax error")
+	}
+	var n int
+	if _, scanErr := fmt.Sscanf(err.Error(), "configuration has %d error(s)", &n); scanErr != nil {
+		t.Fatalf("could not parse error count from %q: %v", err.Error(), scanErr)
+	}
+	// Syntax-error path should yield exactly 1 error (the config-file lump).
+	// If ValidateRuntime were incorrectly running, it would synthesize a
+	// cross_check false-positive and bump the count to 2.
+	if n != 1 {
+		t.Errorf("expected exactly 1 error (config file syntax only) on syntax error, got %d: %q", n, err.Error())
 	}
 }

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -515,12 +515,16 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		return configResult{}, exitCode(domain.ExitError)
 	}
 
-	// Default concurrency to reviewers if not specified (0 means same as reviewers)
+	// Default concurrency to the maximum number of reviewers that may run
+	// across all auto-phase paths (flat / medium / grouped). When the user
+	// explicitly sets --concurrency, honour it but cap at the same maximum
+	// to avoid spawning more goroutines than there are reviewers.
+	maxReviewers := maxPotentialReviewers(resolved)
 	if resolved.Concurrency <= 0 {
-		resolved.Concurrency = resolved.Reviewers
+		resolved.Concurrency = maxReviewers
 	}
-	if resolved.Concurrency > resolved.Reviewers {
-		resolved.Concurrency = resolved.Reviewers
+	if resolved.Concurrency > maxReviewers {
+		resolved.Concurrency = maxReviewers
 	}
 
 	// Merge exclude patterns (config patterns + CLI patterns)
@@ -538,6 +542,20 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		resolved:        resolved,
 		excludePatterns: allExcludePatterns,
 	}, nil
+}
+
+// maxPotentialReviewers returns the maximum number of concurrent reviewers
+// that may run across all auto-phase paths (flat, medium, grouped).
+// Used to default/clamp Concurrency so no phase is bottlenecked.
+func maxPotentialReviewers(r config.ResolvedConfig) int {
+	m := r.Reviewers
+	if v := 1 + r.DiffGroups; v > m {
+		m = v
+	}
+	if v := 1 + r.MediumDiffReviewers; v > m {
+		m = v
+	}
+	return m
 }
 
 func runReview(cmd *cobra.Command, _ []string) error {

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -525,7 +525,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 
 	// Default concurrency to the maximum number of reviewers that may run
 	// across all auto-phase paths (flat / medium / grouped). When the user
-	// explicitly sets --concurrency, honour it but cap at the same maximum
+	// explicitly sets --concurrency, honor it but cap at the same maximum
 	// to avoid spawning more goroutines than there are reviewers.
 	maxReviewers := maxPotentialReviewers(resolved)
 	if resolved.Concurrency <= 0 {

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,27 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/github"
 	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
+
+// parseDiffReviewerAgentsFlag splits a comma-separated agent string into
+// trimmed names. Returns nil for an empty input so callers can distinguish
+// "flag set" from "flag set to empty" (the latter falls back to ReviewerAgents
+// in config.Resolve).
+func parseDiffReviewerAgentsFlag(input string) []string {
+	if strings.TrimSpace(input) == "" {
+		return nil
+	}
+	parts := strings.Split(input, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if name := strings.TrimSpace(p); name != "" {
+			out = append(out, name)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
 
 var (
 	reviewers           int
@@ -37,6 +59,8 @@ var (
 	excludePatterns     []string
 	noConfig            bool
 	agentName           string
+	archReviewerAgent   string
+	diffReviewerAgents  string
 	summarizerAgentName string
 	reviewerModel       string
 	summarizerModel     string
@@ -119,6 +143,10 @@ Exit codes:
 		"Skip loading .acr.yaml config file")
 	rootCmd.Flags().StringVarP(&agentName, "reviewer-agent", "a", "codex",
 		"Agent(s) for reviews (comma-separated): codex, claude, gemini (env: ACR_REVIEWER_AGENT)")
+	rootCmd.Flags().StringVar(&archReviewerAgent, "arch-reviewer-agent", "",
+		"Single agent for arch phase in auto-phase grouped diff (default: same as first --reviewer-agent, env: ACR_ARCH_REVIEWER_AGENT)")
+	rootCmd.Flags().StringVar(&diffReviewerAgents, "diff-reviewer-agents", "",
+		"Agent(s) for diff phase in auto-phase grouped diff, comma-separated (default: same as --reviewer-agent, env: ACR_DIFF_REVIEWER_AGENTS)")
 	rootCmd.Flags().StringVarP(&summarizerAgentName, "summarizer-agent", "s", "codex",
 		"Agent to use for summarization: codex, claude, gemini (env: ACR_SUMMARIZER_AGENT)")
 	rootCmd.Flags().StringVar(&reviewerModel, "reviewer-model", "",
@@ -369,30 +397,32 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	fetchFlagSet := cmd.Flags().Changed("fetch") || cmd.Flags().Changed("no-fetch")
 	autoPhaseAnySet := cmd.Flags().Changed("auto-phase") || cmd.Flags().Changed("no-auto-phase")
 	flagState := config.FlagState{
-		ReviewersSet:         cmd.Flags().Changed("reviewers"),
-		ConcurrencySet:       cmd.Flags().Changed("concurrency"),
-		BaseSet:              cmd.Flags().Changed("base") || wt.baseAutoDetected,
-		TimeoutSet:           cmd.Flags().Changed("timeout"),
-		RetriesSet:           cmd.Flags().Changed("retries"),
-		FetchSet:             fetchFlagSet,
-		ReviewerAgentsSet:    cmd.Flags().Changed("reviewer-agent"),
-		SummarizerAgentSet:   cmd.Flags().Changed("summarizer-agent"),
-		ReviewerModelSet:     cmd.Flags().Changed("reviewer-model"),
-		SummarizerModelSet:   cmd.Flags().Changed("summarizer-model"),
-		SummarizerTimeoutSet: cmd.Flags().Changed("summarizer-timeout"),
-		FPFilterTimeoutSet:   cmd.Flags().Changed("fp-filter-timeout"),
-		GuidanceSet:          cmd.Flags().Changed("guidance"),
-		GuidanceFileSet:      cmd.Flags().Changed("guidance-file"),
-		NoFPFilterSet:        cmd.Flags().Changed("no-fp-filter"),
-		FPThresholdSet:       cmd.Flags().Changed("fp-threshold"),
-		NoPRFeedbackSet:      cmd.Flags().Changed("no-pr-feedback"),
-		PRFeedbackAgentSet:   cmd.Flags().Changed("pr-feedback-agent"),
-		NoCrossCheckSet:      cmd.Flags().Changed("no-cross-check"),
-		CrossCheckAgentSet:   cmd.Flags().Changed("cross-check-agent"),
-		CrossCheckModelSet:   cmd.Flags().Changed("cross-check-model"),
-		CrossCheckTimeoutSet: cmd.Flags().Changed("cross-check-timeout"),
-		AutoPhaseSet:         autoPhaseAnySet,
-		StrictSet:            cmd.Flags().Changed("strict"),
+		ReviewersSet:          cmd.Flags().Changed("reviewers"),
+		ConcurrencySet:        cmd.Flags().Changed("concurrency"),
+		BaseSet:               cmd.Flags().Changed("base") || wt.baseAutoDetected,
+		TimeoutSet:            cmd.Flags().Changed("timeout"),
+		RetriesSet:            cmd.Flags().Changed("retries"),
+		FetchSet:              fetchFlagSet,
+		ReviewerAgentsSet:     cmd.Flags().Changed("reviewer-agent"),
+		ArchReviewerAgentSet:  cmd.Flags().Changed("arch-reviewer-agent"),
+		DiffReviewerAgentsSet: cmd.Flags().Changed("diff-reviewer-agents"),
+		SummarizerAgentSet:    cmd.Flags().Changed("summarizer-agent"),
+		ReviewerModelSet:      cmd.Flags().Changed("reviewer-model"),
+		SummarizerModelSet:    cmd.Flags().Changed("summarizer-model"),
+		SummarizerTimeoutSet:  cmd.Flags().Changed("summarizer-timeout"),
+		FPFilterTimeoutSet:    cmd.Flags().Changed("fp-filter-timeout"),
+		GuidanceSet:           cmd.Flags().Changed("guidance"),
+		GuidanceFileSet:       cmd.Flags().Changed("guidance-file"),
+		NoFPFilterSet:         cmd.Flags().Changed("no-fp-filter"),
+		FPThresholdSet:        cmd.Flags().Changed("fp-threshold"),
+		NoPRFeedbackSet:       cmd.Flags().Changed("no-pr-feedback"),
+		PRFeedbackAgentSet:    cmd.Flags().Changed("pr-feedback-agent"),
+		NoCrossCheckSet:       cmd.Flags().Changed("no-cross-check"),
+		CrossCheckAgentSet:    cmd.Flags().Changed("cross-check-agent"),
+		CrossCheckModelSet:    cmd.Flags().Changed("cross-check-model"),
+		CrossCheckTimeoutSet:  cmd.Flags().Changed("cross-check-timeout"),
+		AutoPhaseSet:          autoPhaseAnySet,
+		StrictSet:             cmd.Flags().Changed("strict"),
 	}
 
 	// Load env var state
@@ -414,30 +444,32 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 
 	autoPhaseValue := autoPhase && !noAutoPhase
 	flagValues := config.ResolvedConfig{
-		Reviewers:         reviewers,
-		Concurrency:       concurrency,
-		Base:              resolvedBaseRef,
-		Timeout:           timeout,
-		Retries:           retries,
-		Fetch:             fetchValue,
-		ReviewerAgents:    agent.ParseAgentNames(agentName),
-		SummarizerAgent:   summarizerAgentName,
-		ReviewerModel:     reviewerModel,
-		SummarizerModel:   summarizerModel,
-		SummarizerTimeout: summarizerTimeout,
-		FPFilterTimeout:   fpFilterTimeout,
-		Guidance:          guidance,
-		GuidanceFile:      guidanceFile,
-		FPFilterEnabled:   !noFPFilter,
-		FPThreshold:       fpThreshold,
-		PRFeedbackEnabled: !noPRFeedback,
-		PRFeedbackAgent:   prFeedbackAgent,
-		CrossCheckEnabled: !noCrossCheck,
-		CrossCheckAgent:   crossCheckAgent,
-		CrossCheckModel:   crossCheckModel,
-		CrossCheckTimeout: crossCheckTimeout,
-		AutoPhase:         autoPhaseValue,
-		Strict:            strict,
+		Reviewers:          reviewers,
+		Concurrency:        concurrency,
+		Base:               resolvedBaseRef,
+		Timeout:            timeout,
+		Retries:            retries,
+		Fetch:              fetchValue,
+		ReviewerAgents:     agent.ParseAgentNames(agentName),
+		ArchReviewerAgent:  strings.TrimSpace(archReviewerAgent),
+		DiffReviewerAgents: parseDiffReviewerAgentsFlag(diffReviewerAgents),
+		SummarizerAgent:    summarizerAgentName,
+		ReviewerModel:      reviewerModel,
+		SummarizerModel:    summarizerModel,
+		SummarizerTimeout:  summarizerTimeout,
+		FPFilterTimeout:    fpFilterTimeout,
+		Guidance:           guidance,
+		GuidanceFile:       guidanceFile,
+		FPFilterEnabled:    !noFPFilter,
+		FPThreshold:        fpThreshold,
+		PRFeedbackEnabled:  !noPRFeedback,
+		PRFeedbackAgent:    prFeedbackAgent,
+		CrossCheckEnabled:  !noCrossCheck,
+		CrossCheckAgent:    crossCheckAgent,
+		CrossCheckModel:    crossCheckModel,
+		CrossCheckTimeout:  crossCheckTimeout,
+		AutoPhase:          autoPhaseValue,
+		Strict:             strict,
 	}
 
 	// Resolve final configuration (precedence: flags > env vars > config file > defaults)
@@ -457,9 +489,19 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		}
 	}
 
-	// Validate resolved config
+	// Validate resolved config (semantic checks shared with config validate).
 	if err := resolved.Validate(); err != nil {
 		logger.Logf(terminal.StyleError, "%v", err)
+		return configResult{}, exitCode(domain.ExitError)
+	}
+	// Round-9: enforce runtime-only contracts that need the merged view of
+	// flags+env+yaml (e.g., cross_check.enabled=true requires cross_check.model
+	// somewhere). Done as a separate pass so YAML-only Validate() does not
+	// false-positive on configs that defer the model to env/CLI.
+	if runtimeErrs := resolved.ValidateRuntime(); len(runtimeErrs) > 0 {
+		for _, e := range runtimeErrs {
+			logger.Logf(terminal.StyleError, "%s", e)
+		}
 		return configResult{}, exitCode(domain.ExitError)
 	}
 

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -508,11 +508,19 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	// flags+env+yaml (e.g., cross_check.enabled=true requires cross_check.model
 	// somewhere). Done as a separate pass so YAML-only Validate() does not
 	// false-positive on configs that defer the model to env/CLI.
-	if runtimeErrs := resolved.ValidateRuntime(); len(runtimeErrs) > 0 {
-		for _, e := range runtimeErrs {
-			logger.Logf(terminal.StyleError, "%s", e)
+	//
+	// Cross-check runs exclusively on the auto-phase grouped (large) path.
+	// When auto-phase is disabled or an explicit --phase overrides it,
+	// cross-check can never execute, so skip validation to avoid rejecting
+	// valid flat/arch,diff workflows that omit cross_check.model.
+	phaseFlag, _ := cmd.Flags().GetString("phase")
+	if resolved.AutoPhase && phaseFlag == "" {
+		if runtimeErrs := resolved.ValidateRuntime(); len(runtimeErrs) > 0 {
+			for _, e := range runtimeErrs {
+				logger.Logf(terminal.StyleError, "%s", e)
+			}
+			return configResult{}, exitCode(domain.ExitError)
 		}
-		return configResult{}, exitCode(domain.ExitError)
 	}
 
 	// Default concurrency to the maximum number of reviewers that may run

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -43,6 +43,8 @@ func parseDiffReviewerAgentsFlag(input string) []string {
 
 var (
 	reviewers           int
+	diffGroups          int
+	mediumDiffReviewers int
 	concurrency         int
 	baseRef             string
 	timeout             time.Duration
@@ -107,7 +109,11 @@ Exit codes:
 
 	// Configuration flags (defaults are resolved via config.Resolve with precedence: flag > env > config > default)
 	rootCmd.Flags().IntVarP(&reviewers, "reviewers", "r", 0,
-		"Number of parallel reviewers (default: 5, env: ACR_REVIEWERS). Auto-phase bumps to minimum (medium:2, large:3) and clamps large to changed_files+1.")
+		"Number of parallel reviewers for flat review path (auto-phase OFF / size=small / explicit --phase). Auto-phase grouped/medium use --diff-groups / --medium-diff-reviewers instead. (default: 5, env: ACR_REVIEWERS)")
+	rootCmd.Flags().IntVar(&diffGroups, "diff-groups", 0,
+		"Number of diff groups in auto-phase grouped path (large diff) (default: 4, env: ACR_DIFF_GROUPS)")
+	rootCmd.Flags().IntVar(&mediumDiffReviewers, "medium-diff-reviewers", 0,
+		"Number of diff reviewers in auto-phase medium path (default: 2, env: ACR_MEDIUM_DIFF_REVIEWERS)")
 	rootCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0,
 		"Max concurrent reviewers (default: same as --reviewers, env: ACR_CONCURRENCY)")
 	rootCmd.Flags().StringVarP(&baseRef, "base", "b", "",
@@ -397,32 +403,34 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	fetchFlagSet := cmd.Flags().Changed("fetch") || cmd.Flags().Changed("no-fetch")
 	autoPhaseAnySet := cmd.Flags().Changed("auto-phase") || cmd.Flags().Changed("no-auto-phase")
 	flagState := config.FlagState{
-		ReviewersSet:          cmd.Flags().Changed("reviewers"),
-		ConcurrencySet:        cmd.Flags().Changed("concurrency"),
-		BaseSet:               cmd.Flags().Changed("base") || wt.baseAutoDetected,
-		TimeoutSet:            cmd.Flags().Changed("timeout"),
-		RetriesSet:            cmd.Flags().Changed("retries"),
-		FetchSet:              fetchFlagSet,
-		ReviewerAgentsSet:     cmd.Flags().Changed("reviewer-agent"),
-		ArchReviewerAgentSet:  cmd.Flags().Changed("arch-reviewer-agent"),
-		DiffReviewerAgentsSet: cmd.Flags().Changed("diff-reviewer-agents"),
-		SummarizerAgentSet:    cmd.Flags().Changed("summarizer-agent"),
-		ReviewerModelSet:      cmd.Flags().Changed("reviewer-model"),
-		SummarizerModelSet:    cmd.Flags().Changed("summarizer-model"),
-		SummarizerTimeoutSet:  cmd.Flags().Changed("summarizer-timeout"),
-		FPFilterTimeoutSet:    cmd.Flags().Changed("fp-filter-timeout"),
-		GuidanceSet:           cmd.Flags().Changed("guidance"),
-		GuidanceFileSet:       cmd.Flags().Changed("guidance-file"),
-		NoFPFilterSet:         cmd.Flags().Changed("no-fp-filter"),
-		FPThresholdSet:        cmd.Flags().Changed("fp-threshold"),
-		NoPRFeedbackSet:       cmd.Flags().Changed("no-pr-feedback"),
-		PRFeedbackAgentSet:    cmd.Flags().Changed("pr-feedback-agent"),
-		NoCrossCheckSet:       cmd.Flags().Changed("no-cross-check"),
-		CrossCheckAgentSet:    cmd.Flags().Changed("cross-check-agent"),
-		CrossCheckModelSet:    cmd.Flags().Changed("cross-check-model"),
-		CrossCheckTimeoutSet:  cmd.Flags().Changed("cross-check-timeout"),
-		AutoPhaseSet:          autoPhaseAnySet,
-		StrictSet:             cmd.Flags().Changed("strict"),
+		ReviewersSet:           cmd.Flags().Changed("reviewers"),
+		DiffGroupsSet:          cmd.Flags().Changed("diff-groups"),
+		MediumDiffReviewersSet: cmd.Flags().Changed("medium-diff-reviewers"),
+		ConcurrencySet:         cmd.Flags().Changed("concurrency"),
+		BaseSet:                cmd.Flags().Changed("base") || wt.baseAutoDetected,
+		TimeoutSet:             cmd.Flags().Changed("timeout"),
+		RetriesSet:             cmd.Flags().Changed("retries"),
+		FetchSet:               fetchFlagSet,
+		ReviewerAgentsSet:      cmd.Flags().Changed("reviewer-agent"),
+		ArchReviewerAgentSet:   cmd.Flags().Changed("arch-reviewer-agent"),
+		DiffReviewerAgentsSet:  cmd.Flags().Changed("diff-reviewer-agents"),
+		SummarizerAgentSet:     cmd.Flags().Changed("summarizer-agent"),
+		ReviewerModelSet:       cmd.Flags().Changed("reviewer-model"),
+		SummarizerModelSet:     cmd.Flags().Changed("summarizer-model"),
+		SummarizerTimeoutSet:   cmd.Flags().Changed("summarizer-timeout"),
+		FPFilterTimeoutSet:     cmd.Flags().Changed("fp-filter-timeout"),
+		GuidanceSet:            cmd.Flags().Changed("guidance"),
+		GuidanceFileSet:        cmd.Flags().Changed("guidance-file"),
+		NoFPFilterSet:          cmd.Flags().Changed("no-fp-filter"),
+		FPThresholdSet:         cmd.Flags().Changed("fp-threshold"),
+		NoPRFeedbackSet:        cmd.Flags().Changed("no-pr-feedback"),
+		PRFeedbackAgentSet:     cmd.Flags().Changed("pr-feedback-agent"),
+		NoCrossCheckSet:        cmd.Flags().Changed("no-cross-check"),
+		CrossCheckAgentSet:     cmd.Flags().Changed("cross-check-agent"),
+		CrossCheckModelSet:     cmd.Flags().Changed("cross-check-model"),
+		CrossCheckTimeoutSet:   cmd.Flags().Changed("cross-check-timeout"),
+		AutoPhaseSet:           autoPhaseAnySet,
+		StrictSet:              cmd.Flags().Changed("strict"),
 	}
 
 	// Load env var state
@@ -444,32 +452,34 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 
 	autoPhaseValue := autoPhase && !noAutoPhase
 	flagValues := config.ResolvedConfig{
-		Reviewers:          reviewers,
-		Concurrency:        concurrency,
-		Base:               resolvedBaseRef,
-		Timeout:            timeout,
-		Retries:            retries,
-		Fetch:              fetchValue,
-		ReviewerAgents:     agent.ParseAgentNames(agentName),
-		ArchReviewerAgent:  strings.TrimSpace(archReviewerAgent),
-		DiffReviewerAgents: parseDiffReviewerAgentsFlag(diffReviewerAgents),
-		SummarizerAgent:    summarizerAgentName,
-		ReviewerModel:      reviewerModel,
-		SummarizerModel:    summarizerModel,
-		SummarizerTimeout:  summarizerTimeout,
-		FPFilterTimeout:    fpFilterTimeout,
-		Guidance:           guidance,
-		GuidanceFile:       guidanceFile,
-		FPFilterEnabled:    !noFPFilter,
-		FPThreshold:        fpThreshold,
-		PRFeedbackEnabled:  !noPRFeedback,
-		PRFeedbackAgent:    prFeedbackAgent,
-		CrossCheckEnabled:  !noCrossCheck,
-		CrossCheckAgent:    crossCheckAgent,
-		CrossCheckModel:    crossCheckModel,
-		CrossCheckTimeout:  crossCheckTimeout,
-		AutoPhase:          autoPhaseValue,
-		Strict:             strict,
+		Reviewers:           reviewers,
+		DiffGroups:          diffGroups,
+		MediumDiffReviewers: mediumDiffReviewers,
+		Concurrency:         concurrency,
+		Base:                resolvedBaseRef,
+		Timeout:             timeout,
+		Retries:             retries,
+		Fetch:               fetchValue,
+		ReviewerAgents:      agent.ParseAgentNames(agentName),
+		ArchReviewerAgent:   strings.TrimSpace(archReviewerAgent),
+		DiffReviewerAgents:  parseDiffReviewerAgentsFlag(diffReviewerAgents),
+		SummarizerAgent:     summarizerAgentName,
+		ReviewerModel:       reviewerModel,
+		SummarizerModel:     summarizerModel,
+		SummarizerTimeout:   summarizerTimeout,
+		FPFilterTimeout:     fpFilterTimeout,
+		Guidance:            guidance,
+		GuidanceFile:        guidanceFile,
+		FPFilterEnabled:     !noFPFilter,
+		FPThreshold:         fpThreshold,
+		PRFeedbackEnabled:   !noPRFeedback,
+		PRFeedbackAgent:     prFeedbackAgent,
+		CrossCheckEnabled:   !noCrossCheck,
+		CrossCheckAgent:     crossCheckAgent,
+		CrossCheckModel:     crossCheckModel,
+		CrossCheckTimeout:   crossCheckTimeout,
+		AutoPhase:           autoPhaseValue,
+		Strict:              strict,
 	}
 
 	// Resolve final configuration (precedence: flags > env vars > config file > defaults)

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -144,7 +144,7 @@ Exit codes:
 	rootCmd.Flags().StringVar(&crossCheckAgent, "cross-check-agent", "",
 		"Agent(s) for cross-check verification, comma-separated (default: same as --summarizer-agent, env: ACR_CROSS_CHECK_AGENT)")
 	rootCmd.Flags().StringVar(&crossCheckModel, "cross-check-model", "",
-		"LLM model for cross-check agent (default: same as --summarizer-model, env: ACR_CROSS_CHECK_MODEL)")
+		"LLM model(s) for cross-check, comma-separated, count must match --cross-check-agent (REQUIRED when cross-check enabled, env: ACR_CROSS_CHECK_MODEL)")
 	rootCmd.Flags().DurationVar(&crossCheckTimeout, "cross-check-timeout", 0,
 		"Timeout for cross-check phase (default: 5m, env: ACR_CROSS_CHECK_TIMEOUT)")
 	rootCmd.Flags().StringVar(&phase, "phase", "",

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -769,7 +769,7 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 // Round-14 F#1 contract: this function is invoked exclusively from the
 // grouped-path gate in executeReview, where sizeStr is guaranteed to be
 // "large" (useGroupedSpecs=true is exclusive to DiffSizeLarge in
-// resolveAutoPhase). The defence-in-depth log helper logCrossCheckModelMatrix
+// resolveAutoPhase). The defense-in-depth log helper logCrossCheckModelMatrix
 // also calls this with the same sizeStr just before the gate, so the size
 // argument is consistent across both call sites. Non-grouped review paths
 // (small / medium / `--phase` / `--no-auto-phase` / arch,diff fallback) skip
@@ -996,10 +996,10 @@ func resolveAutoPhase(
 }
 
 // buildPhaseAgents constructs the arch-phase agent and diff-phase agent slice
-// used by the auto-phase grouped diff path. It honours per-phase overrides
+// used by the auto-phase grouped diff path. It honors per-phase overrides
 // (opts.ArchReviewerAgent, opts.DiffReviewerAgents) and falls back to
 // opts.ReviewerAgents when an override is unset, preserving pre-Round-9
-// behaviour. Each constructed agent picks its model/effort via
+// behavior. Each constructed agent picks its model/effort via
 // modelconfig.ResolveReviewer with the matching phase ("arch" or "diff") so
 // arch_reviewer / diff_reviewer model layers continue to apply.
 func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Agent, error) {
@@ -1068,7 +1068,7 @@ func logPerPhaseModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr st
 	if archName == "" {
 		if len(opts.ReviewerAgents) == 0 {
 			// No arch name resolvable. buildPhaseAgents would have already aborted
-			// the run with a clear error; logging is defence-in-depth only, so
+			// the run with a clear error; logging is defense-in-depth only, so
 			// emit a diagnostic line and skip the per-phase rows rather than panic.
 			logger.Logf(terminal.StyleWarning, "  arch_reviewer[?]    : (unresolvable: reviewer_agents is empty and arch_reviewer_agent is unset)")
 			return
@@ -1105,7 +1105,7 @@ func logPerPhaseModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr st
 // when useGroupedSpecs=true (Round-14 F#1), so emitting these rows earlier
 // would be misleading on small/medium/fallback paths.
 //
-// Defence-in-depth against panic: if cross-check resolution would fail (every
+// Defense-in-depth against panic: if cross-check resolution would fail (every
 // selected agent uncovered by the models tree AND no top-level model), this
 // function emits a diagnostic line and returns rather than panicking. The
 // authoritative resolve happens in the same gate where this is called from

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -145,21 +145,16 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	}
 
 	// Resolve and validate cross-check agents (fail-fast).
-	ccAgentNames, ccModel := resolveCrossCheckAgents(opts)
-	// ccModel came from opts.CrossCheckModel (or SummarizerModel fallback inside
-	// resolveCrossCheckAgents). CrossCheckModelFromCLI reflects whether the raw
-	// opts.CrossCheckModel was a CLI/env override; when it's empty and we fell
-	// back to SummarizerModel, SummarizerModelFromCLI governs precedence instead.
-	ccFromCLI := opts.CrossCheckModelFromCLI
-	if opts.CrossCheckModel == "" {
-		ccFromCLI = opts.SummarizerModelFromCLI
+	ccAgentNames, ccModels, ccErr := resolveCrossCheckAgents(opts)
+	if ccErr != nil {
+		logger.Logf(terminal.StyleError, "%v", ccErr)
+		return domain.ExitError
 	}
-	// Resolve cross-check options per agent so that agents.<name>.cross_check
-	// overrides are honored when multiple agents are configured. The specs
-	// slice preserves caller order and is passed directly to CrossCheck.
+	// Per-agent model is positionally paired with the agent name.
+	// CrossCheckModel is now required, so no SummarizerModel fallback path remains.
 	ccSpecs := make([]summarizer.CrossCheckAgentSpec, 0, len(ccAgentNames))
-	for _, name := range ccAgentNames {
-		cliCCModel, legacyCCModel := cliOrLegacy(ccModel, ccFromCLI)
+	for i, name := range ccAgentNames {
+		cliCCModel, legacyCCModel := cliOrLegacy(ccModels[i], opts.CrossCheckModelFromCLI)
 		perSpec := modelconfig.Resolve(
 			opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
 			cliCCModel, "",
@@ -236,8 +231,8 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		}
 		logger.Logf(terminal.StyleDim, "  summarizer        : %s", formatSpec(agent.AgentOptions{Model: summSpec.Model, Effort: summSpec.Effort}))
 		if opts.CrossCheckEnabled {
-			for _, name := range ccAgentNames {
-				cliCCModelLog, legacyCCModelLog := cliOrLegacy(ccModel, ccFromCLI)
+			for i, name := range ccAgentNames {
+				cliCCModelLog, legacyCCModelLog := cliOrLegacy(ccModels[i], opts.CrossCheckModelFromCLI)
 				perSpec := modelconfig.Resolve(
 					opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
 					cliCCModelLog, "",
@@ -729,25 +724,43 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 }
 
 // resolveCrossCheckAgents returns the resolved cross-check agent names and
-// model. Empty agent falls back to the summarizer agent; empty model falls
-// back to the summarizer model.
+// per-agent models. CrossCheckModel is REQUIRED when cross-check is enabled
+// and must be a comma-separated list whose count matches CrossCheckAgent
+// (after fallback to SummarizerAgent when CrossCheckAgent is unset). Agents
+// and models are paired positionally: agents[i] uses models[i].
+//
+// Returns (nil, nil, nil) when cross-check is disabled.
 //
 // NOTE: agent.ParseAgentNames("") returns []string{DefaultAgent} ("codex"),
 // so we must check the raw string BEFORE calling ParseAgentNames to detect
 // a truly-unset CrossCheckAgent and fall back to SummarizerAgent. This is
 // belt-and-suspenders even if config.Resolve already copies the value,
 // because the fallback here is the canonical resolution point.
-func resolveCrossCheckAgents(opts ReviewOpts) ([]string, string) {
+func resolveCrossCheckAgents(opts ReviewOpts) ([]string, []string, error) {
+	if !opts.CrossCheckEnabled {
+		return nil, nil, nil
+	}
+	if strings.TrimSpace(opts.CrossCheckModel) == "" {
+		return nil, nil, fmt.Errorf("--cross-check-model is required when cross-check is enabled (env: ACR_CROSS_CHECK_MODEL); supply a comma-separated model list paired 1:1 with --cross-check-agent")
+	}
+	rawModels := strings.Split(opts.CrossCheckModel, ",")
+	models := make([]string, 0, len(rawModels))
+	for _, m := range rawModels {
+		m = strings.TrimSpace(m)
+		if m == "" {
+			return nil, nil, fmt.Errorf("--cross-check-model contains an empty entry; check for leading/trailing/duplicate commas")
+		}
+		models = append(models, m)
+	}
 	agentSpec := opts.CrossCheckAgent
 	if strings.TrimSpace(agentSpec) == "" {
 		agentSpec = opts.SummarizerAgent
 	}
 	names := agent.ParseAgentNames(agentSpec)
-	model := opts.CrossCheckModel
-	if model == "" {
-		model = opts.SummarizerModel
+	if len(names) != len(models) {
+		return nil, nil, fmt.Errorf("--cross-check-agent (%d agents) and --cross-check-model (%d models) must have same count; agents and models are paired by position", len(names), len(models))
 	}
-	return names, model
+	return names, models, nil
 }
 
 // buildCrossCheckContext assembles the cross-check input context from review

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -165,23 +165,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			Options: summarizer.CrossCheckOptions{Model: perSpec.Model, Effort: perSpec.Effort},
 		})
 	}
-	if opts.CrossCheckEnabled {
-		if err := agent.ValidateAgentNames(ccAgentNames); err != nil {
-			logger.Logf(terminal.StyleError, "Invalid cross-check agent: %v", err)
-			return domain.ExitError
-		}
-		for _, spec := range ccSpecs {
-			ccAg, err := agent.NewAgentWithOptions(spec.Name, agent.AgentOptions{Model: spec.Options.Model, Effort: spec.Options.Effort})
-			if err != nil {
-				logger.Logf(terminal.StyleError, "Invalid cross-check agent %q: %v", spec.Name, err)
-				return domain.ExitError
-			}
-			if err := ccAg.IsAvailable(); err != nil {
-				logger.Logf(terminal.StyleError, "%s CLI not found (cross-check): %v", spec.Name, err)
-				return domain.ExitError
-			}
-		}
-	}
+	// CLI availability check for cross-check agents is deferred to the
+	// grouped path below (see `if useGroupedSpecs && opts.CrossCheckEnabled`):
+	// small diff / explicit `--phase` / `--no-auto-phase` / `arch,diff` paths
+	// never invoke cross-check, so requiring those CLIs to be installed for
+	// every review run is unnecessary friction. Contract integrity (agent name
+	// validity, model 1:1 pairing) is enforced by resolveCrossCheckAgents above
+	// plus ResolvedConfig.ValidateAll (cross_check.enabled=true requires model).
 
 	// Verbose: log the effective model/effort matrix for all roles once, up-front.
 	// fp_filter and pr_feedback specs are resolved later in the flow, so we
@@ -301,7 +291,16 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			if opts.Verbose {
 				logger.Logf(terminal.StyleDim, "Auto-phase: diff is %s (%d files, %d lines)", size, fileCount, lineCount)
 			}
-			apr := resolveAutoPhase(size, opts.Reviewers, diff, opts.Guidance, diffPrecomputed, reviewAgents)
+			// Resolve per-phase agent backends for the grouped path.
+			// arch_reviewer_agent / diff_reviewer_agents overrides take effect
+			// here; unset overrides fall back to ReviewerAgents (matching the
+			// pre-Round-9 behaviour where every phase used the same cohort).
+			archAgentForPhase, diffAgentsForPhase, agentBuildErr := buildPhaseAgents(opts, sizeStr)
+			if agentBuildErr != nil {
+				logger.Logf(terminal.StyleError, "Failed to build per-phase reviewer agents: %v", agentBuildErr)
+				return domain.ExitError
+			}
+			apr := resolveAutoPhase(size, opts.Reviewers, diff, opts.Guidance, diffPrecomputed, archAgentForPhase, diffAgentsForPhase)
 			// Apply reviewer-count override BEFORE any downstream consumer of
 			// opts.Reviewers (concurrency resolution, runner config, etc.).
 			if apr.ReviewerOverride > 0 && apr.ReviewerOverride != opts.Reviewers {
@@ -474,6 +473,27 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	// Cross-check: run only for grouped diff reviews with >=2 groups.
 	var ccResult *summarizer.CrossCheckResult
 	if useGroupedSpecs && opts.CrossCheckEnabled && ctx.Err() == nil {
+		// Lazy CLI availability check: only verify cross-check agent CLIs are
+		// installed when we are about to actually run cross-check. Non-grouped
+		// paths (small diff / explicit --phase / --no-auto-phase / arch,diff)
+		// skip this entirely so users without the cross-check CLI can still
+		// run those review modes.
+		if err := agent.ValidateAgentNames(ccAgentNames); err != nil {
+			logger.Logf(terminal.StyleError, "Invalid cross-check agent: %v", err)
+			return domain.ExitError
+		}
+		for _, spec := range ccSpecs {
+			ccAg, err := agent.NewAgentWithOptions(spec.Name, agent.AgentOptions{Model: spec.Options.Model, Effort: spec.Options.Effort})
+			if err != nil {
+				logger.Logf(terminal.StyleError, "Invalid cross-check agent %q: %v", spec.Name, err)
+				return domain.ExitError
+			}
+			if err := ccAg.IsAvailable(); err != nil {
+				logger.Logf(terminal.StyleError, "%s CLI not found (cross-check): %v", spec.Name, err)
+				return domain.ExitError
+			}
+		}
+
 		ccCtx := buildCrossCheckContext(aggregated, groupedSpecs, results)
 		if len(ccCtx.Groups) >= 2 {
 			ccSpinner := terminal.NewPhaseSpinner("Cross-checking groups")
@@ -866,7 +886,11 @@ func enforceReviewerBoundsForSize(size git.DiffSize, reviewers, fileCount int) (
 }
 
 // resolveAutoPhase determines phase configuration based on diff size and reviewer budget.
-func resolveAutoPhase(size git.DiffSize, reviewers int, diff, guidance string, diffPrecomputed bool, agents []agent.Agent) autoPhaseResult {
+//
+// archAgent and diffAgents are passed through to buildGroupedDiffSpecs so the
+// arch and diff phases can use distinct agent backends per
+// arch_reviewer_agent / diff_reviewer_agents config.
+func resolveAutoPhase(size git.DiffSize, reviewers int, diff, guidance string, diffPrecomputed bool, archAgent agent.Agent, diffAgents []agent.Agent) autoPhaseResult {
 	switch size {
 	case git.DiffSizeSmall:
 		// Small: no reviewer-count override; flat diff path.
@@ -900,7 +924,7 @@ func resolveAutoPhase(size git.DiffSize, reviewers int, diff, guidance string, d
 		if maxDiffGroups > 4 {
 			maxDiffGroups = 4
 		}
-		specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, agents, maxDiffGroups)
+		specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, maxDiffGroups)
 		if err != nil {
 			apr.PhaseStr = "arch,diff"
 			return apr
@@ -930,16 +954,73 @@ func resolveAutoPhase(size git.DiffSize, reviewers int, diff, guidance string, d
 	}
 }
 
+// buildPhaseAgents constructs the arch-phase agent and diff-phase agent slice
+// used by the auto-phase grouped diff path. It honours per-phase overrides
+// (opts.ArchReviewerAgent, opts.DiffReviewerAgents) and falls back to
+// opts.ReviewerAgents when an override is unset, preserving pre-Round-9
+// behaviour. Each constructed agent picks its model/effort via
+// modelconfig.ResolveReviewer with the matching phase ("arch" or "diff") so
+// arch_reviewer / diff_reviewer model layers continue to apply.
+func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Agent, error) {
+	// Arch agent name: explicit override > first reviewer agent.
+	archAgentName := opts.ArchReviewerAgent
+	if archAgentName == "" {
+		if len(opts.ReviewerAgents) == 0 {
+			return nil, nil, fmt.Errorf("reviewer_agents is empty; cannot derive arch reviewer")
+		}
+		archAgentName = opts.ReviewerAgents[0]
+	}
+	cliRevModel, legacyRevModel := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
+	archSpec := modelconfig.ResolveReviewer(
+		opts.Models, sizeStr, "arch", archAgentName,
+		cliRevModel, "",
+		legacyRevModel, "",
+	)
+	archAgent, err := agent.NewAgentWithOptions(archAgentName, agent.AgentOptions{Model: archSpec.Model, Effort: archSpec.Effort})
+	if err != nil {
+		return nil, nil, fmt.Errorf("arch reviewer %q: %w", archAgentName, err)
+	}
+
+	// Diff agent names: explicit override > all reviewer agents.
+	diffAgentNames := opts.DiffReviewerAgents
+	if len(diffAgentNames) == 0 {
+		diffAgentNames = opts.ReviewerAgents
+	}
+	if len(diffAgentNames) == 0 {
+		return nil, nil, fmt.Errorf("no diff-phase agents available (reviewer_agents and diff_reviewer_agents both empty)")
+	}
+	diffAgents := make([]agent.Agent, 0, len(diffAgentNames))
+	for _, name := range diffAgentNames {
+		spec := modelconfig.ResolveReviewer(
+			opts.Models, sizeStr, "diff", name,
+			cliRevModel, "",
+			legacyRevModel, "",
+		)
+		a, err := agent.NewAgentWithOptions(name, agent.AgentOptions{Model: spec.Model, Effort: spec.Effort})
+		if err != nil {
+			return nil, nil, fmt.Errorf("diff reviewer %q: %w", name, err)
+		}
+		diffAgents = append(diffAgents, a)
+	}
+	return archAgent, diffAgents, nil
+}
+
 // buildGroupedDiffSpecs creates ReviewerSpecs for grouped diff review.
 // It parses the precomputed diff into sections, groups them, and generates:
-//   - 1 arch spec (full diff, GroupKey="arch")
-//   - N diff specs (per-group filtered diff, GroupKey="g01"..."gNN")
+//   - 1 arch spec (full diff, GroupKey="arch") using archAgent
+//   - N diff specs (per-group filtered diff, GroupKey="g01"..."gNN") with
+//     diffAgents assigned round-robin per non-empty diff group
 //
 // maxDiffGroups is clamped to min(--reviewers - 1, 4) by the caller.
+//
+// archAgent and diffAgents are independent so per-phase reviewer overrides
+// (arch_reviewer_agent / diff_reviewer_agents) can route phases to different
+// agent backends.
 func buildGroupedDiffSpecs(
 	fullDiff, guidance string,
 	diffPrecomputed bool,
-	agents []agent.Agent,
+	archAgent agent.Agent,
+	diffAgents []agent.Agent,
 	maxDiffGroups int,
 ) ([]runner.ReviewerSpec, error) {
 	sections := git.ParseDiffSections(fullDiff)
@@ -955,7 +1036,6 @@ func buildGroupedDiffSpecs(
 	specs := make([]runner.ReviewerSpec, 0, 1+len(groups))
 
 	// 1. Arch reviewer: full diff (ReviewerID=1)
-	archAgent := agent.AgentForReviewer(agents, 1)
 	specs = append(specs, runner.ReviewerSpec{
 		ReviewerID:      1,
 		Agent:           archAgent,
@@ -967,8 +1047,11 @@ func buildGroupedDiffSpecs(
 	})
 
 	// 2. Per-group diff reviewers (ReviewerID=2, 3, ...)
-	// Compute ReviewerID once per non-skipped group so agent lookup and ReviewerID
-	// stay in lockstep (empty groups skip both counters together).
+	// Compute ReviewerID once per non-skipped group so spec ordering and the
+	// diff-phase agent round-robin stay in lockstep (empty groups skip both
+	// counters together). diffReviewerIdx is 1-based per AgentForReviewer's
+	// contract; the 1st surviving diff group always uses diffAgents[0].
+	diffReviewerIdx := 0
 	for _, group := range groups {
 		groupDiff := git.JoinDiffSections(group.Sections)
 		if groupDiff == "" {
@@ -981,7 +1064,8 @@ func buildGroupedDiffSpecs(
 			targetFiles = append(targetFiles, s.FilePath)
 		}
 		reviewerID := len(specs) + 1
-		diffAgent := agent.AgentForReviewer(agents, reviewerID)
+		diffReviewerIdx++
+		diffAgent := agent.AgentForReviewer(diffAgents, diffReviewerIdx)
 		specs = append(specs, runner.ReviewerSpec{
 			ReviewerID:      reviewerID,
 			Agent:           diffAgent,

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -203,19 +203,31 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		// cascade layer via ResolveReviewer). Without a classified size, these
 		// rows would be misleading since auto-phase will skip per-phase routing.
 		if opts.AutoPhase && opts.Phase == "" && diffSizeClassified && diffSize != git.DiffSizeSmall {
-			for _, name := range opts.ReviewerAgents {
-				cliRevModelLog, legacyRevModelLog := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
+			cliRevModelLog, legacyRevModelLog := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
+			// Arch: single agent — explicit override or first reviewer agent.
+			archNames := []string{opts.ReviewerAgents[0]}
+			if opts.ArchReviewerAgent != "" {
+				archNames = []string{opts.ArchReviewerAgent}
+			}
+			for _, name := range archNames {
 				archSpec := modelconfig.ResolveReviewer(
 					opts.Models, sizeStr, "arch", name,
 					cliRevModelLog, "",
 					legacyRevModelLog, "",
 				)
+				logger.Logf(terminal.StyleDim, "  arch_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: archSpec.Model, Effort: archSpec.Effort}))
+			}
+			// Diff: all diff-phase agents — explicit override or all reviewer agents.
+			diffNames := opts.ReviewerAgents
+			if len(opts.DiffReviewerAgents) > 0 {
+				diffNames = opts.DiffReviewerAgents
+			}
+			for _, name := range diffNames {
 				diffSpec := modelconfig.ResolveReviewer(
 					opts.Models, sizeStr, "diff", name,
 					cliRevModelLog, "",
 					legacyRevModelLog, "",
 				)
-				logger.Logf(terminal.StyleDim, "  arch_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: archSpec.Model, Effort: archSpec.Effort}))
 				logger.Logf(terminal.StyleDim, "  diff_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: diffSpec.Model, Effort: diffSpec.Effort}))
 			}
 		}
@@ -962,6 +974,9 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 	if err != nil {
 		return nil, nil, fmt.Errorf("arch reviewer %q: %w", archAgentName, err)
 	}
+	if err := archAgent.IsAvailable(); err != nil {
+		return nil, nil, fmt.Errorf("arch reviewer %q unavailable: %w", archAgentName, err)
+	}
 
 	// Diff agent names: explicit override > all reviewer agents.
 	diffAgentNames := opts.DiffReviewerAgents
@@ -981,6 +996,9 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 		a, err := agent.NewAgentWithOptions(name, agent.AgentOptions{Model: spec.Model, Effort: spec.Effort})
 		if err != nil {
 			return nil, nil, fmt.Errorf("diff reviewer %q: %w", name, err)
+		}
+		if err := a.IsAvailable(); err != nil {
+			return nil, nil, fmt.Errorf("diff reviewer %q unavailable: %w", name, err)
 		}
 		diffAgents = append(diffAgents, a)
 	}

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -279,6 +279,9 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	phaseFromAuto := false
 	var useGroupedSpecs bool
 	var groupedSpecs []runner.ReviewerSpec
+	// mediumDiffCount > 0 → auto-phase chose arch,diff and the diff phase
+	// reviewer count must come from medium_diff_reviewers (not opts.Reviewers).
+	mediumDiffCount := 0
 	if shouldUseAutoPhase(opts) {
 		if !diffSizeClassified {
 			if opts.Verbose {
@@ -300,17 +303,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				logger.Logf(terminal.StyleError, "Failed to build per-phase reviewer agents: %v", agentBuildErr)
 				return domain.ExitError
 			}
-			apr := resolveAutoPhase(size, opts.Reviewers, diff, opts.Guidance, diffPrecomputed, archAgentForPhase, diffAgentsForPhase)
-			// Apply reviewer-count override BEFORE any downstream consumer of
-			// opts.Reviewers (concurrency resolution, runner config, etc.).
-			if apr.ReviewerOverride > 0 && apr.ReviewerOverride != opts.Reviewers {
-				logger.Logf(terminal.StyleInfo, "[auto-phase] reviewers bumped %d -> %d (%s)",
-					opts.Reviewers, apr.ReviewerOverride, apr.FallbackReason)
-				opts.Reviewers = apr.ReviewerOverride
-			}
+			apr := resolveAutoPhase(size, diff, opts.Guidance, diffPrecomputed,
+				archAgentForPhase, diffAgentsForPhase,
+				opts.DiffGroups, opts.MediumDiffReviewers)
 			phaseStr = apr.PhaseStr
 			groupedSpecs = apr.GroupedSpecs
 			useGroupedSpecs = apr.UseGrouped
+			mediumDiffCount = apr.MediumDiffCount
 			// Enable per-phase role rebinding (arch_reviewer/diff_reviewer) only
 			// for medium/large diffs. Small diffs use flat diff review with the
 			// generic reviewer role.
@@ -318,13 +317,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			if opts.Verbose {
 				switch {
 				case apr.UseGrouped:
-					logger.Logf(terminal.StyleDim, "Auto-phase: grouped (%d diff groups + arch)", len(groupedSpecs)-1)
-				case size == git.DiffSizeLarge && opts.Reviewers < 2:
-					logger.Logf(terminal.StyleWarning, "Auto-phase: --reviewers=%d too low for grouped diff, falling back to arch,diff", opts.Reviewers)
+					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (diff_groups=%d, arch+%d diff groups)",
+						opts.DiffGroups, len(groupedSpecs)-1)
+				case apr.MediumDiffCount > 0 && apr.FallbackReason != "":
+					logger.Logf(terminal.StyleWarning,
+						"Auto-phase: arch,diff (medium_diff_reviewers=%d) — fallback: %s",
+						apr.MediumDiffCount, apr.FallbackReason)
+				case apr.MediumDiffCount > 0:
+					logger.Logf(terminal.StyleInfo,
+						"Auto-phase: arch,diff (medium_diff_reviewers=%d)", apr.MediumDiffCount)
 				case apr.FallbackReason != "":
 					logger.Logf(terminal.StyleWarning, "Auto-phase: falling back to arch,diff (%s)", apr.FallbackReason)
-				case size == git.DiffSizeLarge && !apr.UseGrouped:
-					logger.Logf(terminal.StyleWarning, "Auto-phase: grouped diff setup failed, falling back to arch,diff")
 				}
 			}
 		}
@@ -357,7 +360,14 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		actualReviewers = len(groupedSpecs)
 		r, err = runner.NewWithSpecs(runnerConfig, groupedSpecs, logger)
 	} else if phaseStr != "" {
-		phases, phaseErr := parsePhases(phaseStr, opts.Reviewers)
+		// Auto-phase medium/large fallback paths supply MediumDiffCount so the
+		// diff phase reviewer count comes from medium_diff_reviewers (NOT
+		// --reviewers, which is reserved for flat / explicit --phase paths).
+		totalForParse := opts.Reviewers
+		if mediumDiffCount > 0 {
+			totalForParse = mediumDiffCount + 1 // +1 for arch
+		}
+		phases, phaseErr := parsePhases(phaseStr, totalForParse)
 		if phaseErr != nil {
 			logger.Logf(terminal.StyleError, "Invalid --phase: %v", phaseErr)
 			return domain.ExitError
@@ -845,112 +855,84 @@ func buildCrossCheckContext(findings []domain.AggregatedFinding, specs []runner.
 
 // autoPhaseResult holds the outcome of resolveAutoPhase.
 type autoPhaseResult struct {
-	PhaseStr         string                // non-empty → use legacy phase path
-	GroupedSpecs     []runner.ReviewerSpec // non-nil → use grouped diff path
-	UseGrouped       bool
-	FallbackReason   string // non-empty when UseGrouped was downgraded to false
-	ReviewerOverride int    // 0 = no override; otherwise the enforced reviewer count
+	PhaseStr        string                // non-empty → use legacy phase path
+	GroupedSpecs    []runner.ReviewerSpec // non-nil → use grouped diff path
+	UseGrouped      bool
+	FallbackReason  string // non-empty when UseGrouped was downgraded to false
+	MediumDiffCount int    // 0 = not an arch,diff fallback; otherwise the diff-phase reviewer count to use with parsePhases (arch=1 + this)
 }
 
-// enforceReviewerBoundsForSize enforces per-size reviewer count bounds.
-//   - small: no change
-//   - medium: floor 2
-//   - large: floor 3, upper = fileCount + 1 (floored at 3)
+// resolveAutoPhase determines phase configuration based on diff size and the
+// new auto-phase knobs.
 //
-// Returns the final reviewer count and a short reason string when an override
-// applies. An empty reason means reviewers was already within bounds.
-func enforceReviewerBoundsForSize(size git.DiffSize, reviewers, fileCount int) (int, string) {
-	switch size {
-	case git.DiffSizeSmall:
-		return reviewers, ""
-	case git.DiffSizeMedium:
-		if reviewers < 2 {
-			return 2, fmt.Sprintf("medium diff requires >=2 reviewers; bumped from %d to 2", reviewers)
-		}
-		return reviewers, ""
-	case git.DiffSizeLarge:
-		const floor = 3
-		upper := fileCount + 1
-		if upper < floor {
-			upper = floor
-		}
-		if reviewers < floor {
-			return floor, fmt.Sprintf("large diff requires >=%d reviewers; bumped from %d to %d", floor, reviewers, floor)
-		}
-		if reviewers > upper {
-			return upper, fmt.Sprintf("large diff clamped to file_count+1 = %d; was %d", upper, reviewers)
-		}
-		return reviewers, ""
-	}
-	return reviewers, ""
-}
-
-// resolveAutoPhase determines phase configuration based on diff size and reviewer budget.
+//   - diffGroups: target group count for the grouped (large) path; capped by
+//     the actual file count to keep at least 1 file per group.
+//   - mediumDiffReviewers: diff-phase reviewer count for the medium path
+//     (arch,diff) and for any large fallback to arch,diff.
 //
 // archAgent and diffAgents are passed through to buildGroupedDiffSpecs so the
 // arch and diff phases can use distinct agent backends per
 // arch_reviewer_agent / diff_reviewer_agents config.
-func resolveAutoPhase(size git.DiffSize, reviewers int, diff, guidance string, diffPrecomputed bool, archAgent agent.Agent, diffAgents []agent.Agent) autoPhaseResult {
+//
+// `reviewers` is intentionally NOT a parameter: --reviewers is now reserved
+// for the flat path (auto-phase OFF / small / explicit --phase). Auto-phase
+// medium/large paths derive their concurrency from these dedicated knobs.
+func resolveAutoPhase(
+	size git.DiffSize,
+	diff, guidance string,
+	diffPrecomputed bool,
+	archAgent agent.Agent, diffAgents []agent.Agent,
+	diffGroups int,
+	mediumDiffReviewers int,
+) autoPhaseResult {
 	switch size {
 	case git.DiffSizeSmall:
-		// Small: no reviewer-count override; flat diff path.
+		// Small: flat diff path; reviewer count is taken from --reviewers by caller.
 		return autoPhaseResult{PhaseStr: "diff"}
 	case git.DiffSizeLarge:
-		// Count files for bounds enforcement (file_count+1 upper bound on large).
 		fileCount := len(git.ParseDiffSections(diff))
-		effectiveReviewers, boundsReason := enforceReviewerBoundsForSize(size, reviewers, fileCount)
-
-		apr := autoPhaseResult{}
-		if effectiveReviewers != reviewers {
-			apr.ReviewerOverride = effectiveReviewers
+		// Sanity cap: 1 group must contain at least 1 file.
+		effectiveGroups := diffGroups
+		if effectiveGroups > fileCount {
+			effectiveGroups = fileCount
 		}
-		appendReason := func(extra string) {
-			if extra == "" {
-				return
+		if effectiveGroups < 2 {
+			// Grouped path needs >=2 diff groups to be meaningful.
+			return autoPhaseResult{
+				PhaseStr:        "arch,diff",
+				MediumDiffCount: mediumDiffReviewers,
+				FallbackReason: fmt.Sprintf(
+					"only %d non-empty diff group(s) possible (file_count=%d, diff_groups=%d)",
+					effectiveGroups, fileCount, diffGroups),
 			}
-			if apr.FallbackReason == "" {
-				apr.FallbackReason = extra
-				return
-			}
-			apr.FallbackReason = apr.FallbackReason + "; " + extra
 		}
-		appendReason(boundsReason)
-
-		if effectiveReviewers < 2 {
-			apr.PhaseStr = "arch,diff"
-			return apr
-		}
-		maxDiffGroups := effectiveReviewers - 1
-		if maxDiffGroups > 4 {
-			maxDiffGroups = 4
-		}
-		specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, maxDiffGroups)
+		specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, effectiveGroups)
 		if err != nil {
-			apr.PhaseStr = "arch,diff"
-			return apr
+			return autoPhaseResult{
+				PhaseStr:        "arch,diff",
+				MediumDiffCount: mediumDiffReviewers,
+				FallbackReason:  fmt.Sprintf("buildGroupedDiffSpecs failed: %v", err),
+			}
 		}
 		// specs[0] is always the arch spec; remaining entries are diff groups.
-		// Grouped path requires at least 2 diff groups for a meaningful cross-check.
 		diffGroupCount := len(specs) - 1
 		if diffGroupCount < 2 {
-			apr.PhaseStr = "arch,diff"
-			appendReason(fmt.Sprintf("only %d non-empty diff group(s)", diffGroupCount))
-			return apr
+			return autoPhaseResult{
+				PhaseStr:        "arch,diff",
+				MediumDiffCount: mediumDiffReviewers,
+				FallbackReason:  fmt.Sprintf("only %d non-empty diff group(s) after building", diffGroupCount),
+			}
 		}
-		apr.GroupedSpecs = specs
-		apr.UseGrouped = true
-		return apr
+		return autoPhaseResult{
+			GroupedSpecs: specs,
+			UseGrouped:   true,
+		}
 	default: // medium
-		// Medium requires >=2 reviewers for meaningful arch+diff coverage.
-		effectiveReviewers, boundsReason := enforceReviewerBoundsForSize(size, reviewers, 0)
-		apr := autoPhaseResult{PhaseStr: "arch,diff"}
-		if effectiveReviewers != reviewers {
-			apr.ReviewerOverride = effectiveReviewers
+		// Medium: arch (1) + diff (mediumDiffReviewers).
+		return autoPhaseResult{
+			PhaseStr:        "arch,diff",
+			MediumDiffCount: mediumDiffReviewers,
 		}
-		if boundsReason != "" {
-			apr.FallbackReason = boundsReason
-		}
-		return apr
 	}
 }
 
@@ -1011,7 +993,9 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 //   - N diff specs (per-group filtered diff, GroupKey="g01"..."gNN") with
 //     diffAgents assigned round-robin per non-empty diff group
 //
-// maxDiffGroups is clamped to min(--reviewers - 1, 4) by the caller.
+// maxDiffGroups is supplied by the caller (resolveAutoPhase) from the
+// dedicated `diff_groups` knob, capped at the actual file count so that
+// every group has at least 1 file.
 //
 // archAgent and diffAgents are independent so per-phase reviewer overrides
 // (arch_reviewer_agent / diff_reviewer_agents) can route phases to different

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -144,34 +144,18 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		return domain.ExitError
 	}
 
-	// Resolve and validate cross-check agents (fail-fast).
-	ccAgentNames, ccModels, ccErr := resolveCrossCheckAgents(opts)
-	if ccErr != nil {
-		logger.Logf(terminal.StyleError, "%v", ccErr)
-		return domain.ExitError
-	}
-	// Per-agent model is positionally paired with the agent name.
-	// CrossCheckModel is now required, so no SummarizerModel fallback path remains.
-	ccSpecs := make([]summarizer.CrossCheckAgentSpec, 0, len(ccAgentNames))
-	for i, name := range ccAgentNames {
-		cliCCModel, legacyCCModel := cliOrLegacy(ccModels[i], opts.CrossCheckModelFromCLI)
-		perSpec := modelconfig.Resolve(
-			opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
-			cliCCModel, "",
-			legacyCCModel, "",
-		)
-		ccSpecs = append(ccSpecs, summarizer.CrossCheckAgentSpec{
-			Name:    name,
-			Options: summarizer.CrossCheckOptions{Model: perSpec.Model, Effort: perSpec.Effort},
-		})
-	}
-	// CLI availability check for cross-check agents is deferred to the
-	// grouped path below (see `if useGroupedSpecs && opts.CrossCheckEnabled`):
-	// small diff / explicit `--phase` / `--no-auto-phase` / `arch,diff` paths
-	// never invoke cross-check, so requiring those CLIs to be installed for
-	// every review run is unnecessary friction. Contract integrity (agent name
-	// validity, model 1:1 pairing) is enforced by resolveCrossCheckAgents above
-	// plus ResolvedConfig.ValidateAll (cross_check.enabled=true requires model).
+	// Cross-check agent resolution and CLI availability checks are BOTH deferred
+	// to the grouped path below (see `if useGroupedSpecs && opts.CrossCheckEnabled`).
+	// Round-14 F#1: cross-check is invoked only when useGroupedSpecs=true, which
+	// resolveAutoPhase only returns under DiffSizeLarge. Eager resolution here
+	// would force users on small/medium diffs (or `--phase`/`--no-auto-phase`/
+	// arch,diff fallback paths) to satisfy cross_check.model purely to start the
+	// run — even though cross-check would never execute. Deferring resolve until
+	// the gate also implicitly tightens validate↔runtime symmetry: at the gate,
+	// sizeStr is guaranteed to be "large", matching `canResolveCrossCheckModelForAgent`'s
+	// sizes["large"] cascade in internal/config. Contract integrity (agent name
+	// validity, model 1:1 pairing) is still enforced at validate time by
+	// ResolvedConfig.ValidateRuntime.
 
 	// Verbose: log the effective model/effort matrix for all roles once, up-front.
 	// fp_filter and pr_feedback specs are resolved later in the flow, so we
@@ -196,53 +180,16 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		for _, s := range reviewerSpecs {
 			logger.Logf(terminal.StyleDim, "  reviewer[%s]       : %s", s.Name, formatSpec(agent.AgentOptions{Model: s.Options.Model, Effort: s.Options.Effort}))
 		}
-		// arch_reviewer / diff_reviewer rows are meaningful only when
-		// auto-phase is enabled AND diff-size classification succeeded: they
-		// show how the multi-phase run will resolve per-phase model/effort
-		// (phase-specific roles fall back to the generic reviewer at the SAME
-		// cascade layer via ResolveReviewer). Without a classified size, these
-		// rows would be misleading since auto-phase will skip per-phase routing.
-		if opts.AutoPhase && opts.Phase == "" && diffSizeClassified && diffSize != git.DiffSizeSmall {
-			cliRevModelLog, legacyRevModelLog := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
-			// Arch: single agent — explicit override or first reviewer agent.
-			archNames := []string{opts.ReviewerAgents[0]}
-			if opts.ArchReviewerAgent != "" {
-				archNames = []string{opts.ArchReviewerAgent}
-			}
-			for _, name := range archNames {
-				archSpec := modelconfig.ResolveReviewer(
-					opts.Models, sizeStr, "arch", name,
-					cliRevModelLog, "",
-					legacyRevModelLog, "",
-				)
-				logger.Logf(terminal.StyleDim, "  arch_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: archSpec.Model, Effort: archSpec.Effort}))
-			}
-			// Diff: all diff-phase agents — explicit override or all reviewer agents.
-			diffNames := opts.ReviewerAgents
-			if len(opts.DiffReviewerAgents) > 0 {
-				diffNames = opts.DiffReviewerAgents
-			}
-			for _, name := range diffNames {
-				diffSpec := modelconfig.ResolveReviewer(
-					opts.Models, sizeStr, "diff", name,
-					cliRevModelLog, "",
-					legacyRevModelLog, "",
-				)
-				logger.Logf(terminal.StyleDim, "  diff_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: diffSpec.Model, Effort: diffSpec.Effort}))
-			}
-		}
+		// arch_reviewer / diff_reviewer rows intentionally omitted here: they
+		// depend on whether the grouped path will actually execute, which is
+		// decided later by resolveAutoPhase (needs the full diff to know
+		// effectiveGroups). When grouped path is selected, the per-phase
+		// rows are emitted alongside the "Auto-phase: grouped" line below.
 		logger.Logf(terminal.StyleDim, "  summarizer        : %s", formatSpec(agent.AgentOptions{Model: summSpec.Model, Effort: summSpec.Effort}))
-		if opts.CrossCheckEnabled {
-			for i, name := range ccAgentNames {
-				cliCCModelLog, legacyCCModelLog := cliOrLegacy(ccModels[i], opts.CrossCheckModelFromCLI)
-				perSpec := modelconfig.Resolve(
-					opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
-					cliCCModelLog, "",
-					legacyCCModelLog, "",
-				)
-				logger.Logf(terminal.StyleDim, "  cross_check[%s]    : %s", name, formatSpec(agent.AgentOptions{Model: perSpec.Model, Effort: perSpec.Effort}))
-			}
-		}
+		// cross_check row intentionally omitted here: cross-check only runs when
+		// useGroupedSpecs=true (resolveAutoPhase, large diff). Like
+		// arch_reviewer / diff_reviewer rows, it is emitted alongside the
+		// "Auto-phase: grouped" line below when grouped path is confirmed.
 		logger.Logf(terminal.StyleDim, "  fp_filter         : %s", formatSpec(agent.AgentOptions{Model: fpSpecLog.Model, Effort: fpSpecLog.Effort}))
 		logger.Logf(terminal.StyleDim, "  pr_feedback       : %s", formatSpec(agent.AgentOptions{Model: prFeedbackSpecLog.Model, Effort: prFeedbackSpecLog.Effort}))
 	}
@@ -306,18 +253,20 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			if opts.Verbose {
 				logger.Logf(terminal.StyleDim, "Auto-phase: diff is %s (%d files, %d lines)", size, fileCount, lineCount)
 			}
-			// Resolve per-phase agent backends for the grouped path.
-			// arch_reviewer_agent / diff_reviewer_agents overrides take effect
-			// here; unset overrides fall back to ReviewerAgents (matching the
-			// pre-Round-9 behaviour where every phase used the same cohort).
-			archAgentForPhase, diffAgentsForPhase, agentBuildErr := buildPhaseAgents(opts, sizeStr)
-			if agentBuildErr != nil {
-				logger.Logf(terminal.StyleError, "Failed to build per-phase reviewer agents: %v", agentBuildErr)
+			// Defer per-phase agent construction to resolveAutoPhase so that
+			// IsAvailable() only runs once grouped path is actually viable.
+			// Small/medium/large→fallback paths never call the closure, so
+			// arch_reviewer_agent / diff_reviewer_agents CLI presence is not
+			// required unless the grouped path will actually execute.
+			apr, agentsErr := resolveAutoPhase(size, diff, opts.Guidance, diffPrecomputed,
+				func() (agent.Agent, []agent.Agent, error) {
+					return buildPhaseAgents(opts, sizeStr)
+				},
+				opts.DiffGroups, opts.MediumDiffReviewers)
+			if agentsErr != nil {
+				logger.Logf(terminal.StyleError, "Failed to build per-phase reviewer agents: %v", agentsErr)
 				return domain.ExitError
 			}
-			apr := resolveAutoPhase(size, diff, opts.Guidance, diffPrecomputed,
-				archAgentForPhase, diffAgentsForPhase,
-				opts.DiffGroups, opts.MediumDiffReviewers)
 			phaseStr = apr.PhaseStr
 			groupedSpecs = apr.GroupedSpecs
 			useGroupedSpecs = apr.UseGrouped
@@ -331,6 +280,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				case apr.UseGrouped:
 					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (diff_groups=%d, arch+%d diff groups)",
 						opts.DiffGroups, len(groupedSpecs)-1)
+					// Per-phase model matrix rows — only meaningful once we
+					// know the grouped path will actually run. Before this
+					// point, a large→flat fallback would have made these rows
+					// misleading, so emission is deferred until here.
+					logPerPhaseModelMatrix(logger, opts, sizeStr)
+					// cross_check rows — same rationale: cross-check fires only
+					// when useGroupedSpecs=true. Emitted here so the verbose
+					// log groups all grouped-path-specific rows together.
+					if opts.CrossCheckEnabled {
+						logCrossCheckModelMatrix(logger, opts, sizeStr)
+					}
 				case apr.MediumDiffCount > 0 && apr.FallbackReason != "":
 					logger.Logf(terminal.StyleWarning,
 						"Auto-phase: arch,diff (medium_diff_reviewers=%d) — fallback: %s",
@@ -495,6 +455,31 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	// Cross-check: run only for grouped diff reviews with >=2 groups.
 	var ccResult *summarizer.CrossCheckResult
 	if useGroupedSpecs && opts.CrossCheckEnabled && ctx.Err() == nil {
+		// Lazy resolve: top-level cross_check.model parsing and per-agent
+		// modelconfig.Resolve happen here, NOT at startup. Round-14 F#1
+		// guarantees this gate is reached only when sizeStr=="large" (since
+		// useGroupedSpecs=true is exclusive to DiffSizeLarge in
+		// resolveAutoPhase), so the size layer cascade lines up with
+		// canResolveCrossCheckModelForAgent's sizes["large"] view.
+		ccAgentNames, ccModels, ccErr := resolveCrossCheckAgents(opts, sizeStr)
+		if ccErr != nil {
+			logger.Logf(terminal.StyleError, "%v", ccErr)
+			return domain.ExitError
+		}
+		// Per-agent model is positionally paired with the agent name.
+		ccSpecs := make([]summarizer.CrossCheckAgentSpec, 0, len(ccAgentNames))
+		for i, name := range ccAgentNames {
+			cliCCModel, legacyCCModel := cliOrLegacy(ccModels[i], opts.CrossCheckModelFromCLI)
+			perSpec := modelconfig.Resolve(
+				opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
+				cliCCModel, "",
+				legacyCCModel, "",
+			)
+			ccSpecs = append(ccSpecs, summarizer.CrossCheckAgentSpec{
+				Name:    name,
+				Options: summarizer.CrossCheckOptions{Model: perSpec.Model, Effort: perSpec.Effort},
+			})
+		}
 		// Lazy CLI availability check: only verify cross-check agent CLIs are
 		// installed when we are about to actually run cross-check. Non-grouped
 		// paths (small diff / explicit --phase / --no-auto-phase / arch,diff)
@@ -766,10 +751,30 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 }
 
 // resolveCrossCheckAgents returns the resolved cross-check agent names and
-// per-agent models. CrossCheckModel is REQUIRED when cross-check is enabled
-// and must be a comma-separated list whose count matches CrossCheckAgent
-// (after fallback to SummarizerAgent when CrossCheckAgent is unset). Agents
-// and models are paired positionally: agents[i] uses models[i].
+// per-agent models. When opts.CrossCheckModel is non-empty it MUST be a
+// comma-separated list whose count matches CrossCheckAgent (after fallback
+// to SummarizerAgent when CrossCheckAgent is unset). Agents and models are
+// paired positionally: agents[i] uses models[i].
+//
+// When opts.CrossCheckModel is empty, per-agent resolution falls back to the
+// models cascade via modelconfig.Resolve(..., RoleCrossCheck, name, ...).
+// This mirrors the validation in config.ValidateRuntime so "validates OK"
+// implies "runs OK" whenever a user configures cross-check through the
+// structured `models` tree (models.agents.<name>.cross_check / models.sizes.
+// large.cross_check / models.defaults.cross_check) instead of the legacy
+// top-level cross_check.model field. Before Round-13 the runtime required
+// opts.CrossCheckModel unconditionally, producing a "validates OK but never
+// runs" contract asymmetry (Round-13 F#1).
+//
+// Round-14 F#1 contract: this function is invoked exclusively from the
+// grouped-path gate in executeReview, where sizeStr is guaranteed to be
+// "large" (useGroupedSpecs=true is exclusive to DiffSizeLarge in
+// resolveAutoPhase). The defence-in-depth log helper logCrossCheckModelMatrix
+// also calls this with the same sizeStr just before the gate, so the size
+// argument is consistent across both call sites. Non-grouped review paths
+// (small / medium / `--phase` / `--no-auto-phase` / arch,diff fallback) skip
+// cross-check entirely and never invoke this function — that is the entire
+// point of Round-14 F#1's resolve deferral.
 //
 // Returns (nil, nil, nil) when cross-check is disabled.
 //
@@ -778,29 +783,59 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 // a truly-unset CrossCheckAgent and fall back to SummarizerAgent. This is
 // belt-and-suspenders even if config.Resolve already copies the value,
 // because the fallback here is the canonical resolution point.
-func resolveCrossCheckAgents(opts ReviewOpts) ([]string, []string, error) {
+func resolveCrossCheckAgents(opts ReviewOpts, sizeStr string) ([]string, []string, error) {
 	if !opts.CrossCheckEnabled {
 		return nil, nil, nil
-	}
-	if strings.TrimSpace(opts.CrossCheckModel) == "" {
-		return nil, nil, fmt.Errorf("--cross-check-model is required when cross-check is enabled (env: ACR_CROSS_CHECK_MODEL); supply a comma-separated model list paired 1:1 with --cross-check-agent")
-	}
-	rawModels := strings.Split(opts.CrossCheckModel, ",")
-	models := make([]string, 0, len(rawModels))
-	for _, m := range rawModels {
-		m = strings.TrimSpace(m)
-		if m == "" {
-			return nil, nil, fmt.Errorf("--cross-check-model contains an empty entry; check for leading/trailing/duplicate commas")
-		}
-		models = append(models, m)
 	}
 	agentSpec := opts.CrossCheckAgent
 	if strings.TrimSpace(agentSpec) == "" {
 		agentSpec = opts.SummarizerAgent
 	}
 	names := agent.ParseAgentNames(agentSpec)
-	if len(names) != len(models) {
-		return nil, nil, fmt.Errorf("--cross-check-agent (%d agents) and --cross-check-model (%d models) must have same count; agents and models are paired by position", len(names), len(models))
+
+	if strings.TrimSpace(opts.CrossCheckModel) != "" {
+		// Explicit top-level model list: split, validate, pair positionally.
+		rawModels := strings.Split(opts.CrossCheckModel, ",")
+		models := make([]string, 0, len(rawModels))
+		for _, m := range rawModels {
+			m = strings.TrimSpace(m)
+			if m == "" {
+				return nil, nil, fmt.Errorf("--cross-check-model contains an empty entry; check for leading/trailing/duplicate commas")
+			}
+			models = append(models, m)
+		}
+		if len(names) != len(models) {
+			return nil, nil, fmt.Errorf("--cross-check-agent (%d agents) and --cross-check-model (%d models) must have same count; agents and models are paired by position", len(names), len(models))
+		}
+		return names, models, nil
+	}
+
+	// Top-level unset: per-agent resolution via the models cascade. Each
+	// selected agent must produce a non-empty Model at the runtime size.
+	models := make([]string, len(names))
+	var missing []string
+	for i, name := range names {
+		spec := modelconfig.Resolve(
+			opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
+			"", "", // no CLI override (top-level was empty)
+			"", "", // no legacy fallback — the cross_check legacy path IS the top-level field we already checked
+		)
+		if strings.TrimSpace(spec.Model) == "" {
+			missing = append(missing, name)
+			continue
+		}
+		models[i] = spec.Model
+	}
+	if len(missing) > 0 {
+		return nil, nil, fmt.Errorf(
+			"cross_check.enabled=true requires cross_check.model for agent(s) %v "+
+				"(supply via --cross-check-model / ACR_CROSS_CHECK_MODEL as a "+
+				"comma-separated list paired 1:1 with --cross-check-agent, or via "+
+				"models.{agents.<name>,sizes.large,defaults}.cross_check.model "+
+				"— note: cross-check runs only at size=large, so sizes.small/medium "+
+				"entries are dead config); "+
+				"or disable cross-check with --no-cross-check",
+			missing)
 	}
 	return names, models, nil
 }
@@ -893,14 +928,14 @@ func resolveAutoPhase(
 	size git.DiffSize,
 	diff, guidance string,
 	diffPrecomputed bool,
-	archAgent agent.Agent, diffAgents []agent.Agent,
+	buildAgents func() (agent.Agent, []agent.Agent, error),
 	diffGroups int,
 	mediumDiffReviewers int,
-) autoPhaseResult {
+) (autoPhaseResult, error) {
 	switch size {
 	case git.DiffSizeSmall:
 		// Small: flat diff path; reviewer count is taken from --reviewers by caller.
-		return autoPhaseResult{PhaseStr: "diff"}
+		return autoPhaseResult{PhaseStr: "diff"}, nil
 	case git.DiffSizeLarge:
 		fileCount := len(git.ParseDiffSections(diff))
 		// Sanity cap: 1 group must contain at least 1 file.
@@ -909,14 +944,26 @@ func resolveAutoPhase(
 			effectiveGroups = fileCount
 		}
 		if effectiveGroups < 2 {
-			// Grouped path needs >=2 diff groups to be meaningful.
+			// Grouped path needs >=2 diff groups to be meaningful. Fall back to
+			// flat arch,diff (parsePhases + reviewAgents) without ever touching
+			// buildAgents, so per-phase override CLI availability does not gate
+			// the fallback.
 			return autoPhaseResult{
 				PhaseStr:        "arch,diff",
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason: fmt.Sprintf(
 					"only %d non-empty diff group(s) possible (file_count=%d, diff_groups=%d)",
 					effectiveGroups, fileCount, diffGroups),
-			}
+			}, nil
+		}
+		// Grouped path confirmed viable; now build the per-phase agents. An
+		// error here means the user configured arch_reviewer_agent /
+		// diff_reviewer_agents but the CLI is not available — surface it to
+		// the caller so the run aborts with a clear message (we intentionally
+		// do NOT silently fall back, because the override was explicit).
+		archAgent, diffAgents, agentsErr := buildAgents()
+		if agentsErr != nil {
+			return autoPhaseResult{}, agentsErr
 		}
 		specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, effectiveGroups)
 		if err != nil {
@@ -924,7 +971,7 @@ func resolveAutoPhase(
 				PhaseStr:        "arch,diff",
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason:  fmt.Sprintf("buildGroupedDiffSpecs failed: %v", err),
-			}
+			}, nil
 		}
 		// specs[0] is always the arch spec; remaining entries are diff groups.
 		diffGroupCount := len(specs) - 1
@@ -933,18 +980,18 @@ func resolveAutoPhase(
 				PhaseStr:        "arch,diff",
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason:  fmt.Sprintf("only %d non-empty diff group(s) after building", diffGroupCount),
-			}
+			}, nil
 		}
 		return autoPhaseResult{
 			GroupedSpecs: specs,
 			UseGrouped:   true,
-		}
+		}, nil
 	default: // medium
-		// Medium: arch (1) + diff (mediumDiffReviewers).
+		// Medium: arch (1) + diff (mediumDiffReviewers). Never calls buildAgents.
 		return autoPhaseResult{
 			PhaseStr:        "arch,diff",
 			MediumDiffCount: mediumDiffReviewers,
-		}
+		}, nil
 	}
 }
 
@@ -1003,6 +1050,85 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 		diffAgents = append(diffAgents, a)
 	}
 	return archAgent, diffAgents, nil
+}
+
+// logPerPhaseModelMatrix emits the arch_reviewer[...] and diff_reviewer[...]
+// verbose rows that continue the "Effective model matrix" block printed
+// earlier. It is only meaningful once resolveAutoPhase has committed to the
+// grouped path: a large→flat fallback makes these rows misleading because
+// the per-phase override agents are never invoked in that case. Callers must
+// gate this on apr.UseGrouped.
+func logPerPhaseModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr string) {
+	cliRevModelLog, legacyRevModelLog := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
+	// Arch: explicit override takes precedence; otherwise fall back to the first
+	// reviewer agent. Evaluation order mirrors buildPhaseAgents so that verbose
+	// logging never panics when ReviewerAgents is empty but ArchReviewerAgent is
+	// set explicitly.
+	archName := opts.ArchReviewerAgent
+	if archName == "" {
+		if len(opts.ReviewerAgents) == 0 {
+			// No arch name resolvable. buildPhaseAgents would have already aborted
+			// the run with a clear error; logging is defence-in-depth only, so
+			// emit a diagnostic line and skip the per-phase rows rather than panic.
+			logger.Logf(terminal.StyleWarning, "  arch_reviewer[?]    : (unresolvable: reviewer_agents is empty and arch_reviewer_agent is unset)")
+			return
+		}
+		archName = opts.ReviewerAgents[0]
+	}
+	archSpec := modelconfig.ResolveReviewer(
+		opts.Models, sizeStr, "arch", archName,
+		cliRevModelLog, "",
+		legacyRevModelLog, "",
+	)
+	logger.Logf(terminal.StyleDim, "  arch_reviewer[%s]  : %s", archName, formatSpec(agent.AgentOptions{Model: archSpec.Model, Effort: archSpec.Effort}))
+	// Diff: explicit override takes precedence; otherwise fall back to all
+	// reviewer agents. Empty result is tolerated (for consistency with arch
+	// guard above) and emits nothing.
+	diffNames := opts.DiffReviewerAgents
+	if len(diffNames) == 0 {
+		diffNames = opts.ReviewerAgents
+	}
+	for _, name := range diffNames {
+		diffSpec := modelconfig.ResolveReviewer(
+			opts.Models, sizeStr, "diff", name,
+			cliRevModelLog, "",
+			legacyRevModelLog, "",
+		)
+		logger.Logf(terminal.StyleDim, "  diff_reviewer[%s]  : %s", name, formatSpec(agent.AgentOptions{Model: diffSpec.Model, Effort: diffSpec.Effort}))
+	}
+}
+
+// logCrossCheckModelMatrix emits the cross_check[...] verbose row(s) that
+// continue the "Effective model matrix" block printed earlier. Like the
+// arch_reviewer / diff_reviewer rows, emission is deferred until
+// resolveAutoPhase has committed to the grouped path: cross-check fires only
+// when useGroupedSpecs=true (Round-14 F#1), so emitting these rows earlier
+// would be misleading on small/medium/fallback paths.
+//
+// Defence-in-depth against panic: if cross-check resolution would fail (every
+// selected agent uncovered by the models tree AND no top-level model), this
+// function emits a diagnostic line and returns rather than panicking. The
+// authoritative resolve happens in the same gate where this is called from
+// (cmd/acr/review.go grouped path), so a real failure surfaces there with a
+// clear, actionable error.
+func logCrossCheckModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr string) {
+	ccAgentNames, ccModels, err := resolveCrossCheckAgents(opts, sizeStr)
+	if err != nil {
+		// Mirror logPerPhaseModelMatrix's posture: skip rows with a hint, do
+		// not panic. The same resolve runs in the grouped path gate moments
+		// later and will abort the run with the real error.
+		logger.Logf(terminal.StyleWarning, "  cross_check[?]    : (unresolvable: %v)", err)
+		return
+	}
+	for i, name := range ccAgentNames {
+		cliCCModelLog, legacyCCModelLog := cliOrLegacy(ccModels[i], opts.CrossCheckModelFromCLI)
+		perSpec := modelconfig.Resolve(
+			opts.Models, sizeStr, modelconfig.RoleCrossCheck, name,
+			cliCCModelLog, "",
+			legacyCCModelLog, "",
+		)
+		logger.Logf(terminal.StyleDim, "  cross_check[%s]    : %s", name, formatSpec(agent.AgentOptions{Model: perSpec.Model, Effort: perSpec.Effort}))
+	}
 }
 
 // buildGroupedDiffSpecs creates ReviewerSpecs for grouped diff review.

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/richhaase/agentic-code-reviewer/internal/git"
 	"github.com/richhaase/agentic-code-reviewer/internal/runner"
 	"github.com/richhaase/agentic-code-reviewer/internal/summarizer"
+	"github.com/richhaase/agentic-code-reviewer/internal/terminal"
 )
 
 func TestParsePhases(t *testing.T) {
@@ -269,7 +270,18 @@ func TestBuildGroupedDiffSpecs_FallbackOnError(t *testing.T) {
 // --- resolveAutoPhase tests ---
 //
 // Signature: resolveAutoPhase(size, diff, guidance, diffPrecomputed,
-//   archAgent, diffAgents, diffGroups, mediumDiffReviewers)
+//   buildAgents func() (agent.Agent, []agent.Agent, error),
+//   diffGroups, mediumDiffReviewers) (autoPhaseResult, error)
+//
+// Tests use testBuildAgents to return pre-constructed agents synchronously.
+// The closure is only invoked when the large grouped path decides to proceed,
+// so medium/small/fallback tests can pass nil values safely.
+
+func testBuildAgents(arch agent.Agent, diffs []agent.Agent) func() (agent.Agent, []agent.Agent, error) {
+	return func() (agent.Agent, []agent.Agent, error) {
+		return arch, diffs, nil
+	}
+}
 
 func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 	// Large diff with diff_groups=3 → grouped specs
@@ -277,7 +289,7 @@ func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for large diff with diff_groups=3")
@@ -294,7 +306,7 @@ func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 	// Large diff but empty diff content → buildGroupedDiffSpecs fails → fallback
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, "", "", true, agents[0], agents, 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, "", "", true, testBuildAgents(agents[0], agents), 3, 2)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when buildGroupedDiffSpecs fails")
@@ -408,7 +420,7 @@ func TestReviewPipeline_CrossCheckUsesAggregatedIDs(t *testing.T) {
 
 func TestResolveCrossCheckAgents_DisabledReturnsNil(t *testing.T) {
 	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{CrossCheckEnabled: false}}
-	names, models, err := resolveCrossCheckAgents(opts)
+	names, models, err := resolveCrossCheckAgents(opts, "")
 	if err != nil {
 		t.Fatalf("disabled: unexpected error: %v", err)
 	}
@@ -418,17 +430,123 @@ func TestResolveCrossCheckAgents_DisabledReturnsNil(t *testing.T) {
 }
 
 func TestResolveCrossCheckAgents_RequiresModel(t *testing.T) {
+	// Top-level CrossCheckModel empty AND models tree empty: every selected
+	// agent fails per-agent resolution → error must name the missing agent(s)
+	// so users know which slot to fill.
 	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
 		CrossCheckEnabled: true,
 		CrossCheckAgent:   "codex,claude",
 		CrossCheckModel:   "",
 	}}
-	_, _, err := resolveCrossCheckAgents(opts)
+	_, _, err := resolveCrossCheckAgents(opts, "")
 	if err == nil {
-		t.Fatal("expected error when CrossCheckModel is empty")
+		t.Fatal("expected error when CrossCheckModel is empty and models tree is empty")
 	}
-	if !strings.Contains(err.Error(), "required") {
-		t.Errorf("error should mention required, got: %v", err)
+	if !strings.Contains(err.Error(), "requires cross_check.model") {
+		t.Errorf("error should mention cross_check.model requirement, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "codex") || !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should name both missing agents, got: %v", err)
+	}
+}
+
+// --- Round-13 F#1: per-agent fallback via models tree ---
+
+func TestResolveCrossCheckAgents_ResolvesFromAgentsModelsTree(t *testing.T) {
+	// Top-level CrossCheckModel empty but agents.<name>.cross_check.model set
+	// for every selected agent → success. This is the canonical "structured
+	// models tree instead of legacy flat field" configuration.
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex,claude",
+		CrossCheckModel:   "",
+		Models: config.ModelsConfig{
+			Agents: map[string]config.RoleModels{
+				"codex":  {CrossCheck: &config.ModelSpec{Model: "gpt-5.4-mini"}},
+				"claude": {CrossCheck: &config.ModelSpec{Model: "claude-opus-4-7"}},
+			},
+		},
+	}}
+	names, models, err := resolveCrossCheckAgents(opts, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 2 || len(models) != 2 {
+		t.Fatalf("expected 2 agents and 2 models, got names=%v models=%v", names, models)
+	}
+	if models[0] != "gpt-5.4-mini" || models[1] != "claude-opus-4-7" {
+		t.Errorf("expected models from agents tree, got %v", models)
+	}
+}
+
+func TestResolveCrossCheckAgents_ResolvesFromDefaultsModelsTree(t *testing.T) {
+	// Top-level empty + only defaults.cross_check.model set → all agents get
+	// the default model.
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex,claude",
+		CrossCheckModel:   "",
+		Models: config.ModelsConfig{
+			Defaults: config.RoleModels{CrossCheck: &config.ModelSpec{Model: "shared-cc-model"}},
+		},
+	}}
+	_, models, err := resolveCrossCheckAgents(opts, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 || models[0] != "shared-cc-model" || models[1] != "shared-cc-model" {
+		t.Errorf("expected both agents to resolve to shared default, got %v", models)
+	}
+}
+
+func TestResolveCrossCheckAgents_ResolvesFromSizesModelsTree(t *testing.T) {
+	// Top-level empty + sizes.large.cross_check.model only → resolves when
+	// sizeStr matches (this exercises the runtime size-layer fallback path
+	// that validate-time cannot verify deterministically).
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex",
+		CrossCheckModel:   "",
+		Models: config.ModelsConfig{
+			Sizes: map[string]config.RoleModels{
+				"large": {CrossCheck: &config.ModelSpec{Model: "gpt-5.4-large"}},
+			},
+		},
+	}}
+	_, models, err := resolveCrossCheckAgents(opts, "large")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 1 || models[0] != "gpt-5.4-large" {
+		t.Errorf("expected model from sizes tree at size=large, got %v", models)
+	}
+}
+
+// TestResolveCrossCheckAgents_PartialTreeReportsMissingAgent verifies the
+// Round-13 F#3 tightening: when the models tree covers some selected agents
+// but not all, runtime must name the uncovered agent(s) rather than silently
+// succeeding for the covered subset.
+func TestResolveCrossCheckAgents_PartialTreeReportsMissingAgent(t *testing.T) {
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex,claude",
+		CrossCheckModel:   "",
+		Models: config.ModelsConfig{
+			Agents: map[string]config.RoleModels{
+				"codex": {CrossCheck: &config.ModelSpec{Model: "gpt-5.4-mini"}},
+				// "claude" intentionally absent and no defaults fallback.
+			},
+		},
+	}}
+	_, _, err := resolveCrossCheckAgents(opts, "")
+	if err == nil {
+		t.Fatal("expected error when one selected agent is uncovered by the models tree")
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should name the uncovered agent 'claude', got: %v", err)
+	}
+	if strings.Contains(err.Error(), "[codex]") {
+		t.Errorf("error should NOT name the covered agent 'codex', got: %v", err)
 	}
 }
 
@@ -438,7 +556,7 @@ func TestResolveCrossCheckAgents_PairsAgentsAndModels(t *testing.T) {
 		CrossCheckAgent:   "codex,claude,gemini",
 		CrossCheckModel:   "gpt-5,opus,gemini-pro",
 	}}
-	names, models, err := resolveCrossCheckAgents(opts)
+	names, models, err := resolveCrossCheckAgents(opts, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -462,7 +580,7 @@ func TestResolveCrossCheckAgents_RejectsCountMismatch(t *testing.T) {
 		CrossCheckAgent:   "codex,claude,gemini",
 		CrossCheckModel:   "gpt-5,opus",
 	}}
-	_, _, err := resolveCrossCheckAgents(opts)
+	_, _, err := resolveCrossCheckAgents(opts, "")
 	if err == nil {
 		t.Fatal("expected error when agent count != model count")
 	}
@@ -477,7 +595,7 @@ func TestResolveCrossCheckAgents_RejectsEmptyEntry(t *testing.T) {
 		CrossCheckAgent:   "codex,claude",
 		CrossCheckModel:   "gpt-5,",
 	}}
-	_, _, err := resolveCrossCheckAgents(opts)
+	_, _, err := resolveCrossCheckAgents(opts, "")
 	if err == nil {
 		t.Fatal("expected error when CrossCheckModel has empty entry")
 	}
@@ -490,7 +608,7 @@ func TestResolveCrossCheckAgents_AgentDefaultsToSummarizer(t *testing.T) {
 		SummarizerAgent:   "codex",
 		CrossCheckModel:   "gpt-5",
 	}}
-	names, models, err := resolveCrossCheckAgents(opts)
+	names, models, err := resolveCrossCheckAgents(opts, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -513,7 +631,7 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 1, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 1, 2)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false for diff_groups=1")
@@ -537,7 +655,7 @@ func TestResolveAutoPhase_TwoDiffGroups_KeepsGrouped(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 2, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 2, 2)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for 2+ diff groups")
@@ -557,7 +675,7 @@ func TestLargeReview_GroupedSpecsProduceCrossCheckableTopology(t *testing.T) {
 	sections := makeSectionsForReview(8, 5)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for large diff with diff_groups=3")
 	}
@@ -887,7 +1005,7 @@ func TestResolveAutoPhase_LargeUsesDiffGroupsKnob(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
 
 	if !apr.UseGrouped {
 		t.Fatalf("expected UseGrouped=true; FallbackReason=%q", apr.FallbackReason)
@@ -910,7 +1028,7 @@ func TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall(t *testi
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 4, 3)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 4, 3)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when fileCount<2")
@@ -929,7 +1047,7 @@ func TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall(t *testi
 // TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob verifies that medium
 // path returns arch,diff with MediumDiffCount=mediumDiffReviewers.
 func TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob(t *testing.T) {
-	apr := resolveAutoPhase(git.DiffSizeMedium, "", "", true, nil, nil, 4, 4)
+	apr, _ := resolveAutoPhase(git.DiffSizeMedium, "", "", true, testBuildAgents(nil, nil), 4, 4)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false on medium")
@@ -954,7 +1072,7 @@ func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 10, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 10, 2)
 
 	if !apr.UseGrouped {
 		t.Fatalf("expected UseGrouped=true with 12 files / diff_groups=10; FallbackReason=%q", apr.FallbackReason)
@@ -973,7 +1091,7 @@ func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 
 // TestResolveAutoPhase_Small returns flat diff regardless of knobs.
 func TestResolveAutoPhase_Small(t *testing.T) {
-	apr := resolveAutoPhase(git.DiffSizeSmall, "irrelevant", "", true, nil, nil, 4, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeSmall, "irrelevant", "", true, testBuildAgents(nil, nil), 4, 2)
 	if apr.UseGrouped {
 		t.Errorf("expected UseGrouped=false for small")
 	}
@@ -1219,4 +1337,153 @@ func TestMaxPotentialReviewers(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- logPerPhaseModelMatrix tests ---
+//
+// Round-13 F#4: logPerPhaseModelMatrix evaluated opts.ReviewerAgents[0] BEFORE
+// consulting ArchReviewerAgent, so a config with reviewer_agents=[] and
+// arch_reviewer_agent="codex" caused a panic in verbose grouped-path logging.
+// The fix re-orders the evaluation to mirror buildPhaseAgents (explicit arch
+// override first, reviewer fallback second) and adds a guard for the fully-empty
+// case so logging degrades gracefully rather than panicking.
+
+func TestLogPerPhaseModelMatrix_EmptyReviewerAgentsWithArchOverride(t *testing.T) {
+	// Empty ReviewerAgents + explicit ArchReviewerAgent must NOT panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logPerPhaseModelMatrix panicked: %v", r)
+		}
+	}()
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:     nil,
+			ArchReviewerAgent:  "codex",
+			DiffReviewerAgents: []string{"claude"},
+		},
+	}
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+}
+
+func TestLogPerPhaseModelMatrix_ArchOverrideTakesPrecedence(t *testing.T) {
+	// When both are set, arch override wins — matches buildPhaseAgents.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logPerPhaseModelMatrix panicked: %v", r)
+		}
+	}()
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:    []string{"gemini", "codex"},
+			ArchReviewerAgent: "claude",
+		},
+	}
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+}
+
+func TestLogPerPhaseModelMatrix_ReviewerAgentsFallback(t *testing.T) {
+	// Without an explicit arch override, the first reviewer agent drives arch.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logPerPhaseModelMatrix panicked: %v", r)
+		}
+	}()
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents: []string{"codex", "claude"},
+		},
+	}
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+}
+
+func TestLogPerPhaseModelMatrix_BothEmpty_GracefulDegrade(t *testing.T) {
+	// Pathological empty config: must not panic. A real run would already have
+	// aborted in buildPhaseAgents, but logging runs defensively.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logPerPhaseModelMatrix panicked: %v", r)
+		}
+	}()
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:     nil,
+			ArchReviewerAgent:  "",
+			DiffReviewerAgents: nil,
+		},
+	}
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+}
+
+// --- logCrossCheckModelMatrix tests ---
+//
+// Round-14 F#1 (案 A): logCrossCheckModelMatrix mirrors logPerPhaseModelMatrix
+// for the cross_check verbose row. Like its sibling, it runs only after the
+// grouped path is confirmed (sizeStr="large"), but defensive coding still
+// requires panic-safety on every reachable input path so a logging failure
+// never crashes a review. These tests pin the same invariants the Round-13
+// F#4 tests pinned for logPerPhaseModelMatrix.
+
+func TestLogCrossCheckModelMatrix_ResolveErrorEmitsWarningNoPanic(t *testing.T) {
+	// Empty top-level CrossCheckModel + empty models tree → resolve fails for
+	// every selected agent. Helper must emit a warning row and return cleanly.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logCrossCheckModelMatrix panicked: %v", r)
+		}
+	}()
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex",
+			CrossCheckModel:   "", // forces tree cascade
+			SummarizerAgent:   "codex",
+			Models:            config.ModelsConfig{}, // empty: no path resolves
+		},
+	}
+	logCrossCheckModelMatrix(terminal.NewLogger(), opts, "large")
+}
+
+func TestLogCrossCheckModelMatrix_AgentDefaultsToSummarizerWhenCrossCheckAgentEmpty(t *testing.T) {
+	// CrossCheckAgent unset must fall back to SummarizerAgent inside the
+	// resolver call from the log helper, mirroring runtime behaviour.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logCrossCheckModelMatrix panicked: %v", r)
+		}
+	}()
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "", // empty → use summarizer agent
+			SummarizerAgent:   "codex",
+			CrossCheckModel:   "gpt-5.4-mini",
+		},
+	}
+	logCrossCheckModelMatrix(terminal.NewLogger(), opts, "large")
+}
+
+func TestLogCrossCheckModelMatrix_EmitsOneRowPerResolvedAgent(t *testing.T) {
+	// Normal grouped-path scenario: all selected agents resolve from the
+	// agents tree. Helper must complete without panicking and produce one
+	// entry per agent (smoke-tested by simply observing no panic).
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("logCrossCheckModelMatrix panicked: %v", r)
+		}
+	}()
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex,claude",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			Models: config.ModelsConfig{
+				Agents: map[string]config.RoleModels{
+					"codex":  {CrossCheck: &config.ModelSpec{Model: "gpt-5.4-mini"}},
+					"claude": {CrossCheck: &config.ModelSpec{Model: "claude-opus-4-7"}},
+				},
+			},
+		},
+	}
+	logCrossCheckModelMatrix(terminal.NewLogger(), opts, "large")
 }

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -430,116 +430,99 @@ func TestReviewPipeline_CrossCheckUsesAggregatedIDs(t *testing.T) {
 
 // --- resolveCrossCheckAgents tests ---
 
-func TestResolveCrossCheckAgents_EmptyFallsBackToSummarizer(t *testing.T) {
-	opts := ReviewOpts{
-		ResolvedConfig: config.ResolvedConfig{
-			SummarizerAgent: "codex",
-			SummarizerModel: "gpt-5",
-			CrossCheckAgent: "",
-			CrossCheckModel: "",
-		},
+func TestResolveCrossCheckAgents_DisabledReturnsNil(t *testing.T) {
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{CrossCheckEnabled: false}}
+	names, models, err := resolveCrossCheckAgents(opts)
+	if err != nil {
+		t.Fatalf("disabled: unexpected error: %v", err)
 	}
-	names, model := resolveCrossCheckAgents(opts)
+	if names != nil || models != nil {
+		t.Errorf("disabled: expected nil names/models, got names=%v models=%v", names, models)
+	}
+}
+
+func TestResolveCrossCheckAgents_RequiresModel(t *testing.T) {
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex,claude",
+		CrossCheckModel:   "",
+	}}
+	_, _, err := resolveCrossCheckAgents(opts)
+	if err == nil {
+		t.Fatal("expected error when CrossCheckModel is empty")
+	}
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("error should mention required, got: %v", err)
+	}
+}
+
+func TestResolveCrossCheckAgents_PairsAgentsAndModels(t *testing.T) {
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex,claude,gemini",
+		CrossCheckModel:   "gpt-5,opus,gemini-pro",
+	}}
+	names, models, err := resolveCrossCheckAgents(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 3 || len(models) != 3 {
+		t.Fatalf("expected 3 agents and 3 models, got names=%v models=%v", names, models)
+	}
+	if names[0] != "codex" || models[0] != "gpt-5" {
+		t.Errorf("expected pair[0]=(codex,gpt-5), got (%s,%s)", names[0], models[0])
+	}
+	if names[1] != "claude" || models[1] != "opus" {
+		t.Errorf("expected pair[1]=(claude,opus), got (%s,%s)", names[1], models[1])
+	}
+	if names[2] != "gemini" || models[2] != "gemini-pro" {
+		t.Errorf("expected pair[2]=(gemini,gemini-pro), got (%s,%s)", names[2], models[2])
+	}
+}
+
+func TestResolveCrossCheckAgents_RejectsCountMismatch(t *testing.T) {
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex,claude,gemini",
+		CrossCheckModel:   "gpt-5,opus",
+	}}
+	_, _, err := resolveCrossCheckAgents(opts)
+	if err == nil {
+		t.Fatal("expected error when agent count != model count")
+	}
+	if !strings.Contains(err.Error(), "same count") {
+		t.Errorf("error should mention count mismatch, got: %v", err)
+	}
+}
+
+func TestResolveCrossCheckAgents_RejectsEmptyEntry(t *testing.T) {
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "codex,claude",
+		CrossCheckModel:   "gpt-5,",
+	}}
+	_, _, err := resolveCrossCheckAgents(opts)
+	if err == nil {
+		t.Fatal("expected error when CrossCheckModel has empty entry")
+	}
+}
+
+func TestResolveCrossCheckAgents_AgentDefaultsToSummarizer(t *testing.T) {
+	opts := ReviewOpts{ResolvedConfig: config.ResolvedConfig{
+		CrossCheckEnabled: true,
+		CrossCheckAgent:   "",
+		SummarizerAgent:   "codex",
+		CrossCheckModel:   "gpt-5",
+	}}
+	names, models, err := resolveCrossCheckAgents(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if len(names) != 1 || names[0] != "codex" {
-		t.Errorf("expected fallback to summarizer agent, got %v", names)
+		t.Errorf("expected default to codex (summarizer agent), got %v", names)
 	}
-	if model != "gpt-5" {
-		t.Errorf("expected fallback to summarizer model, got %q", model)
-	}
-}
-
-func TestResolveCrossCheckAgents_Explicit(t *testing.T) {
-	opts := ReviewOpts{
-		ResolvedConfig: config.ResolvedConfig{
-			SummarizerAgent: "codex",
-			SummarizerModel: "gpt-5",
-			CrossCheckAgent: "claude,gemini",
-			CrossCheckModel: "opus",
-		},
-	}
-	names, model := resolveCrossCheckAgents(opts)
-	if len(names) != 2 || names[0] != "claude" || names[1] != "gemini" {
-		t.Errorf("expected [claude gemini], got %v", names)
-	}
-	if model != "opus" {
-		t.Errorf("expected 'opus', got %q", model)
-	}
-}
-
-func TestResolveCrossCheckAgents_EmptyFallsBackToSummarizer_NonCodex(t *testing.T) {
-	// Verifies fallback when SummarizerAgent is a non-default value (e.g. "claude").
-	// Before the fix, ParseAgentNames("") returned ["codex"] regardless.
-	opts := ReviewOpts{
-		ResolvedConfig: config.ResolvedConfig{
-			SummarizerAgent: "claude",
-			SummarizerModel: "opus",
-			CrossCheckAgent: "",
-			CrossCheckModel: "",
-		},
-	}
-	names, model := resolveCrossCheckAgents(opts)
-	if len(names) != 1 || names[0] != "claude" {
-		t.Errorf("expected fallback to summarizer agent [claude], got %v", names)
-	}
-	if model != "opus" {
-		t.Errorf("expected fallback to summarizer model 'opus', got %q", model)
-	}
-}
-
-func TestResolveCrossCheckAgents_EmptyFallsBackToSummarizerMultiValue(t *testing.T) {
-	// Verifies comma-separated SummarizerAgent is preserved when CrossCheckAgent is empty.
-	opts := ReviewOpts{
-		ResolvedConfig: config.ResolvedConfig{
-			SummarizerAgent: "codex,claude",
-			SummarizerModel: "gpt-5",
-			CrossCheckAgent: "",
-			CrossCheckModel: "",
-		},
-	}
-	names, model := resolveCrossCheckAgents(opts)
-	if len(names) != 2 || names[0] != "codex" || names[1] != "claude" {
-		t.Errorf("expected [codex claude], got %v", names)
-	}
-	if model != "gpt-5" {
-		t.Errorf("expected 'gpt-5', got %q", model)
-	}
-}
-
-func TestResolveCrossCheckAgents_ExplicitOverridesSummarizer(t *testing.T) {
-	// Verifies that a non-empty CrossCheckAgent takes precedence over SummarizerAgent.
-	opts := ReviewOpts{
-		ResolvedConfig: config.ResolvedConfig{
-			SummarizerAgent: "claude",
-			SummarizerModel: "opus",
-			CrossCheckAgent: "gemini",
-			CrossCheckModel: "",
-		},
-	}
-	names, model := resolveCrossCheckAgents(opts)
-	if len(names) != 1 || names[0] != "gemini" {
-		t.Errorf("expected [gemini], got %v", names)
-	}
-	if model != "opus" {
-		t.Errorf("expected model fallback to summarizer 'opus', got %q", model)
-	}
-}
-
-func TestResolveCrossCheckAgents_WhitespaceFallsBack(t *testing.T) {
-	// Verifies that a whitespace-only CrossCheckAgent is treated as unset.
-	opts := ReviewOpts{
-		ResolvedConfig: config.ResolvedConfig{
-			SummarizerAgent: "claude",
-			SummarizerModel: "sonnet",
-			CrossCheckAgent: "   ",
-			CrossCheckModel: "",
-		},
-	}
-	names, model := resolveCrossCheckAgents(opts)
-	if len(names) != 1 || names[0] != "claude" {
-		t.Errorf("expected fallback to [claude], got %v", names)
-	}
-	if model != "sonnet" {
-		t.Errorf("expected fallback to 'sonnet', got %q", model)
+	if len(models) != 1 || models[0] != "gpt-5" {
+		t.Errorf("expected single model, got %v", models)
 	}
 }
 
@@ -664,9 +647,9 @@ func TestBuildCrossCheckContext_UsesSpecReviewerID(t *testing.T) {
 	}
 	aggregated := domain.AggregateFindings(rawFindings)
 	results := []domain.ReviewerResult{
-		{ReviewerID: 3, ExitCode: 0, Findings: []domain.Finding{rawFindings[0]}}, // arch succeeded
-		{ReviewerID: 5, ExitCode: 0, Findings: []domain.Finding{rawFindings[1]}}, // g01 succeeded
-		{ReviewerID: 7, ExitCode: -1, TimedOut: true},                            // g02 timed out
+		{ReviewerID: 3, ExitCode: 0, Findings: []domain.Finding{rawFindings[0]}},  // arch succeeded
+		{ReviewerID: 5, ExitCode: 0, Findings: []domain.Finding{rawFindings[1]}},  // g01 succeeded
+		{ReviewerID: 7, ExitCode: -1, TimedOut: true},                              // g02 timed out
 	}
 
 	ccCtx := buildCrossCheckContext(aggregated, specs, results)
@@ -741,7 +724,7 @@ func TestReviewGate_NoFindings_AllAdvisory_StillLGTM(t *testing.T) {
 }
 
 // TestReviewGate_GroupedFindingsOnly_NotLGTM: grouped has findings (no cc) →
-// gate must return false (existing behavior preserved).
+// gate must return false (existing behaviour preserved).
 func TestReviewGate_GroupedFindingsOnly_NotLGTM(t *testing.T) {
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{
@@ -1107,7 +1090,10 @@ func TestNoAutoPhase_ProducesFlatPath_WithVerdict(t *testing.T) {
 // only for testing; the production path lives at cmd/acr/review.go:~420.
 func computeVerdictWithCCSignals(g *domain.GroupedFindings, cc *summarizer.CrossCheckResult) {
 	ccBlocking := cc.HasBlockingFindings()
-	ccAdvisory := cc != nil && !ccBlocking && (cc.HasAdvisoryFindings() || cc.IsDegraded())
+	ccAdvisory := false
+	if cc != nil && !ccBlocking && (cc.HasAdvisoryFindings() || cc.IsDegraded()) {
+		ccAdvisory = true
+	}
 	g.ComputeVerdict(ccBlocking, ccAdvisory)
 }
 

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -789,7 +789,7 @@ func TestReviewGate_NoFindings_AllAdvisory_StillLGTM(t *testing.T) {
 }
 
 // TestReviewGate_GroupedFindingsOnly_NotLGTM: grouped has findings (no cc) →
-// gate must return false (existing behaviour preserved).
+// gate must return false (existing behavior preserved).
 func TestReviewGate_GroupedFindingsOnly_NotLGTM(t *testing.T) {
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{
@@ -1175,10 +1175,7 @@ func TestNoAutoPhase_ProducesFlatPath_WithVerdict(t *testing.T) {
 // only for testing; the production path lives at cmd/acr/review.go:~420.
 func computeVerdictWithCCSignals(g *domain.GroupedFindings, cc *summarizer.CrossCheckResult) {
 	ccBlocking := cc.HasBlockingFindings()
-	ccAdvisory := false
-	if cc != nil && !ccBlocking && (cc.HasAdvisoryFindings() || cc.IsDegraded()) {
-		ccAdvisory = true
-	}
+	ccAdvisory := cc != nil && !ccBlocking && (cc.HasAdvisoryFindings() || cc.IsDegraded())
 	g.ComputeVerdict(ccBlocking, ccAdvisory)
 }
 
@@ -1445,7 +1442,7 @@ func TestLogCrossCheckModelMatrix_ResolveErrorEmitsWarningNoPanic(t *testing.T) 
 
 func TestLogCrossCheckModelMatrix_AgentDefaultsToSummarizerWhenCrossCheckAgentEmpty(t *testing.T) {
 	// CrossCheckAgent unset must fall back to SummarizerAgent inside the
-	// resolver call from the log helper, mirroring runtime behaviour.
+	// resolver call from the log helper, mirroring runtime behavior.
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("logCrossCheckModelMatrix panicked: %v", r)

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -267,17 +267,20 @@ func TestBuildGroupedDiffSpecs_FallbackOnError(t *testing.T) {
 }
 
 // --- resolveAutoPhase tests ---
+//
+// Signature: resolveAutoPhase(size, diff, guidance, diffPrecomputed,
+//   archAgent, diffAgents, diffGroups, mediumDiffReviewers)
 
 func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
-	// Large diff with enough reviewers → grouped specs
+	// Large diff with diff_groups=3 → grouped specs
 	sections := makeSectionsForReview(12, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 3, fullDiff, "", true, agents[0], agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 3, 2)
 
 	if !apr.UseGrouped {
-		t.Fatal("expected UseGrouped=true for large diff with 3 reviewers")
+		t.Fatal("expected UseGrouped=true for large diff with diff_groups=3")
 	}
 	if apr.PhaseStr != "" {
 		t.Errorf("expected empty PhaseStr, got %q", apr.PhaseStr)
@@ -287,23 +290,11 @@ func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 	}
 }
 
-func TestAutoPhase_Large_FallbackTooFewReviewers(t *testing.T) {
-	// Large diff with reviewers=1 → fallback to arch,diff
-	apr := resolveAutoPhase(git.DiffSizeLarge, 1, "irrelevant", "", true, nil, nil)
-
-	if apr.UseGrouped {
-		t.Fatal("expected UseGrouped=false for reviewers=1")
-	}
-	if apr.PhaseStr != "arch,diff" {
-		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
-	}
-}
-
 func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 	// Large diff but empty diff content → buildGroupedDiffSpecs fails → fallback
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 3, "", "", true, agents[0], agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, "", "", true, agents[0], agents, 3, 2)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when buildGroupedDiffSpecs fails")
@@ -311,23 +302,8 @@ func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 	if apr.PhaseStr != "arch,diff" {
 		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
 	}
-}
-
-func TestAutoPhase_Large_MaxDiffGroupsClamped(t *testing.T) {
-	// reviewers=6 → maxDiffGroups should be clamped to 4 (not 5)
-	sections := makeSectionsForReview(20, 10)
-	fullDiff := git.JoinDiffSections(sections)
-	agents := []agent.Agent{agent.NewCodexAgent("")}
-
-	apr := resolveAutoPhase(git.DiffSizeLarge, 6, fullDiff, "", true, agents[0], agents)
-
-	if !apr.UseGrouped {
-		t.Fatal("expected UseGrouped=true")
-	}
-	// 1 arch + at most 4 diff groups = max 5 specs
-	diffGroupCount := len(apr.GroupedSpecs) - 1 // subtract arch
-	if diffGroupCount > 4 {
-		t.Errorf("expected at most 4 diff groups (clamped), got %d", diffGroupCount)
+	if apr.MediumDiffCount != 2 {
+		t.Errorf("expected MediumDiffCount=2 (from medium_diff_reviewers), got %d", apr.MediumDiffCount)
 	}
 }
 
@@ -528,69 +504,40 @@ func TestResolveCrossCheckAgents_AgentDefaultsToSummarizer(t *testing.T) {
 
 // --- resolveAutoPhase fallback-on-few-groups tests ---
 
-// TestResolveAutoPhase_AllGroupsEmpty_FallsBackToFlat covers the case where
-// buildGroupedDiffSpecs returns only the arch spec (0 diff groups) because
-// every group's JoinDiffSections produced an empty string.
-// We simulate this by passing a diff that parses to exactly 1 section
-// and maxDiffGroups=1: grouping yields one group, but we craft a scenario
-// where len(specs)-1 == 0.  The easiest reproducible path is reviewers=2
-// (maxDiffGroups=1) with a tiny single-file diff so grouping folds it into
-// one group, then assert diffGroupCount < 2 triggers the fallback.
-// In practice 0 diff groups only happens when every JoinDiffSections call
-// returns ""; that code path is already exercised by the guard in
-// buildGroupedDiffSpecs which uses continue on empty groupDiff.
-// This test validates the guard in resolveAutoPhase via an arch-only spec
-// slice crafted directly (testing the decision boundary, not the builder).
-func TestResolveAutoPhase_AllGroupsEmpty_FallsBackToFlat(t *testing.T) {
-	// A single-section diff with reviewers=2 → maxDiffGroups=1.
-	// buildGroupedDiffSpecs will produce 1 arch + 1 diff spec (diffGroupCount=1 < 2).
-	sections := makeSectionsForReview(1, 10)
-	fullDiff := git.JoinDiffSections(sections)
-	agents := []agent.Agent{agent.NewCodexAgent("")}
-
-	apr := resolveAutoPhase(git.DiffSizeLarge, 2, fullDiff, "", true, agents[0], agents)
-
-	if apr.UseGrouped {
-		t.Fatal("expected UseGrouped=false when diffGroupCount < 2")
-	}
-	if apr.PhaseStr != "arch,diff" {
-		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
-	}
-	if apr.FallbackReason == "" {
-		t.Error("expected non-empty FallbackReason")
-	}
-}
-
 // TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat verifies that exactly
-// 1 non-empty diff group (< 2) still triggers the fallback.
+// 1 non-empty diff group (< 2) still triggers the fallback. With
+// diff_groups=1 the file_count cap also kicks in early.
 func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
-	// 2 files, reviewers=2 → maxDiffGroups=1 → 1 diff group → fallback.
+	// 2 files, diff_groups=1 → file_count cap → effectiveGroups=1 → fallback.
 	sections := makeSectionsForReview(2, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 2, fullDiff, "", true, agents[0], agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 1, 2)
 
 	if apr.UseGrouped {
-		t.Fatal("expected UseGrouped=false for 1 diff group")
+		t.Fatal("expected UseGrouped=false for diff_groups=1")
 	}
 	if apr.PhaseStr != "arch,diff" {
 		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
 	}
 	if apr.FallbackReason == "" {
 		t.Error("expected non-empty FallbackReason")
+	}
+	if apr.MediumDiffCount != 2 {
+		t.Errorf("expected MediumDiffCount=2 from medium_diff_reviewers, got %d", apr.MediumDiffCount)
 	}
 }
 
 // TestResolveAutoPhase_TwoDiffGroups_KeepsGrouped verifies that 2 or more
 // non-empty diff groups result in UseGrouped=true (no fallback).
 func TestResolveAutoPhase_TwoDiffGroups_KeepsGrouped(t *testing.T) {
-	// 6 files, reviewers=3 → maxDiffGroups=2 → expect 2 diff groups.
+	// 6 files, diff_groups=2 → expect 2 diff groups.
 	sections := makeSectionsForReview(6, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 3, fullDiff, "", true, agents[0], agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 2, 2)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for 2+ diff groups")
@@ -610,9 +557,9 @@ func TestLargeReview_GroupedSpecsProduceCrossCheckableTopology(t *testing.T) {
 	sections := makeSectionsForReview(8, 5)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	apr := resolveAutoPhase(git.DiffSizeLarge, 4, fullDiff, "", true, agents[0], agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 3, 2)
 	if !apr.UseGrouped {
-		t.Fatal("expected UseGrouped=true for large diff with 4 reviewers")
+		t.Fatal("expected UseGrouped=true for large diff with diff_groups=3")
 	}
 	if apr.GroupedSpecs[0].GroupKey != "arch" {
 		t.Errorf("expected first spec GroupKey=arch, got %q", apr.GroupedSpecs[0].GroupKey)
@@ -928,103 +875,113 @@ func TestFlatPath_VerdictRendered(t *testing.T) {
 	}
 }
 
-// --- enforceReviewerBoundsForSize tests (CC#4) ---
+// --- New auto-phase knob tests (diff_groups / medium_diff_reviewers) ---
 
-func TestEnforceReviewerBounds_SmallUnchanged(t *testing.T) {
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeSmall, 1, 0)
-	if got != 1 {
-		t.Errorf("small: got %d, want 1", got)
-	}
-	if reason != "" {
-		t.Errorf("small: expected empty reason, got %q", reason)
-	}
-}
-
-func TestEnforceReviewerBounds_MediumOneBumpedToTwo(t *testing.T) {
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeMedium, 1, 0)
-	if got != 2 {
-		t.Errorf("medium+1 → want 2, got %d", got)
-	}
-	if reason == "" {
-		t.Error("medium+1: expected non-empty reason")
-	}
-}
-
-func TestEnforceReviewerBounds_MediumTwoUnchanged(t *testing.T) {
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeMedium, 2, 0)
-	if got != 2 {
-		t.Errorf("medium+2 → want 2, got %d", got)
-	}
-	if reason != "" {
-		t.Errorf("medium+2: expected empty reason, got %q", reason)
-	}
-}
-
-func TestEnforceReviewerBounds_LargeOneBumpedToThree(t *testing.T) {
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeLarge, 1, 5)
-	if got != 3 {
-		t.Errorf("large+1 → want 3, got %d", got)
-	}
-	if reason == "" {
-		t.Error("large+1: expected non-empty reason")
-	}
-}
-
-func TestEnforceReviewerBounds_LargeTwoBumpedToThree(t *testing.T) {
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeLarge, 2, 5)
-	if got != 3 {
-		t.Errorf("large+2 → want 3, got %d", got)
-	}
-	if reason == "" {
-		t.Error("large+2: expected non-empty reason")
-	}
-}
-
-func TestEnforceReviewerBounds_LargeThreeUnchanged(t *testing.T) {
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeLarge, 3, 5)
-	if got != 3 {
-		t.Errorf("large+3 → want 3, got %d", got)
-	}
-	if reason != "" {
-		t.Errorf("large+3: expected empty reason, got %q", reason)
-	}
-}
-
-func TestEnforceReviewerBounds_LargeClampedToFileCountPlusOne(t *testing.T) {
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeLarge, 15, 9)
-	if got != 10 {
-		t.Errorf("large+15/files=9 → want 10, got %d", got)
-	}
-	if !strings.Contains(reason, "clamp") {
-		t.Errorf("large clamp: expected reason to mention 'clamp', got %q", reason)
-	}
-}
-
-func TestEnforceReviewerBounds_LargeSmallFileCountDefaultsToFloor(t *testing.T) {
-	// upper = fileCount+1 = 2, below floor=3 → clamp back up to 3.
-	got, reason := enforceReviewerBoundsForSize(git.DiffSizeLarge, 10, 1)
-	if got != 3 {
-		t.Errorf("large+10/files=1 → want 3 (floor), got %d", got)
-	}
-	if reason == "" {
-		t.Error("large+10/files=1: expected non-empty reason")
-	}
-}
-
-// TestResolveAutoPhase_LargeReviewersOneTriggersOverride verifies that a large
-// diff with reviewers=1 sets ReviewerOverride=3 and records the bump reason.
-func TestResolveAutoPhase_LargeReviewersOneTriggersOverride(t *testing.T) {
-	sections := makeSectionsForReview(8, 10)
+// TestResolveAutoPhase_LargeUsesDiffGroupsKnob verifies that the diff_groups
+// knob caps the grouped diff path. With many files / lines the greedy packer
+// would normally produce > diffGroups groups; diffGroups=3 caps the result.
+func TestResolveAutoPhase_LargeUsesDiffGroupsKnob(t *testing.T) {
+	// 25 files × 50 lines (1250 lines, default 200/group) → ~7 groups
+	// without cap; diff_groups=3 caps to 3.
+	sections := makeSectionsForReview(25, 50)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 1, fullDiff, "", true, agents[0], agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 3, 2)
 
-	if apr.ReviewerOverride != 3 {
-		t.Errorf("expected ReviewerOverride=3, got %d", apr.ReviewerOverride)
+	if !apr.UseGrouped {
+		t.Fatalf("expected UseGrouped=true; FallbackReason=%q", apr.FallbackReason)
 	}
-	if !strings.Contains(apr.FallbackReason, "bumped from 1 to 3") {
-		t.Errorf("expected FallbackReason to include bump text, got %q", apr.FallbackReason)
+	diffGroupCount := len(apr.GroupedSpecs) - 1
+	if diffGroupCount > 3 {
+		t.Errorf("expected at most 3 diff groups (diff_groups=3 cap), got %d", diffGroupCount)
+	}
+	if diffGroupCount < 2 {
+		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
+	}
+}
+
+// TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall verifies
+// that when file_count<2 the grouped path is impossible and falls back to
+// arch,diff carrying medium_diff_reviewers as MediumDiffCount.
+func TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall(t *testing.T) {
+	// 1 file, diff_groups=4 → effectiveGroups=1 → fallback.
+	sections := makeSectionsForReview(1, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 4, 3)
+
+	if apr.UseGrouped {
+		t.Fatal("expected UseGrouped=false when fileCount<2")
+	}
+	if apr.PhaseStr != "arch,diff" {
+		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
+	}
+	if apr.MediumDiffCount != 3 {
+		t.Errorf("expected MediumDiffCount=3 (from medium_diff_reviewers), got %d", apr.MediumDiffCount)
+	}
+	if apr.FallbackReason == "" {
+		t.Error("expected non-empty FallbackReason")
+	}
+}
+
+// TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob verifies that medium
+// path returns arch,diff with MediumDiffCount=mediumDiffReviewers.
+func TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob(t *testing.T) {
+	apr := resolveAutoPhase(git.DiffSizeMedium, "", "", true, nil, nil, 4, 4)
+
+	if apr.UseGrouped {
+		t.Fatal("expected UseGrouped=false on medium")
+	}
+	if apr.PhaseStr != "arch,diff" {
+		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
+	}
+	if apr.MediumDiffCount != 4 {
+		t.Errorf("expected MediumDiffCount=4, got %d", apr.MediumDiffCount)
+	}
+}
+
+// TestResolveAutoPhase_LargeRespectsFileCountUpperBound verifies that
+// effectiveGroups = min(diffGroups, fileCount). With diff_groups>>fileCount
+// the cap is fileCount; the resulting group count never exceeds fileCount.
+func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
+	// 12 files (> default 5 files/group) so the greedy packer naturally
+	// produces multiple groups; diff_groups=10 is capped to fileCount=12.
+	// We assert the resulting count never exceeds fileCount and remains
+	// within the diff_groups cap.
+	sections := makeSectionsForReview(12, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	apr := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, agents[0], agents, 10, 2)
+
+	if !apr.UseGrouped {
+		t.Fatalf("expected UseGrouped=true with 12 files / diff_groups=10; FallbackReason=%q", apr.FallbackReason)
+	}
+	diffGroupCount := len(apr.GroupedSpecs) - 1
+	if diffGroupCount > 12 {
+		t.Errorf("expected diff group count capped at fileCount=12, got %d", diffGroupCount)
+	}
+	if diffGroupCount > 10 {
+		t.Errorf("expected diff group count capped at diff_groups=10, got %d", diffGroupCount)
+	}
+	if diffGroupCount < 2 {
+		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
+	}
+}
+
+// TestResolveAutoPhase_Small returns flat diff regardless of knobs.
+func TestResolveAutoPhase_Small(t *testing.T) {
+	apr := resolveAutoPhase(git.DiffSizeSmall, "irrelevant", "", true, nil, nil, 4, 2)
+	if apr.UseGrouped {
+		t.Errorf("expected UseGrouped=false for small")
+	}
+	if apr.PhaseStr != "diff" {
+		t.Errorf("expected PhaseStr 'diff', got %q", apr.PhaseStr)
+	}
+	if apr.MediumDiffCount != 0 {
+		t.Errorf("expected MediumDiffCount=0 on small, got %d", apr.MediumDiffCount)
 	}
 }
 

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1183,3 +1183,40 @@ func TestBuildGroupedDiffSpecs_DiffAgentRoundRobinIndependent(t *testing.T) {
 		t.Errorf("second diff spec should use diffAgents[1]=gemini, got %s", specs[2].Agent.Name())
 	}
 }
+
+func TestMaxPotentialReviewers(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.ResolvedConfig
+		want int
+	}{
+		{
+			name: "flat dominates",
+			cfg:  config.ResolvedConfig{Reviewers: 5, DiffGroups: 3, MediumDiffReviewers: 2},
+			want: 5, // max(5, 1+3, 1+2) = 5
+		},
+		{
+			name: "grouped dominates",
+			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 8, MediumDiffReviewers: 2},
+			want: 9, // max(3, 1+8, 1+2) = 9
+		},
+		{
+			name: "medium dominates",
+			cfg:  config.ResolvedConfig{Reviewers: 2, DiffGroups: 1, MediumDiffReviewers: 5},
+			want: 6, // max(2, 1+1, 1+5) = 6
+		},
+		{
+			name: "all equal",
+			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 2, MediumDiffReviewers: 2},
+			want: 3, // max(3, 1+2, 1+2) = 3
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maxPotentialReviewers(tt.cfg)
+			if got != tt.want {
+				t.Errorf("maxPotentialReviewers() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -151,7 +151,7 @@ func TestBuildGroupedDiffSpecs_BasicGroups(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents, 4)
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents[0], agents, 4)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestBuildGroupedDiffSpecs_GroupKeysAssigned(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents, 4)
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents[0], agents, 4)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestBuildGroupedDiffSpecs_TargetFilesSet(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents, 4)
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents[0], agents, 4)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestBuildGroupedDiffSpecs_RespectsMaxGroups(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents, 2)
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents[0], agents, 2)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestBuildGroupedDiffSpecs_SnapshotConsistency(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents, 4)
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents[0], agents, 4)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -260,7 +260,7 @@ func TestBuildGroupedDiffSpecs_SnapshotConsistency(t *testing.T) {
 
 func TestBuildGroupedDiffSpecs_FallbackOnError(t *testing.T) {
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	_, err := buildGroupedDiffSpecs("", "", true, agents, 4)
+	_, err := buildGroupedDiffSpecs("", "", true, agents[0], agents, 4)
 	if err == nil {
 		t.Fatal("expected error for empty diff, got nil")
 	}
@@ -274,7 +274,7 @@ func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 3, fullDiff, "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 3, fullDiff, "", true, agents[0], agents)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for large diff with 3 reviewers")
@@ -289,7 +289,7 @@ func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 
 func TestAutoPhase_Large_FallbackTooFewReviewers(t *testing.T) {
 	// Large diff with reviewers=1 → fallback to arch,diff
-	apr := resolveAutoPhase(git.DiffSizeLarge, 1, "irrelevant", "", true, nil)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 1, "irrelevant", "", true, nil, nil)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false for reviewers=1")
@@ -303,7 +303,7 @@ func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 	// Large diff but empty diff content → buildGroupedDiffSpecs fails → fallback
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 3, "", "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 3, "", "", true, agents[0], agents)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when buildGroupedDiffSpecs fails")
@@ -319,7 +319,7 @@ func TestAutoPhase_Large_MaxDiffGroupsClamped(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 6, fullDiff, "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 6, fullDiff, "", true, agents[0], agents)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true")
@@ -548,7 +548,7 @@ func TestResolveAutoPhase_AllGroupsEmpty_FallsBackToFlat(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 2, fullDiff, "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 2, fullDiff, "", true, agents[0], agents)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when diffGroupCount < 2")
@@ -569,7 +569,7 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 2, fullDiff, "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 2, fullDiff, "", true, agents[0], agents)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false for 1 diff group")
@@ -590,7 +590,7 @@ func TestResolveAutoPhase_TwoDiffGroups_KeepsGrouped(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 3, fullDiff, "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 3, fullDiff, "", true, agents[0], agents)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for 2+ diff groups")
@@ -610,7 +610,7 @@ func TestLargeReview_GroupedSpecsProduceCrossCheckableTopology(t *testing.T) {
 	sections := makeSectionsForReview(8, 5)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	apr := resolveAutoPhase(git.DiffSizeLarge, 4, fullDiff, "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 4, fullDiff, "", true, agents[0], agents)
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for large diff with 4 reviewers")
 	}
@@ -647,9 +647,9 @@ func TestBuildCrossCheckContext_UsesSpecReviewerID(t *testing.T) {
 	}
 	aggregated := domain.AggregateFindings(rawFindings)
 	results := []domain.ReviewerResult{
-		{ReviewerID: 3, ExitCode: 0, Findings: []domain.Finding{rawFindings[0]}},  // arch succeeded
-		{ReviewerID: 5, ExitCode: 0, Findings: []domain.Finding{rawFindings[1]}},  // g01 succeeded
-		{ReviewerID: 7, ExitCode: -1, TimedOut: true},                              // g02 timed out
+		{ReviewerID: 3, ExitCode: 0, Findings: []domain.Finding{rawFindings[0]}}, // arch succeeded
+		{ReviewerID: 5, ExitCode: 0, Findings: []domain.Finding{rawFindings[1]}}, // g01 succeeded
+		{ReviewerID: 7, ExitCode: -1, TimedOut: true},                            // g02 timed out
 	}
 
 	ccCtx := buildCrossCheckContext(aggregated, specs, results)
@@ -1018,7 +1018,7 @@ func TestResolveAutoPhase_LargeReviewersOneTriggersOverride(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr := resolveAutoPhase(git.DiffSizeLarge, 1, fullDiff, "", true, agents)
+	apr := resolveAutoPhase(git.DiffSizeLarge, 1, fullDiff, "", true, agents[0], agents)
 
 	if apr.ReviewerOverride != 3 {
 		t.Errorf("expected ReviewerOverride=3, got %d", apr.ReviewerOverride)
@@ -1030,13 +1030,16 @@ func TestResolveAutoPhase_LargeReviewersOneTriggersOverride(t *testing.T) {
 
 // TestBuildGroupedDiffSpecs_EmptyGroupsSkipped_IDsContiguous verifies that when
 // buildGroupedDiffSpecs skips empty groups, the surviving specs have contiguous
-// ReviewerIDs (1,2,3,...) and each spec's agent matches AgentForReviewer(id).
+// ReviewerIDs (1,2,3,...). Round-9 contract: specs[0] is the arch spec
+// (always archAgent); specs[1..] round-robin through diffAgents starting from
+// diffAgents[0] for the 1st surviving diff group.
 func TestBuildGroupedDiffSpecs_EmptyGroupsSkipped_IDsContiguous(t *testing.T) {
 	sections := makeSectionsForReview(6, 10)
 	fullDiff := git.JoinDiffSections(sections)
-	agents := []agent.Agent{agent.NewCodexAgent(""), agent.NewCodexAgent("")}
+	diffAgents := []agent.Agent{agent.NewCodexAgent(""), agent.NewCodexAgent("")}
+	archAgent := agent.NewCodexAgent("")
 
-	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, agents, 4)
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, archAgent, diffAgents, 4)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1047,9 +1050,16 @@ func TestBuildGroupedDiffSpecs_EmptyGroupsSkipped_IDsContiguous(t *testing.T) {
 		if s.ReviewerID != wantID {
 			t.Errorf("specs[%d].ReviewerID = %d, want %d", i, s.ReviewerID, wantID)
 		}
-		wantAgent := agent.AgentForReviewer(agents, wantID)
-		if s.Agent != wantAgent {
-			t.Errorf("specs[%d].Agent mismatch: ReviewerID=%d should map to AgentForReviewer(%d)", i, s.ReviewerID, wantID)
+	}
+	// Arch spec uses archAgent.
+	if specs[0].Agent != archAgent {
+		t.Errorf("specs[0].Agent mismatch: expected archAgent")
+	}
+	// Diff specs round-robin diffAgents starting at index 0.
+	for i := 1; i < len(specs); i++ {
+		want := agent.AgentForReviewer(diffAgents, i)
+		if specs[i].Agent != want {
+			t.Errorf("specs[%d].Agent mismatch: expected diffAgents[%d]", i, (i-1)%len(diffAgents))
 		}
 	}
 }
@@ -1149,5 +1159,70 @@ func TestComputeVerdict_CrossCheckBlockingBeatsDegraded(t *testing.T) {
 	computeVerdictWithCCSignals(g, cc)
 	if g.Verdict != "blocking" {
 		t.Errorf("blocking finding must take precedence over degraded, got %q", g.Verdict)
+	}
+}
+
+// --- Round-9: per-phase reviewer agent override tests ---
+
+// TestBuildGroupedDiffSpecs_UsesArchAndDiffAgents verifies that when a
+// distinct archAgent and diffAgents slice are supplied, the arch spec uses
+// archAgent and the diff specs round-robin through diffAgents independently
+// of archAgent.
+func TestBuildGroupedDiffSpecs_UsesArchAndDiffAgents(t *testing.T) {
+	sections := makeSectionsForReview(8, 10)
+	fullDiff := git.JoinDiffSections(sections)
+
+	archAgent := agent.NewClaudeAgent("")
+	diffAgent1 := agent.NewCodexAgent("")
+	diffAgent2 := agent.NewGeminiAgent("")
+	diffAgents := []agent.Agent{diffAgent1, diffAgent2}
+
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, archAgent, diffAgents, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) < 3 {
+		t.Fatalf("expected >=1 arch + 2 diff specs, got %d", len(specs))
+	}
+	if specs[0].Agent != archAgent {
+		t.Errorf("specs[0].Agent should be archAgent (claude), got %T name=%q", specs[0].Agent, specs[0].Agent.Name())
+	}
+	// Diff specs round-robin over diffAgents starting at index 0 (1-based reviewerIdx).
+	for i := 1; i < len(specs); i++ {
+		want := diffAgents[(i-1)%len(diffAgents)]
+		if specs[i].Agent != want {
+			t.Errorf("specs[%d].Agent = %s, want %s", i, specs[i].Agent.Name(), want.Name())
+		}
+	}
+}
+
+// TestBuildGroupedDiffSpecs_DiffAgentRoundRobinIndependent verifies that
+// the diff-phase round-robin starts from diffAgents[0] regardless of
+// archAgent identity (i.e. arch occupying ReviewerID=1 must not consume a
+// diff-agent slot).
+func TestBuildGroupedDiffSpecs_DiffAgentRoundRobinIndependent(t *testing.T) {
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+
+	archAgent := agent.NewClaudeAgent("")
+	diffAgent1 := agent.NewCodexAgent("")
+	diffAgent2 := agent.NewGeminiAgent("")
+	diffAgents := []agent.Agent{diffAgent1, diffAgent2}
+
+	specs, err := buildGroupedDiffSpecs(fullDiff, "", true, archAgent, diffAgents, 4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) < 3 {
+		t.Fatalf("expected >=3 specs, got %d", len(specs))
+	}
+	// First diff spec (index 1) MUST be diffAgents[0] = codex,
+	// not gemini (which would happen if reviewerID=2 was used directly with
+	// the round-robin).
+	if specs[1].Agent != diffAgent1 {
+		t.Errorf("first diff spec should use diffAgents[0]=codex, got %s", specs[1].Agent.Name())
+	}
+	if specs[2].Agent != diffAgent2 {
+		t.Errorf("second diff spec should use diffAgents[1]=gemini, got %s", specs[2].Agent.Name())
 	}
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -414,6 +414,10 @@ func TestConfigSubcommands(t *testing.T) {
 	})
 
 	t.Run("config validate", func(t *testing.T) {
+		// Round-9: cross_check.enabled defaults true and now requires a
+		// model. Supply via env so this test exercises the happy path it
+		// claims to cover, not the cross-check guard.
+		t.Setenv("ACR_CROSS_CHECK_MODEL", "test-cc-model")
 		_, _, exitCode := env.run("config", "validate")
 		if exitCode != 0 {
 			t.Errorf("exit code = %d, want 0", exitCode)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -130,8 +130,47 @@ func replaceEnvVar(env []string, key, value string) ([]string, bool) {
 	return env, true
 }
 
+// isReviewInvocation reports whether `args` invokes the default review path
+// (rather than a subcommand like `config show`). The default review path is
+// the only one that triggers cross-check validation. We classify by the first
+// token: if it starts with '-', it's a flag for the root command (review).
+// Otherwise it's a subcommand name (e.g., "config", "version").
+func isReviewInvocation(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	return strings.HasPrefix(args[0], "-")
+}
+
+// hasCrossCheckOverride reports whether the caller already supplied any
+// cross-check related flag, in which case `run` should leave the args alone.
+func hasCrossCheckOverride(args []string) bool {
+	for _, a := range args {
+		switch {
+		case a == "--no-cross-check":
+			return true
+		case a == "--cross-check-model" || a == "--cross-check-agent" || a == "--cross-check-timeout":
+			return true
+		case strings.HasPrefix(a, "--cross-check-model=") ||
+			strings.HasPrefix(a, "--cross-check-agent=") ||
+			strings.HasPrefix(a, "--cross-check-timeout="):
+			return true
+		}
+	}
+	return false
+}
+
 // run executes acr with the given args and returns stdout, stderr, and exit code.
+//
+// Cross-check is auto-disabled unless the caller already configured it via
+// --cross-check-* flags. Round-9 made --cross-check-model required when
+// cross-check is enabled (default on); these integration tests exercise the
+// review pipeline and not cross-check, so opting out keeps them working
+// without forcing every callsite to spell out a model list.
 func (e *testEnv) run(args ...string) (stdout, stderr string, exitCode int) {
+	if isReviewInvocation(args) && !hasCrossCheckOverride(args) {
+		args = append([]string{"--no-cross-check"}, args...)
+	}
 	cmd := exec.Command(e.acrBin, args...)
 	cmd.Dir = e.repoDir
 	cmd.Env = e.withMockAgents()
@@ -672,7 +711,7 @@ func TestMissingAgentCLI(t *testing.T) {
 	copyIntegrationHelperBinary(t, noAgentDir, "gemini")
 	copyIntegrationHelperBinary(t, noAgentDir, "gh")
 
-	cmd := exec.Command(env.acrBin, "--local", "--reviewer-agent", "codex",
+	cmd := exec.Command(env.acrBin, "--local", "--no-cross-check", "--reviewer-agent", "codex",
 		"--summarizer-agent", "codex", "--base", "HEAD~1")
 	cmd.Dir = env.repoDir
 	// Prepend noAgentDir to PATH so the helper binaries shadow any real CLIs.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -41,4 +41,9 @@ type Agent interface {
 	// The caller MUST call Close() on the result to ensure proper resource cleanup.
 	// After Close(), ExitCode() and Stderr() return valid values.
 	ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error)
+
+	// Options returns the AgentOptions the agent was constructed with.
+	// Used by callers (e.g., runner.BuildReviewerSpecs) to merge per-phase
+	// overrides with the agent's existing model/effort configuration.
+	Options() AgentOptions
 }

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -54,6 +54,11 @@ func (c *ClaudeAgent) Name() string {
 	return "claude"
 }
 
+// Options returns the AgentOptions the agent was constructed with.
+func (c *ClaudeAgent) Options() AgentOptions {
+	return AgentOptions{Model: c.model, Effort: c.effort}
+}
+
 // IsAvailable checks if the claude CLI is installed and accessible.
 func (c *ClaudeAgent) IsAvailable() error {
 	_, err := exec.LookPath("claude")

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -51,6 +51,11 @@ func (c *CodexAgent) Name() string {
 	return "codex"
 }
 
+// Options returns the AgentOptions the agent was constructed with.
+func (c *CodexAgent) Options() AgentOptions {
+	return AgentOptions{Model: c.model, Effort: c.effort}
+}
+
 // IsAvailable checks if the codex CLI is installed and accessible.
 func (c *CodexAgent) IsAvailable() error {
 	_, err := exec.LookPath("codex")

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -361,7 +361,7 @@ func TestCodexAgent_ExecuteReview_WithEffort(t *testing.T) {
 	}
 
 	// Regression guard for F#2 (Round-7): -c flag must precede the 'exec'
-	// subcommand for codex CLI to recognise the model_reasoning_effort
+	// subcommand for codex CLI to recognize the model_reasoning_effort
 	// override. Without ordering verification, an append-style bug like the
 	// claude.go --effort one (Round-8 #4) could silently regress.
 	args := parseHelperArgs(string(output))

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -360,12 +360,22 @@ func TestCodexAgent_ExecuteReview_WithEffort(t *testing.T) {
 		t.Fatalf("failed to read output: %v", err)
 	}
 
-	outputStr := string(output)
-	if !strings.Contains(outputStr, "-c") {
-		t.Errorf("expected -c in args, got:\n%s", outputStr)
+	// Regression guard for F#2 (Round-7): -c flag must precede the 'exec'
+	// subcommand for codex CLI to recognise the model_reasoning_effort
+	// override. Without ordering verification, an append-style bug like the
+	// claude.go --effort one (Round-8 #4) could silently regress.
+	args := parseHelperArgs(string(output))
+	iC := argIndex(args, "-c")
+	iValue := argIndex(args, "model_reasoning_effort=high")
+	iExec := argIndex(args, "exec")
+	if iC < 0 || iValue < 0 {
+		t.Fatalf("expected -c and model_reasoning_effort=high in args, got: %v", args)
 	}
-	if !strings.Contains(outputStr, "model_reasoning_effort=high") {
-		t.Errorf("expected model_reasoning_effort=high in args, got:\n%s", outputStr)
+	if iValue != iC+1 {
+		t.Errorf("expected 'model_reasoning_effort=high' immediately after -c, got args=%v", args)
+	}
+	if iExec < 0 || iC > iExec {
+		t.Errorf("-c (idx=%d) must precede 'exec' subcommand (idx=%d), got args=%v", iC, iExec, args)
 	}
 }
 
@@ -386,11 +396,23 @@ func TestCodexAgent_ExecuteSummary_WithEffort(t *testing.T) {
 		t.Fatalf("failed to read output: %v", err)
 	}
 
-	outputStr := string(output)
-	if !strings.Contains(outputStr, "-c") {
-		t.Errorf("expected -c in args, got:\n%s", outputStr)
+	// Regression guard (see TestCodexAgent_ExecuteReview_WithEffort):
+	// -c must precede 'exec' AND the positional '-' stdin marker.
+	args := parseHelperArgs(string(output))
+	iC := argIndex(args, "-c")
+	iValue := argIndex(args, "model_reasoning_effort=medium")
+	iExec := argIndex(args, "exec")
+	iDash := argIndex(args, "-")
+	if iC < 0 || iValue < 0 {
+		t.Fatalf("expected -c and model_reasoning_effort=medium in args, got: %v", args)
 	}
-	if !strings.Contains(outputStr, "model_reasoning_effort=medium") {
-		t.Errorf("expected model_reasoning_effort=medium in args, got:\n%s", outputStr)
+	if iValue != iC+1 {
+		t.Errorf("expected 'model_reasoning_effort=medium' immediately after -c, got args=%v", args)
+	}
+	if iExec < 0 || iC > iExec {
+		t.Errorf("-c (idx=%d) must precede 'exec' subcommand (idx=%d), got args=%v", iC, iExec, args)
+	}
+	if iDash < 0 || iC > iDash {
+		t.Errorf("-c (idx=%d) must precede positional '-' stdin marker (idx=%d), got args=%v", iC, iDash, args)
 	}
 }

--- a/internal/agent/cohort_test.go
+++ b/internal/agent/cohort_test.go
@@ -261,3 +261,5 @@ func (m *mockAgent) ExecuteReview(_ context.Context, _ *ReviewConfig) (*Executio
 func (m *mockAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*ExecutionResult, error) {
 	return nil, nil
 }
+
+func (m *mockAgent) Options() AgentOptions { return AgentOptions{} }

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -41,6 +41,11 @@ func (g *GeminiAgent) Name() string {
 	return "gemini"
 }
 
+// Options returns the AgentOptions the agent was constructed with.
+func (g *GeminiAgent) Options() AgentOptions {
+	return AgentOptions{Model: g.model, Effort: g.effort}
+}
+
 // IsAvailable checks if the gemini CLI is installed and accessible.
 func (g *GeminiAgent) IsAvailable() error {
 	_, err := exec.LookPath("gemini")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -600,6 +600,10 @@ func (r *ResolvedConfig) ValidateRuntime() []string {
 			}
 		}
 
+		// Fall back to SummarizerAgent when CrossCheckAgent is unset, mirroring
+		// resolveCrossCheckAgents. Note: config.Defaults always sets
+		// SummarizerAgent ("codex"), so the empty-string edge case
+		// (strings.Split("",",") → [""] → count 0) is unreachable in practice.
 		agentSpec := r.CrossCheckAgent
 		if strings.TrimSpace(agentSpec) == "" {
 			agentSpec = r.SummarizerAgent

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -566,10 +566,133 @@ func (r *ResolvedConfig) ValidateRuntime() []string {
 	// also disables auto-phase grouped review consistency), the user MUST pick
 	// a model. Defaults intentionally leaves CrossCheckModel empty so this
 	// guard fires for users who never configured cross-check at all.
+	//
+	// Exception: if the user has populated cross_check entries in the `models`
+	// tree (models.agents.*.cross_check / models.sizes.*.cross_check /
+	// models.defaults.cross_check), modelconfig.Resolve can produce a non-empty
+	// model at runtime for the selected agent(s), so the top-level legacy
+	// field is redundant. Round-13 F#3 tightens the check from "ANY tree
+	// entry exists" to "EVERY selected cross_check agent resolves", so partial
+	// tree configuration (one agent covered, others not) is caught at validate
+	// time rather than leaking through to runtime.
 	if r.CrossCheckEnabled && strings.TrimSpace(r.CrossCheckModel) == "" {
-		errs = append(errs, "cross_check.enabled=true requires cross_check.model (or --cross-check-model / ACR_CROSS_CHECK_MODEL); supply a comma-separated model list paired 1:1 with cross_check.agent, or disable cross-check explicitly with cross_check.enabled=false / --no-cross-check (note: disabling cross-check forfeits auto-phase grouped review consistency)")
+		missing := missingCrossCheckAgentsInModelsTree(r)
+		if len(missing) > 0 {
+			errs = append(errs, fmt.Sprintf(
+				"cross_check.enabled=true requires cross_check.model for agent(s) %v "+
+					"(supply via --cross-check-model / ACR_CROSS_CHECK_MODEL as a "+
+					"comma-separated list paired 1:1 with cross_check.agent, or via "+
+					"models.{agents.<name>,sizes.large,defaults}.cross_check.model "+
+					"— note: cross-check runs only at size=large, so sizes.small/medium "+
+					"entries are dead config and rejected); "+
+					"or disable cross-check explicitly with cross_check.enabled=false / "+
+					"--no-cross-check (note: disabling cross-check forfeits auto-phase "+
+					"grouped review consistency)",
+				missing))
+		}
+	}
+	// Additional cross_check pairing validation when model IS specified.
+	if r.CrossCheckEnabled && strings.TrimSpace(r.CrossCheckModel) != "" {
+		models := strings.Split(r.CrossCheckModel, ",")
+		for i, m := range models {
+			if strings.TrimSpace(m) == "" {
+				errs = append(errs, fmt.Sprintf("cross_check.model contains empty entry at position %d; check for leading/trailing/duplicate commas", i+1))
+			}
+		}
+
+		agentSpec := r.CrossCheckAgent
+		if strings.TrimSpace(agentSpec) == "" {
+			agentSpec = r.SummarizerAgent
+		}
+		agentTokens := strings.Split(agentSpec, ",")
+		agentCount := 0
+		for _, tok := range agentTokens {
+			if strings.TrimSpace(tok) != "" {
+				agentCount++
+			}
+		}
+		modelCount := 0
+		for _, m := range models {
+			if strings.TrimSpace(m) != "" {
+				modelCount++
+			}
+		}
+		if agentCount != modelCount {
+			errs = append(errs, fmt.Sprintf("cross_check.agent (%d agents) and cross_check.model (%d models) must have same count; agents and models are paired by position", agentCount, modelCount))
+		}
 	}
 	return errs
+}
+
+// canResolveCrossCheckModelForAgent reports whether the models cascade can
+// produce a non-empty cross_check.model for the given agentName.
+//
+// Round-14 F#1 (案 V): cross-check runs exclusively at size=large (gated by
+// `useGroupedSpecs && opts.CrossCheckEnabled` in cmd/acr/review.go, where
+// useGroupedSpecs=true is only reachable via DiffSizeLarge in resolveAutoPhase).
+// Therefore non-large size layers (sizes.small / sizes.medium) are dead code
+// for the cross_check role: configuring them never affects runtime resolution.
+// The validate-time check now mirrors this constraint by consulting only
+// sizes["large"], guaranteeing complete validate↔runtime symmetry.
+//
+// Cascade order mirrored from modelconfig.Resolve for RoleCrossCheck at
+// size=large:
+//  1. agents[name].cross_check.model  (agent-specific override)
+//  2. sizes["large"].cross_check.model (size-specific, large only)
+//  3. defaults.cross_check.model      (global default for the role)
+//
+// Effort-only entries are ignored: Effort alone never satisfies the runtime
+// requirement for a non-empty Model.
+func canResolveCrossCheckModelForAgent(m ModelsConfig, agentName string) bool {
+	// Layer 1: agents.
+	if rm, ok := m.Agents[agentName]; ok {
+		if rm.CrossCheck != nil && strings.TrimSpace(rm.CrossCheck.Model) != "" {
+			return true
+		}
+	}
+	// Layer 2: sizes["large"] only — cross-check runs exclusively at size=large.
+	// Other size layers (sizes.small / sizes.medium) are dead code for this role
+	// and intentionally rejected here so users get a clear validate-time error
+	// rather than a silent "validates OK but cross-check never runs".
+	if rm, ok := m.Sizes["large"]; ok {
+		if rm.CrossCheck != nil && strings.TrimSpace(rm.CrossCheck.Model) != "" {
+			return true
+		}
+	}
+	// Layer 3: defaults.
+	if m.Defaults.CrossCheck != nil && strings.TrimSpace(m.Defaults.CrossCheck.Model) != "" {
+		return true
+	}
+	return false
+}
+
+// missingCrossCheckAgentsInModelsTree returns the selected cross_check agent
+// names for which the models cascade cannot produce a non-empty cross_check
+// model. Empty slice means every selected agent is covered by the tree, in
+// which case the top-level cross_check.model requirement can be waived.
+//
+// Agent selection mirrors resolveCrossCheckAgents (runtime): CrossCheckAgent
+// takes precedence; empty falls back to SummarizerAgent. Whitespace-only
+// entries are skipped to match the runtime parser behaviour.
+//
+// Returns nil (not []) when no agents are selected, so callers can distinguish
+// "no selection yet" from "selection fully covered by tree".
+func missingCrossCheckAgentsInModelsTree(r *ResolvedConfig) []string {
+	agentSpec := r.CrossCheckAgent
+	if strings.TrimSpace(agentSpec) == "" {
+		agentSpec = r.SummarizerAgent
+	}
+	var missing []string
+	for _, raw := range strings.Split(agentSpec, ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if !canResolveCrossCheckModelForAgent(r.Models, name) {
+			missing = append(missing, name)
+		}
+	}
+	return missing
 }
 
 // validateModelsAgents checks that all agent keys in models.agents are supported agents.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,27 +85,35 @@ type ModelsConfig struct {
 }
 
 type Config struct {
-	Reviewers         *int             `yaml:"reviewers"`
-	Concurrency       *int             `yaml:"concurrency"`
-	Base              *string          `yaml:"base"`
-	Timeout           *Duration        `yaml:"timeout"`
-	Retries           *int             `yaml:"retries"`
-	Fetch             *bool            `yaml:"fetch"`
-	ReviewerAgent     *string          `yaml:"reviewer_agent"`
-	ReviewerAgents    []string         `yaml:"reviewer_agents"`
-	SummarizerAgent   *string          `yaml:"summarizer_agent"`
-	ReviewerModel     *string          `yaml:"reviewer_model"`
-	SummarizerModel   *string          `yaml:"summarizer_model"`
-	SummarizerTimeout *Duration        `yaml:"summarizer_timeout"`
-	FPFilterTimeout   *Duration        `yaml:"fp_filter_timeout"`
-	CrossCheckTimeout *Duration        `yaml:"cross_check_timeout"`
-	GuidanceFile      *string          `yaml:"guidance_file"`
-	AutoPhase         *bool            `yaml:"auto_phase"`
-	Filters           FilterConfig     `yaml:"filters"`
-	FPFilter          FPFilterConfig   `yaml:"fp_filter"`
-	PRFeedback        PRFeedbackConfig `yaml:"pr_feedback"`
-	CrossCheck        CrossCheckConfig `yaml:"cross_check"`
-	Models            ModelsConfig     `yaml:"models"`
+	Reviewers      *int      `yaml:"reviewers"`
+	Concurrency    *int      `yaml:"concurrency"`
+	Base           *string   `yaml:"base"`
+	Timeout        *Duration `yaml:"timeout"`
+	Retries        *int      `yaml:"retries"`
+	Fetch          *bool     `yaml:"fetch"`
+	ReviewerAgent  *string   `yaml:"reviewer_agent"`
+	ReviewerAgents []string  `yaml:"reviewer_agents"`
+	// ArchReviewerAgent is the optional per-phase override for the arch phase
+	// in auto-phase grouped diff. When unset (nil), it falls back to the first
+	// entry of ReviewerAgents.
+	ArchReviewerAgent *string `yaml:"arch_reviewer_agent"`
+	// DiffReviewerAgents is the optional per-phase override for the diff phase
+	// in auto-phase grouped diff (round-robin). When empty, it falls back to
+	// ReviewerAgents.
+	DiffReviewerAgents []string         `yaml:"diff_reviewer_agents"`
+	SummarizerAgent    *string          `yaml:"summarizer_agent"`
+	ReviewerModel      *string          `yaml:"reviewer_model"`
+	SummarizerModel    *string          `yaml:"summarizer_model"`
+	SummarizerTimeout  *Duration        `yaml:"summarizer_timeout"`
+	FPFilterTimeout    *Duration        `yaml:"fp_filter_timeout"`
+	CrossCheckTimeout  *Duration        `yaml:"cross_check_timeout"`
+	GuidanceFile       *string          `yaml:"guidance_file"`
+	AutoPhase          *bool            `yaml:"auto_phase"`
+	Filters            FilterConfig     `yaml:"filters"`
+	FPFilter           FPFilterConfig   `yaml:"fp_filter"`
+	PRFeedback         PRFeedbackConfig `yaml:"pr_feedback"`
+	CrossCheck         CrossCheckConfig `yaml:"cross_check"`
+	Models             ModelsConfig     `yaml:"models"`
 }
 
 // CrossCheckConfig holds cross-check verification settings.
@@ -213,7 +221,7 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
+var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
@@ -498,6 +506,18 @@ func (r *ResolvedConfig) ValidateAll() []string {
 			errs = append(errs, fmt.Sprintf("reviewer_agents contains unsupported agent %q, must be one of %v", a, agent.SupportedAgents))
 		}
 	}
+	// arch_reviewer_agent is optional; empty string means fall back to
+	// ReviewerAgents[0]. When set, it must be a supported agent.
+	if r.ArchReviewerAgent != "" && !slices.Contains(agent.SupportedAgents, r.ArchReviewerAgent) {
+		errs = append(errs, fmt.Sprintf("arch_reviewer_agent must be one of %v, got %q", agent.SupportedAgents, r.ArchReviewerAgent))
+	}
+	// diff_reviewer_agents is optional; empty list means fall back to
+	// ReviewerAgents. When set, every entry must be a supported agent.
+	for _, a := range r.DiffReviewerAgents {
+		if !slices.Contains(agent.SupportedAgents, a) {
+			errs = append(errs, fmt.Sprintf("diff_reviewer_agents contains unsupported agent %q, must be one of %v", a, agent.SupportedAgents))
+		}
+	}
 	if !slices.Contains(agent.SupportedAgents, r.SummarizerAgent) {
 		errs = append(errs, fmt.Sprintf("summarizer_agent must be one of %v, got %q", agent.SupportedAgents, r.SummarizerAgent))
 	}
@@ -521,6 +541,25 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	}
 	if r.CrossCheckTimeout <= 0 {
 		errs = append(errs, fmt.Sprintf("cross_check_timeout must be > 0, got %s", r.CrossCheckTimeout))
+	}
+	return errs
+}
+
+// ValidateRuntime returns errors that should only be enforced once all
+// configuration sources (config file + env + CLI flags) have been merged into
+// the final ResolvedConfig. Unlike ValidateAll (which is also invoked during
+// YAML parse, where only the file + Defaults are visible), these checks would
+// produce false positives for users who legitimately supply the value through
+// env or CLI. main.go calls this immediately after Resolve(); config validate
+// invokes it as well so users get the same fail-fast behavior interactively.
+func (r *ResolvedConfig) ValidateRuntime() []string {
+	var errs []string
+	// Round-9 contract: when cross-check is enabled (the default; disabling it
+	// also disables auto-phase grouped review consistency), the user MUST pick
+	// a model. Defaults intentionally leaves CrossCheckModel empty so this
+	// guard fires for users who never configured cross-check at all.
+	if r.CrossCheckEnabled && strings.TrimSpace(r.CrossCheckModel) == "" {
+		errs = append(errs, "cross_check.enabled=true requires cross_check.model (or --cross-check-model / ACR_CROSS_CHECK_MODEL); supply a comma-separated model list paired 1:1 with cross_check.agent, or disable cross-check explicitly with cross_check.enabled=false / --no-cross-check (note: disabling cross-check forfeits auto-phase grouped review consistency)")
 	}
 	return errs
 }
@@ -641,30 +680,38 @@ var Defaults = ResolvedConfig{
 }
 
 type ResolvedConfig struct {
-	Reviewers         int
-	Concurrency       int
-	Base              string
-	Timeout           time.Duration
-	Retries           int
-	Fetch             bool
-	ReviewerAgents    []string
-	SummarizerAgent   string
-	ReviewerModel     string
-	SummarizerModel   string
-	SummarizerTimeout time.Duration
-	FPFilterTimeout   time.Duration
-	CrossCheckTimeout time.Duration
-	Guidance          string
-	GuidanceFile      string
-	FPFilterEnabled   bool
-	FPThreshold       int
-	PRFeedbackEnabled bool
-	PRFeedbackAgent   string
-	CrossCheckEnabled bool
-	CrossCheckAgent   string // empty means use summarizer agent
-	CrossCheckModel   string // empty means use summarizer model
-	AutoPhase         bool
-	Strict            bool // when true, advisory verdict exits 1 (default false)
+	Reviewers      int
+	Concurrency    int
+	Base           string
+	Timeout        time.Duration
+	Retries        int
+	Fetch          bool
+	ReviewerAgents []string
+	// ArchReviewerAgent is the per-phase override for the arch phase in
+	// auto-phase grouped diff. Empty string means fall back to the first
+	// entry of ReviewerAgents.
+	ArchReviewerAgent string
+	// DiffReviewerAgents is the per-phase override for the diff phase in
+	// auto-phase grouped diff (round-robin). Empty slice means fall back to
+	// ReviewerAgents.
+	DiffReviewerAgents []string
+	SummarizerAgent    string
+	ReviewerModel      string
+	SummarizerModel    string
+	SummarizerTimeout  time.Duration
+	FPFilterTimeout    time.Duration
+	CrossCheckTimeout  time.Duration
+	Guidance           string
+	GuidanceFile       string
+	FPFilterEnabled    bool
+	FPThreshold        int
+	PRFeedbackEnabled  bool
+	PRFeedbackAgent    string
+	CrossCheckEnabled  bool
+	CrossCheckAgent    string // empty means use summarizer agent
+	CrossCheckModel    string // empty means use summarizer model
+	AutoPhase          bool
+	Strict             bool // when true, advisory verdict exits 1 (default false)
 	// ReviewerModelFromCLI is true when --reviewer-model or ACR_REVIEWER_MODEL
 	// set the ReviewerModel field, making it a CLI/env override that should win
 	// over models.agents/sizes/defaults config.
@@ -675,81 +722,87 @@ type ResolvedConfig struct {
 }
 
 type FlagState struct {
-	ReviewersSet         bool
-	ConcurrencySet       bool
-	BaseSet              bool
-	TimeoutSet           bool
-	RetriesSet           bool
-	FetchSet             bool
-	ReviewerAgentsSet    bool
-	SummarizerAgentSet   bool
-	ReviewerModelSet     bool
-	SummarizerModelSet   bool
-	SummarizerTimeoutSet bool
-	FPFilterTimeoutSet   bool
-	CrossCheckTimeoutSet bool
-	GuidanceSet          bool
-	GuidanceFileSet      bool
-	NoFPFilterSet        bool
-	FPThresholdSet       bool
-	NoPRFeedbackSet      bool
-	PRFeedbackAgentSet   bool
-	NoCrossCheckSet      bool
-	CrossCheckAgentSet   bool
-	CrossCheckModelSet   bool
-	AutoPhaseSet         bool
-	StrictSet            bool
+	ReviewersSet          bool
+	ConcurrencySet        bool
+	BaseSet               bool
+	TimeoutSet            bool
+	RetriesSet            bool
+	FetchSet              bool
+	ReviewerAgentsSet     bool
+	ArchReviewerAgentSet  bool
+	DiffReviewerAgentsSet bool
+	SummarizerAgentSet    bool
+	ReviewerModelSet      bool
+	SummarizerModelSet    bool
+	SummarizerTimeoutSet  bool
+	FPFilterTimeoutSet    bool
+	CrossCheckTimeoutSet  bool
+	GuidanceSet           bool
+	GuidanceFileSet       bool
+	NoFPFilterSet         bool
+	FPThresholdSet        bool
+	NoPRFeedbackSet       bool
+	PRFeedbackAgentSet    bool
+	NoCrossCheckSet       bool
+	CrossCheckAgentSet    bool
+	CrossCheckModelSet    bool
+	AutoPhaseSet          bool
+	StrictSet             bool
 }
 
 type EnvState struct {
-	Reviewers            int
-	ReviewersSet         bool
-	Concurrency          int
-	ConcurrencySet       bool
-	Base                 string
-	BaseSet              bool
-	Timeout              time.Duration
-	TimeoutSet           bool
-	Retries              int
-	RetriesSet           bool
-	Fetch                bool
-	FetchSet             bool
-	ReviewerAgents       []string
-	ReviewerAgentsSet    bool
-	SummarizerAgent      string
-	SummarizerAgentSet   bool
-	ReviewerModel        string
-	ReviewerModelSet     bool
-	SummarizerModel      string
-	SummarizerModelSet   bool
-	SummarizerTimeout    time.Duration
-	SummarizerTimeoutSet bool
-	FPFilterTimeout      time.Duration
-	FPFilterTimeoutSet   bool
-	Guidance             string
-	GuidanceSet          bool
-	GuidanceFile         string
-	GuidanceFileSet      bool
-	FPFilterEnabled      bool
-	FPFilterSet          bool
-	FPThreshold          int
-	FPThresholdSet       bool
-	PRFeedbackEnabled    bool
-	PRFeedbackEnabledSet bool
-	PRFeedbackAgent      string
-	PRFeedbackAgentSet   bool
-	CrossCheckEnabled    bool
-	CrossCheckEnabledSet bool
-	CrossCheckAgent      string
-	CrossCheckAgentSet   bool
-	CrossCheckModel      string
-	CrossCheckModelSet   bool
-	CrossCheckTimeout    time.Duration
-	CrossCheckTimeoutSet bool
-	AutoPhase            bool
-	AutoPhaseSet         bool
-	Strict               bool
-	StrictSet            bool
+	Reviewers             int
+	ReviewersSet          bool
+	Concurrency           int
+	ConcurrencySet        bool
+	Base                  string
+	BaseSet               bool
+	Timeout               time.Duration
+	TimeoutSet            bool
+	Retries               int
+	RetriesSet            bool
+	Fetch                 bool
+	FetchSet              bool
+	ReviewerAgents        []string
+	ReviewerAgentsSet     bool
+	ArchReviewerAgent     string
+	ArchReviewerAgentSet  bool
+	DiffReviewerAgents    []string
+	DiffReviewerAgentsSet bool
+	SummarizerAgent       string
+	SummarizerAgentSet    bool
+	ReviewerModel         string
+	ReviewerModelSet      bool
+	SummarizerModel       string
+	SummarizerModelSet    bool
+	SummarizerTimeout     time.Duration
+	SummarizerTimeoutSet  bool
+	FPFilterTimeout       time.Duration
+	FPFilterTimeoutSet    bool
+	Guidance              string
+	GuidanceSet           bool
+	GuidanceFile          string
+	GuidanceFileSet       bool
+	FPFilterEnabled       bool
+	FPFilterSet           bool
+	FPThreshold           int
+	FPThresholdSet        bool
+	PRFeedbackEnabled     bool
+	PRFeedbackEnabledSet  bool
+	PRFeedbackAgent       string
+	PRFeedbackAgentSet    bool
+	CrossCheckEnabled     bool
+	CrossCheckEnabledSet  bool
+	CrossCheckAgent       string
+	CrossCheckAgentSet    bool
+	CrossCheckModel       string
+	CrossCheckModelSet    bool
+	CrossCheckTimeout     time.Duration
+	CrossCheckTimeoutSet  bool
+	AutoPhase             bool
+	AutoPhaseSet          bool
+	Strict                bool
+	StrictSet             bool
 }
 
 // LoadEnvState reads environment variables and returns their state.
@@ -813,6 +866,16 @@ func LoadEnvState() (EnvState, []string) {
 		if agents := parseCommaSeparated(v); agents != nil {
 			state.ReviewerAgents = agents
 			state.ReviewerAgentsSet = true
+		}
+	}
+	if v := os.Getenv("ACR_ARCH_REVIEWER_AGENT"); v != "" {
+		state.ArchReviewerAgent = strings.TrimSpace(v)
+		state.ArchReviewerAgentSet = true
+	}
+	if v := os.Getenv("ACR_DIFF_REVIEWER_AGENTS"); v != "" {
+		if agents := parseCommaSeparated(v); agents != nil {
+			state.DiffReviewerAgents = agents
+			state.DiffReviewerAgentsSet = true
 		}
 	}
 	if v := os.Getenv("ACR_SUMMARIZER_AGENT"); v != "" {
@@ -995,6 +1058,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		} else if cfg.ReviewerAgent != nil {
 			result.ReviewerAgents = []string{*cfg.ReviewerAgent}
 		}
+		if cfg.ArchReviewerAgent != nil {
+			result.ArchReviewerAgent = *cfg.ArchReviewerAgent
+		}
+		if len(cfg.DiffReviewerAgents) > 0 {
+			result.DiffReviewerAgents = cfg.DiffReviewerAgents
+		}
 		if cfg.SummarizerAgent != nil {
 			result.SummarizerAgent = *cfg.SummarizerAgent
 		}
@@ -1063,6 +1132,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if envState.ReviewerAgentsSet {
 		result.ReviewerAgents = envState.ReviewerAgents
 	}
+	if envState.ArchReviewerAgentSet {
+		result.ArchReviewerAgent = envState.ArchReviewerAgent
+	}
+	if envState.DiffReviewerAgentsSet {
+		result.DiffReviewerAgents = envState.DiffReviewerAgents
+	}
 	if envState.SummarizerAgentSet {
 		result.SummarizerAgent = envState.SummarizerAgent
 	}
@@ -1129,6 +1204,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	}
 	if flagState.ReviewerAgentsSet {
 		result.ReviewerAgents = flagValues.ReviewerAgents
+	}
+	if flagState.ArchReviewerAgentSet {
+		result.ArchReviewerAgent = flagValues.ArchReviewerAgent
+	}
+	if flagState.DiffReviewerAgentsSet {
+		result.DiffReviewerAgents = flagValues.DiffReviewerAgents
 	}
 	if flagState.SummarizerAgentSet {
 		result.SummarizerAgent = flagValues.SummarizerAgent

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -608,13 +608,7 @@ func (r *ResolvedConfig) ValidateRuntime() []string {
 		if strings.TrimSpace(agentSpec) == "" {
 			agentSpec = r.SummarizerAgent
 		}
-		agentTokens := strings.Split(agentSpec, ",")
-		agentCount := 0
-		for _, tok := range agentTokens {
-			if strings.TrimSpace(tok) != "" {
-				agentCount++
-			}
-		}
+		agentCount := len(agent.ParseAgentNames(agentSpec))
 		modelCount := 0
 		for _, m := range models {
 			if strings.TrimSpace(m) != "" {
@@ -676,22 +670,20 @@ func canResolveCrossCheckModelForAgent(m ModelsConfig, agentName string) bool {
 // which case the top-level cross_check.model requirement can be waived.
 //
 // Agent selection mirrors resolveCrossCheckAgents (runtime): CrossCheckAgent
-// takes precedence; empty falls back to SummarizerAgent. Whitespace-only
-// entries are skipped to match the runtime parser behaviour.
+// takes precedence; empty falls back to SummarizerAgent. Agent names are
+// resolved via agent.ParseAgentNames to match runtime behavior.
 //
-// Returns nil (not []) when no agents are selected, so callers can distinguish
-// "no selection yet" from "selection fully covered by tree".
+// When no selected agents are missing from the models tree, this function
+// returns nil. That includes both cases where no agents are selected and where
+// every selected agent is covered by the tree, so callers must not use the
+// nil result to distinguish between those states.
 func missingCrossCheckAgentsInModelsTree(r *ResolvedConfig) []string {
 	agentSpec := r.CrossCheckAgent
 	if strings.TrimSpace(agentSpec) == "" {
 		agentSpec = r.SummarizerAgent
 	}
 	var missing []string
-	for _, raw := range strings.Split(agentSpec, ",") {
-		name := strings.TrimSpace(raw)
-		if name == "" {
-			continue
-		}
+	for _, name := range agent.ParseAgentNames(agentSpec) {
 		if !canResolveCrossCheckModelForAgent(r.Models, name) {
 			missing = append(missing, name)
 		}
@@ -811,7 +803,7 @@ var Defaults = ResolvedConfig{
 	PRFeedbackAgent:     "", // empty means use summarizer agent
 	CrossCheckEnabled:   true,
 	CrossCheckAgent:     "", // empty means use summarizer agent
-	CrossCheckModel:     "", // empty means use summarizer model
+	CrossCheckModel:     "", // empty: must resolve via models config or ValidateRuntime will error
 	AutoPhase:           true,
 	Strict:              false,
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,14 +85,16 @@ type ModelsConfig struct {
 }
 
 type Config struct {
-	Reviewers      *int      `yaml:"reviewers"`
-	Concurrency    *int      `yaml:"concurrency"`
-	Base           *string   `yaml:"base"`
-	Timeout        *Duration `yaml:"timeout"`
-	Retries        *int      `yaml:"retries"`
-	Fetch          *bool     `yaml:"fetch"`
-	ReviewerAgent  *string   `yaml:"reviewer_agent"`
-	ReviewerAgents []string  `yaml:"reviewer_agents"`
+	Reviewers           *int      `yaml:"reviewers"`
+	DiffGroups          *int      `yaml:"diff_groups"`
+	MediumDiffReviewers *int      `yaml:"medium_diff_reviewers"`
+	Concurrency         *int      `yaml:"concurrency"`
+	Base                *string   `yaml:"base"`
+	Timeout             *Duration `yaml:"timeout"`
+	Retries             *int      `yaml:"retries"`
+	Fetch               *bool     `yaml:"fetch"`
+	ReviewerAgent       *string   `yaml:"reviewer_agent"`
+	ReviewerAgents      []string  `yaml:"reviewer_agents"`
 	// ArchReviewerAgent is the optional per-phase override for the arch phase
 	// in auto-phase grouped diff. When unset (nil), it falls back to the first
 	// entry of ReviewerAgents.
@@ -221,7 +223,7 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
+var knownTopLevelKeys = []string{"reviewers", "diff_groups", "medium_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
@@ -483,6 +485,12 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.Reviewers < 1 {
 		errs = append(errs, fmt.Sprintf("reviewers must be >= 1, got %d", r.Reviewers))
 	}
+	if r.DiffGroups < 1 {
+		errs = append(errs, fmt.Sprintf("diff_groups must be >= 1, got %d", r.DiffGroups))
+	}
+	if r.MediumDiffReviewers < 1 {
+		errs = append(errs, fmt.Sprintf("medium_diff_reviewers must be >= 1, got %d", r.MediumDiffReviewers))
+	}
 	if r.Concurrency < 0 {
 		errs = append(errs, fmt.Sprintf("concurrency must be >= 0, got %d", r.Concurrency))
 	}
@@ -657,36 +665,40 @@ func (r *ResolvedConfig) Validate() error {
 }
 
 var Defaults = ResolvedConfig{
-	Reviewers:         5,
-	Concurrency:       0,
-	Base:              "main",
-	Timeout:           10 * time.Minute,
-	Retries:           1,
-	Fetch:             true,
-	ReviewerAgents:    []string{agent.DefaultAgent},
-	SummarizerAgent:   agent.DefaultSummarizerAgent,
-	SummarizerTimeout: 5 * time.Minute,
-	FPFilterTimeout:   5 * time.Minute,
-	CrossCheckTimeout: 5 * time.Minute,
-	FPFilterEnabled:   true,
-	FPThreshold:       75,
-	PRFeedbackEnabled: true,
-	PRFeedbackAgent:   "", // empty means use summarizer agent
-	CrossCheckEnabled: true,
-	CrossCheckAgent:   "", // empty means use summarizer agent
-	CrossCheckModel:   "", // empty means use summarizer model
-	AutoPhase:         true,
-	Strict:            false,
+	Reviewers:           5,
+	DiffGroups:          4,
+	MediumDiffReviewers: 2,
+	Concurrency:         0,
+	Base:                "main",
+	Timeout:             10 * time.Minute,
+	Retries:             1,
+	Fetch:               true,
+	ReviewerAgents:      []string{agent.DefaultAgent},
+	SummarizerAgent:     agent.DefaultSummarizerAgent,
+	SummarizerTimeout:   5 * time.Minute,
+	FPFilterTimeout:     5 * time.Minute,
+	CrossCheckTimeout:   5 * time.Minute,
+	FPFilterEnabled:     true,
+	FPThreshold:         75,
+	PRFeedbackEnabled:   true,
+	PRFeedbackAgent:     "", // empty means use summarizer agent
+	CrossCheckEnabled:   true,
+	CrossCheckAgent:     "", // empty means use summarizer agent
+	CrossCheckModel:     "", // empty means use summarizer model
+	AutoPhase:           true,
+	Strict:              false,
 }
 
 type ResolvedConfig struct {
-	Reviewers      int
-	Concurrency    int
-	Base           string
-	Timeout        time.Duration
-	Retries        int
-	Fetch          bool
-	ReviewerAgents []string
+	Reviewers           int
+	DiffGroups          int
+	MediumDiffReviewers int
+	Concurrency         int
+	Base                string
+	Timeout             time.Duration
+	Retries             int
+	Fetch               bool
+	ReviewerAgents      []string
 	// ArchReviewerAgent is the per-phase override for the arch phase in
 	// auto-phase grouped diff. Empty string means fall back to the first
 	// entry of ReviewerAgents.
@@ -722,87 +734,93 @@ type ResolvedConfig struct {
 }
 
 type FlagState struct {
-	ReviewersSet          bool
-	ConcurrencySet        bool
-	BaseSet               bool
-	TimeoutSet            bool
-	RetriesSet            bool
-	FetchSet              bool
-	ReviewerAgentsSet     bool
-	ArchReviewerAgentSet  bool
-	DiffReviewerAgentsSet bool
-	SummarizerAgentSet    bool
-	ReviewerModelSet      bool
-	SummarizerModelSet    bool
-	SummarizerTimeoutSet  bool
-	FPFilterTimeoutSet    bool
-	CrossCheckTimeoutSet  bool
-	GuidanceSet           bool
-	GuidanceFileSet       bool
-	NoFPFilterSet         bool
-	FPThresholdSet        bool
-	NoPRFeedbackSet       bool
-	PRFeedbackAgentSet    bool
-	NoCrossCheckSet       bool
-	CrossCheckAgentSet    bool
-	CrossCheckModelSet    bool
-	AutoPhaseSet          bool
-	StrictSet             bool
+	ReviewersSet           bool
+	DiffGroupsSet          bool
+	MediumDiffReviewersSet bool
+	ConcurrencySet         bool
+	BaseSet                bool
+	TimeoutSet             bool
+	RetriesSet             bool
+	FetchSet               bool
+	ReviewerAgentsSet      bool
+	ArchReviewerAgentSet   bool
+	DiffReviewerAgentsSet  bool
+	SummarizerAgentSet     bool
+	ReviewerModelSet       bool
+	SummarizerModelSet     bool
+	SummarizerTimeoutSet   bool
+	FPFilterTimeoutSet     bool
+	CrossCheckTimeoutSet   bool
+	GuidanceSet            bool
+	GuidanceFileSet        bool
+	NoFPFilterSet          bool
+	FPThresholdSet         bool
+	NoPRFeedbackSet        bool
+	PRFeedbackAgentSet     bool
+	NoCrossCheckSet        bool
+	CrossCheckAgentSet     bool
+	CrossCheckModelSet     bool
+	AutoPhaseSet           bool
+	StrictSet              bool
 }
 
 type EnvState struct {
-	Reviewers             int
-	ReviewersSet          bool
-	Concurrency           int
-	ConcurrencySet        bool
-	Base                  string
-	BaseSet               bool
-	Timeout               time.Duration
-	TimeoutSet            bool
-	Retries               int
-	RetriesSet            bool
-	Fetch                 bool
-	FetchSet              bool
-	ReviewerAgents        []string
-	ReviewerAgentsSet     bool
-	ArchReviewerAgent     string
-	ArchReviewerAgentSet  bool
-	DiffReviewerAgents    []string
-	DiffReviewerAgentsSet bool
-	SummarizerAgent       string
-	SummarizerAgentSet    bool
-	ReviewerModel         string
-	ReviewerModelSet      bool
-	SummarizerModel       string
-	SummarizerModelSet    bool
-	SummarizerTimeout     time.Duration
-	SummarizerTimeoutSet  bool
-	FPFilterTimeout       time.Duration
-	FPFilterTimeoutSet    bool
-	Guidance              string
-	GuidanceSet           bool
-	GuidanceFile          string
-	GuidanceFileSet       bool
-	FPFilterEnabled       bool
-	FPFilterSet           bool
-	FPThreshold           int
-	FPThresholdSet        bool
-	PRFeedbackEnabled     bool
-	PRFeedbackEnabledSet  bool
-	PRFeedbackAgent       string
-	PRFeedbackAgentSet    bool
-	CrossCheckEnabled     bool
-	CrossCheckEnabledSet  bool
-	CrossCheckAgent       string
-	CrossCheckAgentSet    bool
-	CrossCheckModel       string
-	CrossCheckModelSet    bool
-	CrossCheckTimeout     time.Duration
-	CrossCheckTimeoutSet  bool
-	AutoPhase             bool
-	AutoPhaseSet          bool
-	Strict                bool
-	StrictSet             bool
+	Reviewers              int
+	ReviewersSet           bool
+	DiffGroups             int
+	DiffGroupsSet          bool
+	MediumDiffReviewers    int
+	MediumDiffReviewersSet bool
+	Concurrency            int
+	ConcurrencySet         bool
+	Base                   string
+	BaseSet                bool
+	Timeout                time.Duration
+	TimeoutSet             bool
+	Retries                int
+	RetriesSet             bool
+	Fetch                  bool
+	FetchSet               bool
+	ReviewerAgents         []string
+	ReviewerAgentsSet      bool
+	ArchReviewerAgent      string
+	ArchReviewerAgentSet   bool
+	DiffReviewerAgents     []string
+	DiffReviewerAgentsSet  bool
+	SummarizerAgent        string
+	SummarizerAgentSet     bool
+	ReviewerModel          string
+	ReviewerModelSet       bool
+	SummarizerModel        string
+	SummarizerModelSet     bool
+	SummarizerTimeout      time.Duration
+	SummarizerTimeoutSet   bool
+	FPFilterTimeout        time.Duration
+	FPFilterTimeoutSet     bool
+	Guidance               string
+	GuidanceSet            bool
+	GuidanceFile           string
+	GuidanceFileSet        bool
+	FPFilterEnabled        bool
+	FPFilterSet            bool
+	FPThreshold            int
+	FPThresholdSet         bool
+	PRFeedbackEnabled      bool
+	PRFeedbackEnabledSet   bool
+	PRFeedbackAgent        string
+	PRFeedbackAgentSet     bool
+	CrossCheckEnabled      bool
+	CrossCheckEnabledSet   bool
+	CrossCheckAgent        string
+	CrossCheckAgentSet     bool
+	CrossCheckModel        string
+	CrossCheckModelSet     bool
+	CrossCheckTimeout      time.Duration
+	CrossCheckTimeoutSet   bool
+	AutoPhase              bool
+	AutoPhaseSet           bool
+	Strict                 bool
+	StrictSet              bool
 }
 
 // LoadEnvState reads environment variables and returns their state.
@@ -817,6 +835,22 @@ func LoadEnvState() (EnvState, []string) {
 			state.ReviewersSet = true
 		} else {
 			warnings = append(warnings, fmt.Sprintf("ACR_REVIEWERS=%q is not a valid integer, ignoring", v))
+		}
+	}
+	if v := os.Getenv("ACR_DIFF_GROUPS"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			state.DiffGroups = i
+			state.DiffGroupsSet = true
+		} else {
+			warnings = append(warnings, fmt.Sprintf("ACR_DIFF_GROUPS=%q is not a valid integer, ignoring", v))
+		}
+	}
+	if v := os.Getenv("ACR_MEDIUM_DIFF_REVIEWERS"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			state.MediumDiffReviewers = i
+			state.MediumDiffReviewersSet = true
+		} else {
+			warnings = append(warnings, fmt.Sprintf("ACR_MEDIUM_DIFF_REVIEWERS=%q is not a valid integer, ignoring", v))
 		}
 	}
 	if v := os.Getenv("ACR_CONCURRENCY"); v != "" {
@@ -1037,6 +1071,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.Reviewers != nil {
 			result.Reviewers = *cfg.Reviewers
 		}
+		if cfg.DiffGroups != nil {
+			result.DiffGroups = *cfg.DiffGroups
+		}
+		if cfg.MediumDiffReviewers != nil {
+			result.MediumDiffReviewers = *cfg.MediumDiffReviewers
+		}
 		if cfg.Concurrency != nil {
 			result.Concurrency = *cfg.Concurrency
 		}
@@ -1114,6 +1154,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if envState.ReviewersSet {
 		result.Reviewers = envState.Reviewers
 	}
+	if envState.DiffGroupsSet {
+		result.DiffGroups = envState.DiffGroups
+	}
+	if envState.MediumDiffReviewersSet {
+		result.MediumDiffReviewers = envState.MediumDiffReviewers
+	}
 	if envState.ConcurrencySet {
 		result.Concurrency = envState.Concurrency
 	}
@@ -1186,6 +1232,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 
 	if flagState.ReviewersSet {
 		result.Reviewers = flagValues.Reviewers
+	}
+	if flagState.DiffGroupsSet {
+		result.DiffGroups = flagValues.DiffGroups
+	}
+	if flagState.MediumDiffReviewersSet {
+		result.MediumDiffReviewers = flagValues.MediumDiffReviewers
 	}
 	if flagState.ConcurrencySet {
 		result.Concurrency = flagValues.Concurrency

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1602,6 +1602,84 @@ func TestResolvedConfig_Validate_EmptyCrossCheckAgent(t *testing.T) {
 	}
 }
 
+// TestResolve_RejectsCrossCheckEnabledWithoutModel asserts the round-9 contract:
+// when cross_check.enabled=true (the default) AND cross_check.model is empty,
+// ValidateRuntime returns a fail-fast error directing the user to either supply
+// a model or explicitly disable cross-check. ValidateRuntime (not ValidateAll)
+// is used so YAML-only Config.Validate() does not false-positive on configs
+// that legitimately defer the model to env/CLI.
+func TestResolve_RejectsCrossCheckEnabledWithoutModel(t *testing.T) {
+	wantSubstr := "cross_check.enabled=true requires cross_check.model"
+
+	t.Run("defaults_only", func(t *testing.T) {
+		// Bare defaults: enabled=true, model="" -> must reject at runtime.
+		resolved := Resolve(&Config{}, EnvState{}, FlagState{}, Defaults)
+		errs := resolved.ValidateRuntime()
+		if !containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected error containing %q, got: %v", wantSubstr, errs)
+		}
+		// And ValidateAll must NOT include it (parse-time tests must stay green
+		// for users who supply the model via env/CLI later).
+		if containsSubstr(resolved.ValidateAll(), wantSubstr) {
+			t.Fatalf("ValidateAll must not enforce runtime cross-check guard")
+		}
+	})
+
+	t.Run("env_disable_only_no_model", func(t *testing.T) {
+		// User disables via env (resolved.CrossCheckEnabled=false) -> ok even
+		// when model is empty.
+		env := EnvState{CrossCheckEnabled: false, CrossCheckEnabledSet: true}
+		resolved := Resolve(&Config{}, env, FlagState{}, Defaults)
+		if errs := resolved.ValidateRuntime(); containsSubstr(errs, wantSubstr) {
+			t.Fatalf("did not expect cross-check error when disabled, got: %v", errs)
+		}
+	})
+
+	t.Run("flag_supplies_model", func(t *testing.T) {
+		flagState := FlagState{CrossCheckModelSet: true}
+		flagValues := Defaults
+		flagValues.CrossCheckModel = "gpt-flag"
+		resolved := Resolve(&Config{}, EnvState{}, flagState, flagValues)
+		if errs := resolved.ValidateRuntime(); containsSubstr(errs, wantSubstr) {
+			t.Fatalf("did not expect cross-check error when --cross-check-model set, got: %v", errs)
+		}
+	})
+
+	t.Run("env_supplies_model", func(t *testing.T) {
+		env := EnvState{CrossCheckModel: "env-model", CrossCheckModelSet: true}
+		resolved := Resolve(&Config{}, env, FlagState{}, Defaults)
+		if errs := resolved.ValidateRuntime(); containsSubstr(errs, wantSubstr) {
+			t.Fatalf("did not expect cross-check error when ACR_CROSS_CHECK_MODEL set, got: %v", errs)
+		}
+	})
+
+	t.Run("yaml_supplies_model", func(t *testing.T) {
+		cfg := &Config{CrossCheck: CrossCheckConfig{Model: strPtr("yaml-model")}}
+		resolved := Resolve(cfg, EnvState{}, FlagState{}, Defaults)
+		if errs := resolved.ValidateRuntime(); containsSubstr(errs, wantSubstr) {
+			t.Fatalf("did not expect cross-check error when yaml model set, got: %v", errs)
+		}
+	})
+
+	t.Run("whitespace_only_model_rejected", func(t *testing.T) {
+		// "   " is not a valid model: contract uses TrimSpace.
+		cfg := &Config{CrossCheck: CrossCheckConfig{Model: strPtr("   ")}}
+		resolved := Resolve(cfg, EnvState{}, FlagState{}, Defaults)
+		if errs := resolved.ValidateRuntime(); !containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected whitespace-only model to be rejected, got: %v", errs)
+		}
+	})
+}
+
+func containsSubstr(errs []string, want string) bool {
+	for _, e := range errs {
+		if strings.Contains(e, want) {
+			return true
+		}
+	}
+	return false
+}
+
 func TestResolve_CrossCheckPrecedence(t *testing.T) {
 	cfg := &Config{
 		CrossCheck: CrossCheckConfig{
@@ -2391,5 +2469,151 @@ func TestConfig_ModelsEffort_CaseInsensitive_StillRejectsInvalid(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ULTRA") {
 		t.Errorf("expected error to mention 'ULTRA', got: %v", err)
+	}
+}
+
+// --- Round-9: per-phase reviewer agent override tests ---
+
+func TestResolve_ArchReviewerAgent_FromYAML(t *testing.T) {
+	cfg := &Config{
+		ReviewerAgents:    []string{"codex", "claude", "gemini"},
+		ArchReviewerAgent: strPtr("claude"),
+	}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.ArchReviewerAgent != "claude" {
+		t.Errorf("expected ArchReviewerAgent='claude', got %q", result.ArchReviewerAgent)
+	}
+	if len(result.ReviewerAgents) != 3 {
+		t.Errorf("reviewer_agents should be preserved, got %v", result.ReviewerAgents)
+	}
+}
+
+func TestResolve_DiffReviewerAgents_FromYAML(t *testing.T) {
+	cfg := &Config{
+		ReviewerAgents:     []string{"codex", "claude", "gemini"},
+		DiffReviewerAgents: []string{"codex", "claude"},
+	}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if len(result.DiffReviewerAgents) != 2 {
+		t.Fatalf("expected 2 diff reviewer agents, got %d", len(result.DiffReviewerAgents))
+	}
+	if result.DiffReviewerAgents[0] != "codex" || result.DiffReviewerAgents[1] != "claude" {
+		t.Errorf("expected [codex claude], got %v", result.DiffReviewerAgents)
+	}
+}
+
+func TestResolve_ArchReviewerAgent_CLIOverridesYAML(t *testing.T) {
+	cfg := &Config{
+		ReviewerAgents:    []string{"codex"},
+		ArchReviewerAgent: strPtr("claude"),
+	}
+	envState := EnvState{ArchReviewerAgent: "gemini", ArchReviewerAgentSet: true}
+	flagState := FlagState{ArchReviewerAgentSet: true}
+	flagValues := ResolvedConfig{ArchReviewerAgent: "codex"}
+
+	result := Resolve(cfg, envState, flagState, flagValues)
+
+	if result.ArchReviewerAgent != "codex" {
+		t.Errorf("expected CLI value 'codex' to win, got %q", result.ArchReviewerAgent)
+	}
+}
+
+func TestResolve_DiffReviewerAgents_EnvOverridesYAML(t *testing.T) {
+	cfg := &Config{
+		ReviewerAgents:     []string{"codex"},
+		DiffReviewerAgents: []string{"claude"},
+	}
+	envState := EnvState{
+		DiffReviewerAgents:    []string{"gemini", "codex"},
+		DiffReviewerAgentsSet: true,
+	}
+	result := Resolve(cfg, envState, FlagState{}, ResolvedConfig{})
+
+	if len(result.DiffReviewerAgents) != 2 {
+		t.Fatalf("expected 2 diff reviewer agents, got %v", result.DiffReviewerAgents)
+	}
+	if result.DiffReviewerAgents[0] != "gemini" {
+		t.Errorf("expected env value 'gemini' first, got %q", result.DiffReviewerAgents[0])
+	}
+}
+
+func TestResolve_DiffReviewerAgents_DefaultsEmpty(t *testing.T) {
+	cfg := &Config{ReviewerAgents: []string{"codex"}}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if len(result.DiffReviewerAgents) != 0 {
+		t.Errorf("expected empty DiffReviewerAgents when unset, got %v", result.DiffReviewerAgents)
+	}
+	if result.ArchReviewerAgent != "" {
+		t.Errorf("expected empty ArchReviewerAgent when unset, got %q", result.ArchReviewerAgent)
+	}
+}
+
+func TestResolve_ArchReviewerAgent_RejectsUnsupportedAgent(t *testing.T) {
+	cfg := &Config{
+		ReviewerAgents:    []string{"codex"},
+		ArchReviewerAgent: strPtr("notarealagent"),
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for unsupported arch_reviewer_agent")
+	} else if !strings.Contains(err.Error(), "arch_reviewer_agent") {
+		t.Errorf("expected error mentioning arch_reviewer_agent, got: %v", err)
+	}
+}
+
+func TestResolve_DiffReviewerAgents_RejectsUnsupportedAgent(t *testing.T) {
+	cfg := &Config{
+		ReviewerAgents:     []string{"codex"},
+		DiffReviewerAgents: []string{"codex", "notarealagent"},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validation error for unsupported diff_reviewer_agents entry")
+	} else if !strings.Contains(err.Error(), "diff_reviewer_agents") {
+		t.Errorf("expected error mentioning diff_reviewer_agents, got: %v", err)
+	}
+}
+
+func TestLoadEnvState_ArchReviewerAgent(t *testing.T) {
+	original := os.Getenv("ACR_ARCH_REVIEWER_AGENT")
+	defer func() {
+		if original != "" {
+			os.Setenv("ACR_ARCH_REVIEWER_AGENT", original)
+		} else {
+			os.Unsetenv("ACR_ARCH_REVIEWER_AGENT")
+		}
+	}()
+
+	os.Setenv("ACR_ARCH_REVIEWER_AGENT", "claude")
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.ArchReviewerAgentSet {
+		t.Error("expected ArchReviewerAgentSet=true")
+	}
+	if state.ArchReviewerAgent != "claude" {
+		t.Errorf("expected ArchReviewerAgent='claude', got %q", state.ArchReviewerAgent)
+	}
+}
+
+func TestLoadEnvState_DiffReviewerAgents(t *testing.T) {
+	original := os.Getenv("ACR_DIFF_REVIEWER_AGENTS")
+	defer func() {
+		if original != "" {
+			os.Setenv("ACR_DIFF_REVIEWER_AGENTS", original)
+		} else {
+			os.Unsetenv("ACR_DIFF_REVIEWER_AGENTS")
+		}
+	}()
+
+	os.Setenv("ACR_DIFF_REVIEWER_AGENTS", "codex, claude")
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.DiffReviewerAgentsSet {
+		t.Error("expected DiffReviewerAgentsSet=true")
+	}
+	if len(state.DiffReviewerAgents) != 2 || state.DiffReviewerAgents[0] != "codex" || state.DiffReviewerAgents[1] != "claude" {
+		t.Errorf("expected [codex claude], got %v", state.DiffReviewerAgents)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1202,7 +1202,8 @@ func TestResolveGuidance_ConfigFileAbsolutePath(t *testing.T) {
 func clearACREnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"ACR_REVIEWERS", "ACR_CONCURRENCY", "ACR_BASE_REF", "ACR_TIMEOUT",
+		"ACR_REVIEWERS", "ACR_DIFF_GROUPS", "ACR_MEDIUM_DIFF_REVIEWERS",
+		"ACR_CONCURRENCY", "ACR_BASE_REF", "ACR_TIMEOUT",
 		"ACR_RETRIES", "ACR_FETCH", "ACR_REVIEWER_AGENT", "ACR_SUMMARIZER_AGENT",
 		"ACR_SUMMARIZER_TIMEOUT", "ACR_FP_FILTER_TIMEOUT",
 		"ACR_GUIDANCE", "ACR_GUIDANCE_FILE", "ACR_FP_FILTER", "ACR_FP_THRESHOLD",
@@ -2615,5 +2616,163 @@ func TestLoadEnvState_DiffReviewerAgents(t *testing.T) {
 	}
 	if len(state.DiffReviewerAgents) != 2 || state.DiffReviewerAgents[0] != "codex" || state.DiffReviewerAgents[1] != "claude" {
 		t.Errorf("expected [codex claude], got %v", state.DiffReviewerAgents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests for diff_groups and medium_diff_reviewers (auto-phase reviewer knobs)
+// ---------------------------------------------------------------------------
+
+func TestResolve_DiffGroups_FromYAML(t *testing.T) {
+	cfg := &Config{DiffGroups: ptr(7)}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.DiffGroups != 7 {
+		t.Errorf("expected diff_groups=7 from yaml, got %d", result.DiffGroups)
+	}
+}
+
+func TestResolve_DiffGroups_EnvOverridesYAML(t *testing.T) {
+	cfg := &Config{DiffGroups: ptr(7)}
+	envState := EnvState{DiffGroups: 9, DiffGroupsSet: true}
+	result := Resolve(cfg, envState, FlagState{}, ResolvedConfig{})
+	if result.DiffGroups != 9 {
+		t.Errorf("expected env diff_groups=9 to override yaml, got %d", result.DiffGroups)
+	}
+}
+
+func TestResolve_DiffGroups_CLIOverridesEnv(t *testing.T) {
+	cfg := &Config{DiffGroups: ptr(7)}
+	envState := EnvState{DiffGroups: 9, DiffGroupsSet: true}
+	flagState := FlagState{DiffGroupsSet: true}
+	flagValues := ResolvedConfig{DiffGroups: 12}
+	result := Resolve(cfg, envState, flagState, flagValues)
+	if result.DiffGroups != 12 {
+		t.Errorf("expected CLI diff_groups=12 to override env, got %d", result.DiffGroups)
+	}
+}
+
+func TestResolve_DiffGroups_DefaultsTo4(t *testing.T) {
+	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.DiffGroups != 4 {
+		t.Errorf("expected default diff_groups=4, got %d", result.DiffGroups)
+	}
+	if Defaults.DiffGroups != 4 {
+		t.Errorf("expected Defaults.DiffGroups=4, got %d", Defaults.DiffGroups)
+	}
+}
+
+func TestResolve_MediumDiffReviewers_FromYAML(t *testing.T) {
+	cfg := &Config{MediumDiffReviewers: ptr(5)}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.MediumDiffReviewers != 5 {
+		t.Errorf("expected medium_diff_reviewers=5 from yaml, got %d", result.MediumDiffReviewers)
+	}
+}
+
+func TestResolve_MediumDiffReviewers_EnvOverridesYAML(t *testing.T) {
+	cfg := &Config{MediumDiffReviewers: ptr(5)}
+	envState := EnvState{MediumDiffReviewers: 8, MediumDiffReviewersSet: true}
+	result := Resolve(cfg, envState, FlagState{}, ResolvedConfig{})
+	if result.MediumDiffReviewers != 8 {
+		t.Errorf("expected env medium_diff_reviewers=8 to override yaml, got %d", result.MediumDiffReviewers)
+	}
+}
+
+func TestResolve_MediumDiffReviewers_CLIOverridesEnv(t *testing.T) {
+	cfg := &Config{MediumDiffReviewers: ptr(5)}
+	envState := EnvState{MediumDiffReviewers: 8, MediumDiffReviewersSet: true}
+	flagState := FlagState{MediumDiffReviewersSet: true}
+	flagValues := ResolvedConfig{MediumDiffReviewers: 11}
+	result := Resolve(cfg, envState, flagState, flagValues)
+	if result.MediumDiffReviewers != 11 {
+		t.Errorf("expected CLI medium_diff_reviewers=11 to override env, got %d", result.MediumDiffReviewers)
+	}
+}
+
+func TestResolve_MediumDiffReviewers_DefaultsTo2(t *testing.T) {
+	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.MediumDiffReviewers != 2 {
+		t.Errorf("expected default medium_diff_reviewers=2, got %d", result.MediumDiffReviewers)
+	}
+	if Defaults.MediumDiffReviewers != 2 {
+		t.Errorf("expected Defaults.MediumDiffReviewers=2, got %d", Defaults.MediumDiffReviewers)
+	}
+}
+
+func TestValidate_RejectsZeroDiffGroups(t *testing.T) {
+	cfg := Defaults
+	cfg.DiffGroups = 0
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for diff_groups=0, got nil")
+	}
+	if !strings.Contains(err.Error(), "diff_groups must be >= 1") {
+		t.Errorf("expected 'diff_groups must be >= 1' in error, got: %v", err)
+	}
+}
+
+func TestValidate_RejectsZeroMediumDiffReviewers(t *testing.T) {
+	cfg := Defaults
+	cfg.MediumDiffReviewers = 0
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for medium_diff_reviewers=0, got nil")
+	}
+	if !strings.Contains(err.Error(), "medium_diff_reviewers must be >= 1") {
+		t.Errorf("expected 'medium_diff_reviewers must be >= 1' in error, got: %v", err)
+	}
+}
+
+func TestLoadEnvState_DiffGroups(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_DIFF_GROUPS", "6")
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.DiffGroupsSet {
+		t.Error("expected DiffGroupsSet=true")
+	}
+	if state.DiffGroups != 6 {
+		t.Errorf("expected DiffGroups=6, got %d", state.DiffGroups)
+	}
+}
+
+func TestLoadEnvState_DiffGroups_Malformed(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_DIFF_GROUPS", "abc")
+	state, warnings := LoadEnvState()
+	if state.DiffGroupsSet {
+		t.Error("expected DiffGroupsSet=false for invalid value")
+	}
+	if !hasWarningContaining(warnings, "ACR_DIFF_GROUPS") {
+		t.Errorf("expected warning about ACR_DIFF_GROUPS, got %v", warnings)
+	}
+}
+
+func TestLoadEnvState_MediumDiffReviewers(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_MEDIUM_DIFF_REVIEWERS", "3")
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.MediumDiffReviewersSet {
+		t.Error("expected MediumDiffReviewersSet=true")
+	}
+	if state.MediumDiffReviewers != 3 {
+		t.Errorf("expected MediumDiffReviewers=3, got %d", state.MediumDiffReviewers)
+	}
+}
+
+func TestLoadEnvState_MediumDiffReviewers_Malformed(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_MEDIUM_DIFF_REVIEWERS", "xyz")
+	state, warnings := LoadEnvState()
+	if state.MediumDiffReviewersSet {
+		t.Error("expected MediumDiffReviewersSet=false for invalid value")
+	}
+	if !hasWarningContaining(warnings, "ACR_MEDIUM_DIFF_REVIEWERS") {
+		t.Errorf("expected warning about ACR_MEDIUM_DIFF_REVIEWERS, got %v", warnings)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1205,6 +1205,7 @@ func clearACREnv(t *testing.T) {
 		"ACR_REVIEWERS", "ACR_DIFF_GROUPS", "ACR_MEDIUM_DIFF_REVIEWERS",
 		"ACR_CONCURRENCY", "ACR_BASE_REF", "ACR_TIMEOUT",
 		"ACR_RETRIES", "ACR_FETCH", "ACR_REVIEWER_AGENT", "ACR_SUMMARIZER_AGENT",
+		"ACR_ARCH_REVIEWER_AGENT", "ACR_DIFF_REVIEWER_AGENTS",
 		"ACR_SUMMARIZER_TIMEOUT", "ACR_FP_FILTER_TIMEOUT",
 		"ACR_GUIDANCE", "ACR_GUIDANCE_FILE", "ACR_FP_FILTER", "ACR_FP_THRESHOLD",
 		"ACR_PR_FEEDBACK", "ACR_PR_FEEDBACK_AGENT",
@@ -2775,4 +2776,302 @@ func TestLoadEnvState_MediumDiffReviewers_Malformed(t *testing.T) {
 	if !hasWarningContaining(warnings, "ACR_MEDIUM_DIFF_REVIEWERS") {
 		t.Errorf("expected warning about ACR_MEDIUM_DIFF_REVIEWERS, got %v", warnings)
 	}
+}
+
+func TestValidateRuntime_CrossCheckPairing(t *testing.T) {
+	tests := []struct {
+		name             string
+		crossCheckEnable bool
+		crossCheckAgent  string
+		crossCheckModel  string
+		summarizerAgent  string
+		wantMinErrs      int
+		wantErrSubstring string
+	}{
+		{
+			name:             "valid 1:1 pairing",
+			crossCheckEnable: true,
+			crossCheckAgent:  "codex",
+			crossCheckModel:  "gpt-5",
+			summarizerAgent:  "codex",
+			wantMinErrs:      0,
+		},
+		{
+			name:             "valid multi pairing",
+			crossCheckEnable: true,
+			crossCheckAgent:  "codex,claude",
+			crossCheckModel:  "gpt-5,claude-opus-4-6",
+			summarizerAgent:  "codex",
+			wantMinErrs:      0,
+		},
+		{
+			name:             "count mismatch",
+			crossCheckEnable: true,
+			crossCheckAgent:  "codex,claude",
+			crossCheckModel:  "gpt-5",
+			summarizerAgent:  "codex",
+			wantMinErrs:      1,
+			wantErrSubstring: "same count",
+		},
+		{
+			name:             "empty model token",
+			crossCheckEnable: true,
+			crossCheckAgent:  "codex",
+			crossCheckModel:  "gpt-5,,claude-opus",
+			summarizerAgent:  "codex",
+			wantMinErrs:      1,
+			wantErrSubstring: "empty entry",
+		},
+		{
+			name:             "trailing comma",
+			crossCheckEnable: true,
+			crossCheckAgent:  "codex",
+			crossCheckModel:  "gpt-5,",
+			summarizerAgent:  "codex",
+			wantMinErrs:      1,
+			wantErrSubstring: "empty entry",
+		},
+		{
+			name:             "agent fallback to summarizer",
+			crossCheckEnable: true,
+			crossCheckAgent:  "",
+			crossCheckModel:  "gpt-5",
+			summarizerAgent:  "codex",
+			wantMinErrs:      0,
+		},
+		{
+			name:             "agent fallback count mismatch",
+			crossCheckEnable: true,
+			crossCheckAgent:  "",
+			crossCheckModel:  "gpt-5,claude-opus",
+			summarizerAgent:  "codex",
+			wantMinErrs:      1,
+			wantErrSubstring: "same count",
+		},
+		{
+			name:             "disabled skips all",
+			crossCheckEnable: false,
+			crossCheckAgent:  "codex,claude",
+			crossCheckModel:  "",
+			summarizerAgent:  "codex",
+			wantMinErrs:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := &ResolvedConfig{
+				CrossCheckEnabled: tt.crossCheckEnable,
+				CrossCheckAgent:   tt.crossCheckAgent,
+				CrossCheckModel:   tt.crossCheckModel,
+				SummarizerAgent:   tt.summarizerAgent,
+				CrossCheckTimeout: 5 * time.Minute,
+			}
+			errs := rc.ValidateRuntime()
+			if len(errs) < tt.wantMinErrs {
+				t.Errorf("expected at least %d error(s), got %d: %v", tt.wantMinErrs, len(errs), errs)
+			}
+			if tt.wantErrSubstring != "" {
+				found := false
+				for _, e := range errs {
+					if strings.Contains(e, tt.wantErrSubstring) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected error containing %q, got %v", tt.wantErrSubstring, errs)
+				}
+			}
+			if tt.wantMinErrs == 0 && len(errs) != 0 {
+				t.Errorf("expected no errors, got %v", errs)
+			}
+		})
+	}
+}
+
+// TestValidateRuntime_CrossCheckModelsTreeFallback exercises the Round-13 F#3
+// tightening: ValidateRuntime used to accept ANY cross_check entry in the
+// models tree as sufficient coverage, which let partial configs slip through
+// validation only to blow up at runtime with "cross-check-model is required".
+// The fix is per-agent: every selected cross_check agent must have a
+// resolvable path in the tree (agents / sizes / defaults), else validation
+// reports which agent is uncovered.
+func TestValidateRuntime_CrossCheckModelsTreeFallback(t *testing.T) {
+	wantSubstr := "cross_check.enabled=true requires cross_check.model"
+
+	t.Run("agents_tree_covers_all_selected_agents", func(t *testing.T) {
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex,claude",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Agents: map[string]RoleModels{
+					"codex":  {CrossCheck: &ModelSpec{Model: "gpt-5.4-mini"}},
+					"claude": {CrossCheck: &ModelSpec{Model: "claude-opus-4-7"}},
+				},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected no cross_check runtime error when every selected agent is covered, got: %v", errs)
+		}
+	})
+
+	t.Run("defaults_tree_covers_all_selected_agents", func(t *testing.T) {
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex,claude",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Defaults: RoleModels{CrossCheck: &ModelSpec{Model: "shared-cc-model"}},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected no cross_check runtime error when defaults tree covers all, got: %v", errs)
+		}
+	})
+
+	t.Run("sizes_tree_covers_all_selected_agents", func(t *testing.T) {
+		// sizes-only config legitimately expects the size layer to activate
+		// at runtime. Validate tolerates ANY size having a model because the
+		// size is unknown at validate time.
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex,claude",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Sizes: map[string]RoleModels{
+					"large": {CrossCheck: &ModelSpec{Model: "gpt-5.4-large"}},
+				},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected no cross_check runtime error when sizes tree covers all, got: %v", errs)
+		}
+	})
+
+	t.Run("partial_agents_tree_fails_with_agent_name", func(t *testing.T) {
+		// Round-13 F#3 regression guard: one agent covered, the other not.
+		// Before fix: hasCrossCheckModelInModelsTree returned true because
+		// codex entry existed → validation passed → runtime blew up on claude.
+		// After fix: validation names "claude" explicitly.
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex,claude",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Agents: map[string]RoleModels{
+					"codex": {CrossCheck: &ModelSpec{Model: "gpt-5.4-mini"}},
+				},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if !containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected cross_check runtime error when claude is uncovered, got: %v", errs)
+		}
+		if !containsSubstr(errs, "claude") {
+			t.Errorf("error must name the uncovered agent 'claude', got: %v", errs)
+		}
+	})
+
+	t.Run("effort_only_entries_do_not_satisfy_model_requirement", func(t *testing.T) {
+		// Effort alone never satisfies the runtime Model requirement.
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Agents: map[string]RoleModels{
+					"codex": {CrossCheck: &ModelSpec{Effort: "high"}}, // no Model
+				},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if !containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected cross_check runtime error when only Effort is set, got: %v", errs)
+		}
+	})
+
+	// Round-14 F#1 (案 V): cross-check runs exclusively at size=large, so the
+	// validate-time tolerance for "ANY size" is tightened to "sizes.large only".
+	// sizes.small / sizes.medium entries are dead config for the cross_check
+	// role (runtime modelconfig.Resolve receives sizeStr="large" at the gate),
+	// and the validate layer now rejects them with an actionable error.
+	t.Run("sizes_tree_only_covers_small_now_rejected", func(t *testing.T) {
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Sizes: map[string]RoleModels{
+					"small": {CrossCheck: &ModelSpec{Model: "gpt-5.4-small"}},
+				},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if !containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected cross_check runtime error when only sizes.small is set, got: %v", errs)
+		}
+		if !containsSubstr(errs, "sizes.large") {
+			t.Errorf("error must guide users to sizes.large, got: %v", errs)
+		}
+	})
+
+	t.Run("sizes_tree_only_covers_medium_now_rejected", func(t *testing.T) {
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Sizes: map[string]RoleModels{
+					"medium": {CrossCheck: &ModelSpec{Model: "gpt-5.4-medium"}},
+				},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if !containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected cross_check runtime error when only sizes.medium is set, got: %v", errs)
+		}
+		if !containsSubstr(errs, "sizes.large") {
+			t.Errorf("error must guide users to sizes.large, got: %v", errs)
+		}
+	})
+
+	t.Run("sizes_large_alone_still_accepted", func(t *testing.T) {
+		// Round-14 F#1 regression guard: tightening sizes layer to "large only"
+		// must not break users who configure cross_check under sizes.large.
+		r := &ResolvedConfig{
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex",
+			CrossCheckModel:   "",
+			SummarizerAgent:   "codex",
+			CrossCheckTimeout: 5 * time.Minute,
+			Models: ModelsConfig{
+				Sizes: map[string]RoleModels{
+					"large": {CrossCheck: &ModelSpec{Model: "gpt-5.4-large"}},
+				},
+			},
+		}
+		errs := r.ValidateRuntime()
+		if containsSubstr(errs, wantSubstr) {
+			t.Fatalf("expected sizes.large alone to still satisfy validate, got: %v", errs)
+		}
+	})
 }

--- a/internal/runner/phase.go
+++ b/internal/runner/phase.go
@@ -47,8 +47,21 @@ func BuildReviewerSpecs(phases []PhaseConfig, defaultAgents []agent.Agent, globa
 			} else {
 				base := agent.AgentForReviewer(defaultAgents, reviewerIdx)
 				if pc.Effort != "" || pc.Model != "" {
+					// Merge: pc.Effort/Model が空のときは base agent の既存値を継承する。
+					// 部分 override (例: pc.Effort="high" のみ) で base agent の model
+					// 設定が落ちないようにするための cascade。現状 caller はこの分岐に
+					// 到達しないが (parsePhases / auto-phase はいずれも pc.Effort/Model
+					// を空に保つ)、将来 caller が増えたときの regression を予防する。
+					baseOpts := base.Options()
+					merged := agent.AgentOptions{Model: pc.Model, Effort: pc.Effort}
+					if merged.Model == "" {
+						merged.Model = baseOpts.Model
+					}
+					if merged.Effort == "" {
+						merged.Effort = baseOpts.Effort
+					}
 					var rebindErr error
-					a, rebindErr = agent.NewAgentWithOptions(base.Name(), agent.AgentOptions{Model: pc.Model, Effort: pc.Effort})
+					a, rebindErr = agent.NewAgentWithOptions(base.Name(), merged)
 					if rebindErr != nil {
 						return nil, fmt.Errorf("phase %q effort rebind: %w", pc.Phase, rebindErr)
 					}

--- a/internal/runner/phase_test.go
+++ b/internal/runner/phase_test.go
@@ -9,7 +9,9 @@ import (
 
 // mockPhaseAgent implements agent.Agent for phase testing.
 type mockPhaseAgent struct {
-	name string
+	name   string
+	model  string
+	effort string
 }
 
 func (m *mockPhaseAgent) Name() string       { return m.name }
@@ -19,6 +21,9 @@ func (m *mockPhaseAgent) ExecuteReview(_ context.Context, _ *agent.ReviewConfig)
 }
 func (m *mockPhaseAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
 	return nil, nil
+}
+func (m *mockPhaseAgent) Options() agent.AgentOptions {
+	return agent.AgentOptions{Model: m.model, Effort: m.effort}
 }
 
 func TestBuildReviewerSpecs_ArchAndDiff(t *testing.T) {
@@ -153,5 +158,35 @@ func TestDefaultPromptForPhase(t *testing.T) {
 				t.Errorf("defaultPromptForPhase(%q) = empty, want non-empty", tt.phase)
 			}
 		})
+	}
+}
+
+// TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseModel locks in the
+// cascade-merge behavior added in Round-9: when a PhaseConfig overrides only
+// Effort (or only Model) on the AgentName=="" path, the rebuilt agent must
+// inherit the unset field from the base agent's existing options instead of
+// silently dropping it. The current callers never populate PhaseConfig.Effort
+// or .Model, so this guard exists purely to prevent a future caller from
+// re-introducing the Round-8 dead-code regression.
+func TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseModel(t *testing.T) {
+	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: ""}
+	phases := []PhaseConfig{
+		{Phase: "diff", ReviewerCount: 1, Effort: "high"},
+	}
+
+	specs, err := BuildReviewerSpecs(phases, []agent.Agent{base}, "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+
+	got := specs[0].Agent.Options()
+	if got.Model != "gpt-5" {
+		t.Errorf("base model dropped: Options().Model = %q, want %q", got.Model, "gpt-5")
+	}
+	if got.Effort != "high" {
+		t.Errorf("phase override lost: Options().Effort = %q, want %q", got.Effort, "high")
 	}
 }

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -266,6 +266,8 @@ func (m *mockAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agen
 	return nil, nil
 }
 
+func (m *mockAgent) Options() agent.AgentOptions { return agent.AgentOptions{} }
+
 // mockStreamingAgent implements agent.Agent for testing streaming output parsing.
 type mockStreamingAgent struct {
 	name   string
@@ -291,6 +293,8 @@ func (m *mockStreamingAgent) ExecuteReview(_ context.Context, _ *agent.ReviewCon
 func (m *mockStreamingAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
+
+func (m *mockStreamingAgent) Options() agent.AgentOptions { return agent.AgentOptions{} }
 
 func TestRunReviewer_ParserErrorRecovery(t *testing.T) {
 	// Create mock agent that returns JSONL with one bad line in the middle
@@ -400,6 +404,8 @@ func (m *mockAuthFailAgent) ExecuteReview(_ context.Context, _ *agent.ReviewConf
 func (m *mockAuthFailAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
 	return nil, nil
 }
+
+func (m *mockAuthFailAgent) Options() agent.AgentOptions { return agent.AgentOptions{} }
 
 func TestRunReviewerWithRetry_SkipsRetryOnAuthFailure(t *testing.T) {
 	mock := &mockAuthFailAgent{name: "gemini", exitCode: 41, stderr: ""}


### PR DESCRIPTION
## Summary

Themes D+E of the review-gate post-merge work. Round-9/10/14 follow-ups plus housekeeping.

### What's included

- **Theme D — Per-phase agents & cross-check hardening**
  - \`--cross-check-model\` required, paired with \`--cross-check-agent\`
  - Separate reviewer-count knobs for flat / medium / grouped paths
  - \`ValidateRuntime\` validates cross_check agent/model pairing
  - Base concurrency clamp on max potential reviewer count
  - \`defer buildPhaseAgents\` to medium/large diffs only
  - Round-9 self-review follow-ups (cross-check + per-phase agents)
  - Round-10 advisory follow-ups (\`IsAvailable\`, verbose log, init)
  - Codex \`--effort\` position regression guard
  - Preserve base agent options on partial phase override

- **Theme E — Housekeeping**
  - Ignore \`.claude/settings.json\`, \`.tmp/\` scratch, \`.claude/scheduled_tasks.lock\`
  - Tune \`.acr.yaml\` for per-phase agent routing + model updates

### Stacked PR context

This is **PR 3 of 3** (final):

- PR 1 (#4): Themes A+B — base \`main\`
- PR 2 (#5): Theme C — base \`pr/grouped-diff-autophase\` (#4)
- **PR 3 (this)**: Themes D+E — base \`pr/new-agent-with-options\` (#5)

Depends on \`AgentOptions\` and \`ModelsConfig\` types from #5. Merge #5 first.

### Technical notes

Theme E (4 chore commits, ~20 LOC) was absorbed into this PR rather than kept as a standalone PR — the overhead of a 4th cascade boundary was not worth the trivial review scope.

## Test plan

- [ ] CI green
- [ ] \`make check\` passes
- [ ] \`git log --grep='^fixup!' pr/new-agent-with-options..HEAD\` returns empty
- [ ] Smoke: \`acr --local --reviewers 3 --base HEAD~1 --reviewer-agent codex,claude,gemini --verbose\` on a medium diff