### PR TITLE
docs: Rule B docstring 明確化 + beta notice TODO 追記

### DIFF
--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -392,6 +392,7 @@ func confirmAndSubmitReview(ctx context.Context, body string, pr prContext, verd
 		return nil
 	}
 
+	// TODO(Issue #3): remove beta notice once PR posting is stabilized.
 	betaNoticeOnce.Do(func() {
 		logger.Logf(terminal.StyleWarning, "PR posting is beta in the Windows port; behavior may change.")
 	})
@@ -490,6 +491,7 @@ func confirmAndSubmitLGTM(ctx context.Context, body string, pr prContext, opts R
 		return nil
 	}
 
+	// TODO(Issue #3): remove beta notice once PR posting is stabilized.
 	betaNoticeOnce.Do(func() {
 		logger.Logf(terminal.StyleWarning, "PR posting is beta in the Windows port; behavior may change.")
 	})

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -291,7 +291,7 @@ func backfillGroupKeys(grouped *domain.GroupedFindings, aggregated []domain.Aggr
 //   - Rule C (allow-list): unknown severity values normalize to "advisory".
 //   - Rule A (upgrade): any valid source with Severity=="blocking" → group Severity="blocking".
 //   - Rule B (downgrade): group Severity=="blocking" with valid sources but no blocking source
-//     → downgrade to "advisory" (LLM-claimed blocking without source citation is downgraded).
+//     → downgrade to "advisory" (LLM-claimed blocking not supported by any blocking source is downgraded).
 //   - Rule B preserves Severity when no valid sources exist (empty Sources or all out-of-range):
 //     treated as information loss, not evidence of non-blocking.
 //   - Default: empty Severity → "advisory".

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -291,7 +291,7 @@ func backfillGroupKeys(grouped *domain.GroupedFindings, aggregated []domain.Aggr
 //   - Rule C (allow-list): unknown severity values normalize to "advisory".
 //   - Rule A (upgrade): any valid source with Severity=="blocking" → group Severity="blocking".
 //   - Rule B (downgrade): group Severity=="blocking" with valid sources but no blocking source
-//     → downgrade to "advisory" (LLM-fabricated).
+//     → downgrade to "advisory" (LLM-claimed blocking without source citation is downgraded).
 //   - Rule B preserves Severity when no valid sources exist (empty Sources or all out-of-range):
 //     treated as information loss, not evidence of non-blocking.
 //   - Default: empty Severity → "advisory".


### PR DESCRIPTION
## 概要

バックログ持ち越しタスク (backlog/2026-04-22_03.md) のうち、小規模修正2件を束ねたクリーンアップ PR。

- **C-2 docstring 強化**: `backfillSeverity` の Rule B コメントを「LLM-claimed blocking without source citation is downgraded」に明確化。従来の "LLM-fabricated" では downgrade 条件の意図が不明瞭だった
- **Beta notice 追跡**: `pr_submit.go` の `betaNoticeOnce` 2箇所に `TODO(Issue #3)` を追加し、beta notice 削除時期を Issue で追跡可能にした

## テスト計画

- [x] `go test ./internal/summarizer/... ./cmd/acr/... -count=1` PASS
- [x] `go build ./cmd/acr` 成功
- コメント変更のみのため、行動変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)