### PR TITLE
feat: small_diff_reviewers ノブ導入 (Issue #8)

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -2,9 +2,9 @@
 # See https://github.com/richhaase/agentic-code-reviewer for documentation.
 
 # Number of parallel reviewers (default: 5)
-# This applies ONLY to flat review path (auto-phase OFF / size=small /
-# explicit --phase). Auto-phase grouped/medium use diff_groups /
-# medium_diff_reviewers below.
+# This applies ONLY to flat review path (auto-phase OFF, no --phase).
+# --phase diff uses small_diff_reviewers; --phase arch,diff uses
+# medium_diff_reviewers. Auto-phase selects automatically by diff size.
 reviewers: 5
 
 # Number of diff groups in auto-phase grouped path (large diff). Default: 4.

--- a/.acr.yaml
+++ b/.acr.yaml
@@ -14,12 +14,12 @@ diff_groups: 4
 
 # Number of reviewers in auto-phase small path. Default: 1.
 # Small diff = files <= 3 AND lines <= 100. Flat diff-only review (no arch).
-# small_diff_reviewers: 1
+small_diff_reviewers: 1
 
 # Number of diff reviewers in auto-phase medium path. Default: 2.
 # arch reviewer is always 1. Total reviewers in medium path =
 # 1 + medium_diff_reviewers.
-# medium_diff_reviewers: 2
+medium_diff_reviewers: 2
 
 # Maximum concurrent reviewers (default: same as reviewers)
 # concurrency: 0
@@ -94,9 +94,9 @@ cross_check:
 #     > agent built-in default
 #
 # Roles:
-#   reviewer       — flat review (auto-phase OFF / explicit --phase) and
-#                    auto-phase small path. Also fallback for arch_reviewer /
-#                    diff_reviewer when those are unset at the same cascade layer.
+#   reviewer       — flat review (auto-phase OFF / size=small / --phase diff)
+#                    and fallback for arch_reviewer / diff_reviewer when those
+#                    are unset at the same cascade layer.
 #   arch_reviewer  — auto-phase medium/large の arch フェーズのみ
 #   diff_reviewer  — auto-phase medium/large の diff フェーズのみ
 #   summarizer     — finding clustering

--- a/.acr.yaml
+++ b/.acr.yaml
@@ -12,6 +12,10 @@ reviewers: 5
 # (sees full diff). Total reviewers in grouped path = 1 + diff_groups.
 diff_groups: 4
 
+# Number of reviewers in auto-phase small path. Default: 1.
+# Small diff = files <= 3 AND lines <= 100. Flat diff-only review (no arch).
+# small_diff_reviewers: 1
+
 # Number of diff reviewers in auto-phase medium path. Default: 2.
 # arch reviewer is always 1. Total reviewers in medium path =
 # 1 + medium_diff_reviewers.
@@ -90,9 +94,9 @@ cross_check:
 #     > agent built-in default
 #
 # Roles:
-#   reviewer       — flat review (auto-phase OFF / size=small / --phase diff)
-#                    and fallback for arch_reviewer / diff_reviewer when those
-#                    are unset at the same cascade layer.
+#   reviewer       — flat review (auto-phase OFF / explicit --phase) and
+#                    auto-phase small path. Also fallback for arch_reviewer /
+#                    diff_reviewer when those are unset at the same cascade layer.
 #   arch_reviewer  — auto-phase medium/large の arch フェーズのみ
 #   diff_reviewer  — auto-phase medium/large の diff フェーズのみ
 #   summarizer     — finding clustering

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -45,6 +45,7 @@ var (
 	reviewers           int
 	diffGroups          int
 	mediumDiffReviewers int
+	smallDiffReviewers  int
 	concurrency         int
 	baseRef             string
 	timeout             time.Duration
@@ -109,11 +110,13 @@ Exit codes:
 
 	// Configuration flags (defaults are resolved via config.Resolve with precedence: flag > env > config > default)
 	rootCmd.Flags().IntVarP(&reviewers, "reviewers", "r", 0,
-		"Number of parallel reviewers for flat review path (auto-phase OFF / size=small / explicit --phase). Auto-phase grouped/medium use --diff-groups / --medium-diff-reviewers instead. (default: 5, env: ACR_REVIEWERS)")
+		"Number of parallel reviewers for flat review path (auto-phase OFF, no --phase). --phase diff uses --small-diff-reviewers; --phase arch,diff uses --medium-diff-reviewers. (default: 5, env: ACR_REVIEWERS)")
 	rootCmd.Flags().IntVar(&diffGroups, "diff-groups", 0,
 		"Number of diff groups in auto-phase grouped path (large diff) (default: 4, env: ACR_DIFF_GROUPS)")
 	rootCmd.Flags().IntVar(&mediumDiffReviewers, "medium-diff-reviewers", 0,
-		"Number of diff reviewers in auto-phase medium path (default: 2, env: ACR_MEDIUM_DIFF_REVIEWERS)")
+		"Number of diff reviewers for auto-phase medium and --phase arch,diff (default: 2, env: ACR_MEDIUM_DIFF_REVIEWERS)")
+	rootCmd.Flags().IntVar(&smallDiffReviewers, "small-diff-reviewers", 0,
+		"Number of reviewers for auto-phase small and --phase diff (default: 1, env: ACR_SMALL_DIFF_REVIEWERS)")
 	rootCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0,
 		"Max concurrent reviewers (default: same as --reviewers, env: ACR_CONCURRENCY)")
 	rootCmd.Flags().StringVarP(&baseRef, "base", "b", "",
@@ -406,6 +409,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		ReviewersSet:           cmd.Flags().Changed("reviewers"),
 		DiffGroupsSet:          cmd.Flags().Changed("diff-groups"),
 		MediumDiffReviewersSet: cmd.Flags().Changed("medium-diff-reviewers"),
+		SmallDiffReviewersSet:  cmd.Flags().Changed("small-diff-reviewers"),
 		ConcurrencySet:         cmd.Flags().Changed("concurrency"),
 		BaseSet:                cmd.Flags().Changed("base") || wt.baseAutoDetected,
 		TimeoutSet:             cmd.Flags().Changed("timeout"),
@@ -455,6 +459,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		Reviewers:           reviewers,
 		DiffGroups:          diffGroups,
 		MediumDiffReviewers: mediumDiffReviewers,
+		SmallDiffReviewers:  smallDiffReviewers,
 		Concurrency:         concurrency,
 		Base:                resolvedBaseRef,
 		Timeout:             timeout,
@@ -561,6 +566,9 @@ func maxPotentialReviewers(r config.ResolvedConfig) int {
 		m = v
 	}
 	if v := 1 + r.MediumDiffReviewers; v > m {
+		m = v
+	}
+	if v := r.SmallDiffReviewers; v > m {
 		m = v
 	}
 	return m

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -935,7 +935,7 @@ func resolveAutoPhase(
 ) (autoPhaseResult, error) {
 	switch size {
 	case git.DiffSizeSmall:
-		// Small: flat diff path; reviewer count is taken from --reviewers by caller.
+		// Small: flat diff path; reviewer count comes from small_diff_reviewers.
 		return autoPhaseResult{PhaseStr: "diff"}, nil
 	case git.DiffSizeLarge:
 		fileCount := len(git.ParseDiffSections(diff))

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -238,9 +238,6 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	phaseFromAuto := false
 	var useGroupedSpecs bool
 	var groupedSpecs []runner.ReviewerSpec
-	// mediumDiffCount > 0 → auto-phase chose arch,diff and the diff phase
-	// reviewer count must come from medium_diff_reviewers (not opts.Reviewers).
-	mediumDiffCount := 0
 	if shouldUseAutoPhase(opts) {
 		if !diffSizeClassified {
 			if opts.Verbose {
@@ -270,7 +267,6 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			phaseStr = apr.PhaseStr
 			groupedSpecs = apr.GroupedSpecs
 			useGroupedSpecs = apr.UseGrouped
-			mediumDiffCount = apr.MediumDiffCount
 			// Enable per-phase role rebinding (arch_reviewer/diff_reviewer) only
 			// for medium/large diffs. Small diffs use flat diff review with the
 			// generic reviewer role.
@@ -334,10 +330,15 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	} else if phaseStr != "" {
 		// Auto-phase medium/large fallback paths supply MediumDiffCount so the
 		// diff phase reviewer count comes from medium_diff_reviewers (NOT
-		// --reviewers, which is reserved for flat / explicit --phase paths).
+		// --reviewers is for --no-auto-phase (flat review). Phase-based
+		// paths use the corresponding knob: small_diff_reviewers for "diff",
+		// medium_diff_reviewers (+1 arch) for "arch,diff".
 		totalForParse := opts.Reviewers
-		if mediumDiffCount > 0 {
-			totalForParse = mediumDiffCount + 1 // +1 for arch
+		switch phaseStr {
+		case "diff":
+			totalForParse = opts.SmallDiffReviewers
+		case "arch,diff":
+			totalForParse = opts.MediumDiffReviewers + 1
 		}
 		phases, phaseErr := parsePhases(phaseStr, totalForParse)
 		if phaseErr != nil {

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1307,23 +1307,28 @@ func TestMaxPotentialReviewers(t *testing.T) {
 	}{
 		{
 			name: "flat dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 5, DiffGroups: 3, MediumDiffReviewers: 2},
-			want: 5, // max(5, 1+3, 1+2) = 5
+			cfg:  config.ResolvedConfig{Reviewers: 5, DiffGroups: 3, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			want: 5, // max(5, 1+3, 1+2, 1) = 5
 		},
 		{
 			name: "grouped dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 8, MediumDiffReviewers: 2},
-			want: 9, // max(3, 1+8, 1+2) = 9
+			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 8, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			want: 9, // max(3, 1+8, 1+2, 1) = 9
 		},
 		{
 			name: "medium dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 2, DiffGroups: 1, MediumDiffReviewers: 5},
-			want: 6, // max(2, 1+1, 1+5) = 6
+			cfg:  config.ResolvedConfig{Reviewers: 2, DiffGroups: 1, MediumDiffReviewers: 5, SmallDiffReviewers: 1},
+			want: 6, // max(2, 1+1, 1+5, 1) = 6
 		},
 		{
 			name: "all equal",
-			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 2, MediumDiffReviewers: 2},
-			want: 3, // max(3, 1+2, 1+2) = 3
+			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 2, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			want: 3, // max(3, 1+2, 1+2, 1) = 3
+		},
+		{
+			name: "small dominates",
+			cfg:  config.ResolvedConfig{Reviewers: 2, DiffGroups: 1, MediumDiffReviewers: 1, SmallDiffReviewers: 10},
+			want: 10, // max(2, 1+1, 1+1, 10) = 10
 		},
 	}
 	for _, tt := range tests {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ type Config struct {
 	Reviewers           *int      `yaml:"reviewers"`
 	DiffGroups          *int      `yaml:"diff_groups"`
 	MediumDiffReviewers *int      `yaml:"medium_diff_reviewers"`
+	SmallDiffReviewers  *int      `yaml:"small_diff_reviewers"`
 	Concurrency         *int      `yaml:"concurrency"`
 	Base                *string   `yaml:"base"`
 	Timeout             *Duration `yaml:"timeout"`
@@ -223,7 +224,7 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "diff_groups", "medium_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
+var knownTopLevelKeys = []string{"reviewers", "diff_groups", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
@@ -490,6 +491,9 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	}
 	if r.MediumDiffReviewers < 1 {
 		errs = append(errs, fmt.Sprintf("medium_diff_reviewers must be >= 1, got %d", r.MediumDiffReviewers))
+	}
+	if r.SmallDiffReviewers < 1 {
+		errs = append(errs, fmt.Sprintf("small_diff_reviewers must be >= 1, got %d", r.SmallDiffReviewers))
 	}
 	if r.Concurrency < 0 {
 		errs = append(errs, fmt.Sprintf("concurrency must be >= 0, got %d", r.Concurrency))
@@ -787,6 +791,7 @@ var Defaults = ResolvedConfig{
 	Reviewers:           5,
 	DiffGroups:          4,
 	MediumDiffReviewers: 2,
+	SmallDiffReviewers:  1,
 	Concurrency:         0,
 	Base:                "main",
 	Timeout:             10 * time.Minute,
@@ -812,6 +817,7 @@ type ResolvedConfig struct {
 	Reviewers           int
 	DiffGroups          int
 	MediumDiffReviewers int
+	SmallDiffReviewers  int
 	Concurrency         int
 	Base                string
 	Timeout             time.Duration
@@ -856,6 +862,7 @@ type FlagState struct {
 	ReviewersSet           bool
 	DiffGroupsSet          bool
 	MediumDiffReviewersSet bool
+	SmallDiffReviewersSet  bool
 	ConcurrencySet         bool
 	BaseSet                bool
 	TimeoutSet             bool
@@ -890,6 +897,8 @@ type EnvState struct {
 	DiffGroupsSet          bool
 	MediumDiffReviewers    int
 	MediumDiffReviewersSet bool
+	SmallDiffReviewers     int
+	SmallDiffReviewersSet  bool
 	Concurrency            int
 	ConcurrencySet         bool
 	Base                   string
@@ -970,6 +979,14 @@ func LoadEnvState() (EnvState, []string) {
 			state.MediumDiffReviewersSet = true
 		} else {
 			warnings = append(warnings, fmt.Sprintf("ACR_MEDIUM_DIFF_REVIEWERS=%q is not a valid integer, ignoring", v))
+		}
+	}
+	if v := os.Getenv("ACR_SMALL_DIFF_REVIEWERS"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			state.SmallDiffReviewers = i
+			state.SmallDiffReviewersSet = true
+		} else {
+			warnings = append(warnings, fmt.Sprintf("ACR_SMALL_DIFF_REVIEWERS=%q is not a valid integer, ignoring", v))
 		}
 	}
 	if v := os.Getenv("ACR_CONCURRENCY"); v != "" {
@@ -1196,6 +1213,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.MediumDiffReviewers != nil {
 			result.MediumDiffReviewers = *cfg.MediumDiffReviewers
 		}
+		if cfg.SmallDiffReviewers != nil {
+			result.SmallDiffReviewers = *cfg.SmallDiffReviewers
+		}
 		if cfg.Concurrency != nil {
 			result.Concurrency = *cfg.Concurrency
 		}
@@ -1279,6 +1299,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if envState.MediumDiffReviewersSet {
 		result.MediumDiffReviewers = envState.MediumDiffReviewers
 	}
+	if envState.SmallDiffReviewersSet {
+		result.SmallDiffReviewers = envState.SmallDiffReviewers
+	}
 	if envState.ConcurrencySet {
 		result.Concurrency = envState.Concurrency
 	}
@@ -1357,6 +1380,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	}
 	if flagState.MediumDiffReviewersSet {
 		result.MediumDiffReviewers = flagValues.MediumDiffReviewers
+	}
+	if flagState.SmallDiffReviewersSet {
+		result.SmallDiffReviewers = flagValues.SmallDiffReviewers
 	}
 	if flagState.ConcurrencySet {
 		result.Concurrency = flagValues.Concurrency

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1202,7 +1202,7 @@ func TestResolveGuidance_ConfigFileAbsolutePath(t *testing.T) {
 func clearACREnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"ACR_REVIEWERS", "ACR_DIFF_GROUPS", "ACR_MEDIUM_DIFF_REVIEWERS",
+		"ACR_REVIEWERS", "ACR_DIFF_GROUPS", "ACR_MEDIUM_DIFF_REVIEWERS", "ACR_SMALL_DIFF_REVIEWERS",
 		"ACR_CONCURRENCY", "ACR_BASE_REF", "ACR_TIMEOUT",
 		"ACR_RETRIES", "ACR_FETCH", "ACR_REVIEWER_AGENT", "ACR_SUMMARIZER_AGENT",
 		"ACR_ARCH_REVIEWER_AGENT", "ACR_DIFF_REVIEWER_AGENTS",
@@ -2775,6 +2775,83 @@ func TestLoadEnvState_MediumDiffReviewers_Malformed(t *testing.T) {
 	}
 	if !hasWarningContaining(warnings, "ACR_MEDIUM_DIFF_REVIEWERS") {
 		t.Errorf("expected warning about ACR_MEDIUM_DIFF_REVIEWERS, got %v", warnings)
+	}
+}
+
+func TestResolve_SmallDiffReviewers_FromYAML(t *testing.T) {
+	cfg := &Config{SmallDiffReviewers: ptr(3)}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.SmallDiffReviewers != 3 {
+		t.Errorf("expected small_diff_reviewers=3 from yaml, got %d", result.SmallDiffReviewers)
+	}
+}
+
+func TestResolve_SmallDiffReviewers_EnvOverridesYAML(t *testing.T) {
+	cfg := &Config{SmallDiffReviewers: ptr(3)}
+	envState := EnvState{SmallDiffReviewers: 7, SmallDiffReviewersSet: true}
+	result := Resolve(cfg, envState, FlagState{}, ResolvedConfig{})
+	if result.SmallDiffReviewers != 7 {
+		t.Errorf("expected env small_diff_reviewers=7 to override yaml, got %d", result.SmallDiffReviewers)
+	}
+}
+
+func TestResolve_SmallDiffReviewers_CLIOverridesEnv(t *testing.T) {
+	cfg := &Config{SmallDiffReviewers: ptr(3)}
+	envState := EnvState{SmallDiffReviewers: 7, SmallDiffReviewersSet: true}
+	flagState := FlagState{SmallDiffReviewersSet: true}
+	flagValues := ResolvedConfig{SmallDiffReviewers: 10}
+	result := Resolve(cfg, envState, flagState, flagValues)
+	if result.SmallDiffReviewers != 10 {
+		t.Errorf("expected CLI small_diff_reviewers=10 to override env, got %d", result.SmallDiffReviewers)
+	}
+}
+
+func TestResolve_SmallDiffReviewers_DefaultsTo1(t *testing.T) {
+	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.SmallDiffReviewers != 1 {
+		t.Errorf("expected default small_diff_reviewers=1, got %d", result.SmallDiffReviewers)
+	}
+	if Defaults.SmallDiffReviewers != 1 {
+		t.Errorf("expected Defaults.SmallDiffReviewers=1, got %d", Defaults.SmallDiffReviewers)
+	}
+}
+
+func TestValidate_RejectsZeroSmallDiffReviewers(t *testing.T) {
+	cfg := Defaults
+	cfg.SmallDiffReviewers = 0
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for small_diff_reviewers=0, got nil")
+	}
+	if !strings.Contains(err.Error(), "small_diff_reviewers must be >= 1") {
+		t.Errorf("expected 'small_diff_reviewers must be >= 1' in error, got: %v", err)
+	}
+}
+
+func TestLoadEnvState_SmallDiffReviewers(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_SMALL_DIFF_REVIEWERS", "4")
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.SmallDiffReviewersSet {
+		t.Error("expected SmallDiffReviewersSet=true")
+	}
+	if state.SmallDiffReviewers != 4 {
+		t.Errorf("expected SmallDiffReviewers=4, got %d", state.SmallDiffReviewers)
+	}
+}
+
+func TestLoadEnvState_SmallDiffReviewers_Malformed(t *testing.T) {
+	clearACREnv(t)
+	t.Setenv("ACR_SMALL_DIFF_REVIEWERS", "bad")
+	state, warnings := LoadEnvState()
+	if state.SmallDiffReviewersSet {
+		t.Error("expected SmallDiffReviewersSet=false for invalid value")
+	}
+	if !hasWarningContaining(warnings, "ACR_SMALL_DIFF_REVIEWERS") {
+		t.Errorf("expected warning about ACR_SMALL_DIFF_REVIEWERS, got %v", warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

- auto-phase small diff (ファイル <= 3, 行数 <= 100) で reviewer 数が `--reviewers` (デフォルト 5) にフォールバックする設計不整合を修正
- `medium_diff_reviewers` と同パターンで `small_diff_reviewers` (デフォルト 1) を全層に実装
- 明示的 `--phase diff` 指定時も `small_diff_reviewers` を使用し、auto-phase small との一貫性を確保

## 変更内容

| ファイル | 変更 |
|----------|------|
| `internal/config/config.go` | Config struct, Defaults(=1), ResolvedConfig, FlagState, EnvState, LoadEnvState(`ACR_SMALL_DIFF_REVIEWERS`), ValidateAll(>=1), Resolve 3層カスケード, knownTopLevelKeys |
| `cmd/acr/main.go` | `--small-diff-reviewers` CLIフラグ, FlagState/flagValues 組立, `maxPotentialReviewers`, `--reviewers` 説明文更新 |
| `cmd/acr/review.go` | `phaseStr == "diff"` 条件で `SmallDiffReviewers` を使用, コメント更新 |
| `internal/config/config_test.go` | Resolve 3層 / Defaults / Validation / LoadEnvState テスト 7件追加 |
| `cmd/acr/review_test.go` | `maxPotentialReviewers` に small ケース追加 |
| `.acr.yaml` | `small_diff_reviewers` エントリ追加 + コメント更新 |

## 設計判断

- `phaseStr == "diff"` の条件で auto-phase small と明示的 `--phase diff` の両方をカバー（medium/large は常に `"arch,diff"` か grouped なので衝突しない）
- レガシー動作（5 reviewer 並列）が必要な場合は `--no-auto-phase` で呼び出す導線が既存

## Test plan

- [x] `go test ./...` 全 14 パッケージ PASS
- [x] `go build ./cmd/acr` 成功
- [x] ACR セルフレビュー実施、指摘対応済み
- [ ] 実環境で small diff に対して `small_diff_reviewers=1` の動作確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)