### PR TITLE
feat: --phase/config key 命名規則を SIZE ベースに統一

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -3,14 +3,14 @@
 
 # Number of parallel reviewers (default: 5)
 # This applies ONLY to flat review path (auto-phase OFF, no --phase).
-# --phase diff uses small_diff_reviewers; --phase arch,diff uses
+# --phase small uses small_diff_reviewers; --phase medium uses
 # medium_diff_reviewers. Auto-phase selects automatically by diff size.
 reviewers: 5
 
 # Number of diff groups in auto-phase grouped path (large diff). Default: 4.
 # Each group reviews a subset of changed files. arch reviewer is always 1
-# (sees full diff). Total reviewers in grouped path = 1 + diff_groups.
-diff_groups: 4
+# (sees full diff). Total reviewers in grouped path = 1 + large_diff_groups.
+large_diff_groups: 4
 
 # Number of reviewers in auto-phase small path. Default: 1.
 # Small diff = files <= 3 AND lines <= 100. Flat diff-only review (no arch).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ internal/
 
 6. **Terminal Detection**: Colors auto-disabled when stdout is not a TTY.
 
-7. **Auto-phase (default on)**: ACR automatically chooses review phases based on diff size. Small diffs → flat `diff` phase; large diffs → grouped arch+diff. Opt out with `--no-auto-phase`, `--phase diff`, `.acr.yaml: auto_phase: false`, or `ACR_AUTO_PHASE=false`. See README "Auto-phase (default) vs flat review" for the full contract.
+7. **Auto-phase (default on)**: ACR automatically chooses review phases based on diff size. Small diffs → flat diff-only review; large diffs → grouped arch+diff. Opt out with `--no-auto-phase`, `--phase small`, `.acr.yaml: auto_phase: false`, or `ACR_AUTO_PHASE=false`. See README "Auto-phase (default) vs flat review" for the full contract.
 
 ## Code Patterns
 

--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ To run a flat (single big diff × N reviewers) review instead:
 
 | Method | How |
 |---|---|
-| Ad-hoc flag | `acr --phase diff` |
+| Ad-hoc flag | `acr --phase small` |
 | Disable auto-phase for one run | `acr --no-auto-phase` |
 | Persistent opt-out in project | `.acr.yaml`: `auto_phase: false` |
 | Persistent opt-out via env | `ACR_AUTO_PHASE=false acr` |
 
-Using `--phase arch,diff` forces both phases explicitly (arch + diff) without grouping, regardless of diff size.
+Using `--phase medium` forces both phases explicitly (arch + diff) without grouping, regardless of diff size.
 
 The verdict field (`ok` / `advisory` / `blocking`) and exit-code policy apply on both paths. Use `--strict` to treat advisory findings as blocking (exit 1).
 
@@ -371,7 +371,7 @@ models:
       reviewer:   { model: sonnet-4-6,   effort: high }
 ```
 
-**`arch_reviewer` / `diff_reviewer` phase-specific roles**: when auto-phase enters a multi-phase run (`medium`/`large` diffs → `arch` + `diff` phases), the phase-specific reviewer role is consulted first at each cascade layer, falling back to the generic `reviewer` role at the *same* layer before descending. Flat review paths (auto-phase OFF, `size=small`, or explicit `--phase diff`) ignore these keys and use `reviewer` only. Legacy flat fields (`reviewer_model`, etc.) apply as the generic reviewer fallback only — there is no `arch_reviewer_model` legacy field.
+**`arch_reviewer` / `diff_reviewer` phase-specific roles**: when auto-phase enters a multi-phase run (`medium`/`large` diffs → `arch` + `diff` phases), the phase-specific reviewer role is consulted first at each cascade layer, falling back to the generic `reviewer` role at the *same* layer before descending. Flat review paths (auto-phase OFF, `size=small`, or explicit `--phase small`) ignore these keys and use `reviewer` only. Legacy flat fields (`reviewer_model`, etc.) apply as the generic reviewer fallback only — there is no `arch_reviewer_model` legacy field.
 
 **`effort` field behavior by agent:**
 - **codex**: `low`, `medium`, or `high` map to `-c model_reasoning_effort=<value>` (codex CLI's config override; there is no `--reasoning-effort` flag). Unknown values are ignored.

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -43,7 +43,7 @@ func parseDiffReviewerAgentsFlag(input string) []string {
 
 var (
 	reviewers           int
-	diffGroups          int
+	largeDiffGroups     int
 	mediumDiffReviewers int
 	smallDiffReviewers  int
 	concurrency         int
@@ -110,13 +110,13 @@ Exit codes:
 
 	// Configuration flags (defaults are resolved via config.Resolve with precedence: flag > env > config > default)
 	rootCmd.Flags().IntVarP(&reviewers, "reviewers", "r", 0,
-		"Number of parallel reviewers for flat review path (auto-phase OFF, no --phase). --phase diff uses --small-diff-reviewers; --phase arch,diff uses --medium-diff-reviewers. (default: 5, env: ACR_REVIEWERS)")
-	rootCmd.Flags().IntVar(&diffGroups, "diff-groups", 0,
-		"Number of diff groups in auto-phase grouped path (large diff) (default: 4, env: ACR_DIFF_GROUPS)")
+		"Number of parallel reviewers for flat review path (auto-phase OFF, no --phase). --phase small uses --small-diff-reviewers; --phase medium uses --medium-diff-reviewers. (default: 5, env: ACR_REVIEWERS)")
+	rootCmd.Flags().IntVar(&largeDiffGroups, "large-diff-groups", 0,
+		"Number of diff groups in auto-phase grouped path (large diff) (default: 4, env: ACR_LARGE_DIFF_GROUPS)")
 	rootCmd.Flags().IntVar(&mediumDiffReviewers, "medium-diff-reviewers", 0,
-		"Number of diff reviewers for auto-phase medium and --phase arch,diff (default: 2, env: ACR_MEDIUM_DIFF_REVIEWERS)")
+		"Number of diff reviewers for auto-phase medium and --phase medium (default: 2, env: ACR_MEDIUM_DIFF_REVIEWERS)")
 	rootCmd.Flags().IntVar(&smallDiffReviewers, "small-diff-reviewers", 0,
-		"Number of reviewers for auto-phase small and --phase diff (default: 1, env: ACR_SMALL_DIFF_REVIEWERS)")
+		"Number of reviewers for auto-phase small and --phase small (default: 1, env: ACR_SMALL_DIFF_REVIEWERS)")
 	rootCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0,
 		"Max concurrent reviewers (default: same as --reviewers, env: ACR_CONCURRENCY)")
 	rootCmd.Flags().StringVarP(&baseRef, "base", "b", "",
@@ -185,7 +185,7 @@ Exit codes:
 	rootCmd.Flags().DurationVar(&crossCheckTimeout, "cross-check-timeout", 0,
 		"Timeout for cross-check phase (default: 5m, env: ACR_CROSS_CHECK_TIMEOUT)")
 	rootCmd.Flags().StringVar(&phase, "phase", "",
-		"Review phases (comma-separated): arch, diff, arch,diff")
+		"Override auto-phase: small, medium")
 	rootCmd.Flags().StringVar(&formatOutput, "format", "text",
 		"Output format: text or json")
 	rootCmd.Flags().BoolVar(&autoPhase, "auto-phase", true,
@@ -407,7 +407,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	autoPhaseAnySet := cmd.Flags().Changed("auto-phase") || cmd.Flags().Changed("no-auto-phase")
 	flagState := config.FlagState{
 		ReviewersSet:           cmd.Flags().Changed("reviewers"),
-		DiffGroupsSet:          cmd.Flags().Changed("diff-groups"),
+		LargeDiffGroupsSet:     cmd.Flags().Changed("large-diff-groups"),
 		MediumDiffReviewersSet: cmd.Flags().Changed("medium-diff-reviewers"),
 		SmallDiffReviewersSet:  cmd.Flags().Changed("small-diff-reviewers"),
 		ConcurrencySet:         cmd.Flags().Changed("concurrency"),
@@ -457,7 +457,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	autoPhaseValue := autoPhase && !noAutoPhase
 	flagValues := config.ResolvedConfig{
 		Reviewers:           reviewers,
-		DiffGroups:          diffGroups,
+		LargeDiffGroups:     largeDiffGroups,
 		MediumDiffReviewers: mediumDiffReviewers,
 		SmallDiffReviewers:  smallDiffReviewers,
 		Concurrency:         concurrency,
@@ -562,7 +562,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 // Used to default/clamp Concurrency so no phase is bottlenecked.
 func maxPotentialReviewers(r config.ResolvedConfig) int {
 	m := r.Reviewers
-	if v := 1 + r.DiffGroups; v > m {
+	if v := 1 + r.LargeDiffGroups; v > m {
 		m = v
 	}
 	if v := 1 + r.MediumDiffReviewers; v > m {

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -149,7 +149,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	// Round-14 F#1: cross-check is invoked only when useGroupedSpecs=true, which
 	// resolveAutoPhase only returns under DiffSizeLarge. Eager resolution here
 	// would force users on small/medium diffs (or `--phase`/`--no-auto-phase`/
-	// arch,diff fallback paths) to satisfy cross_check.model purely to start the
+	// medium fallback paths) to satisfy cross_check.model purely to start the
 	// run — even though cross-check would never execute. Deferring resolve until
 	// the gate also implicitly tightens validate↔runtime symmetry: at the gate,
 	// sizeStr is guaranteed to be "large", matching `canResolveCrossCheckModelForAgent`'s
@@ -259,7 +259,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				func() (agent.Agent, []agent.Agent, error) {
 					return buildPhaseAgents(opts, sizeStr)
 				},
-				opts.DiffGroups, opts.MediumDiffReviewers)
+				opts.LargeDiffGroups, opts.MediumDiffReviewers)
 			if agentsErr != nil {
 				logger.Logf(terminal.StyleError, "Failed to build per-phase reviewer agents: %v", agentsErr)
 				return domain.ExitError
@@ -274,8 +274,8 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			if opts.Verbose {
 				switch {
 				case apr.UseGrouped:
-					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (diff_groups=%d, arch+%d diff groups)",
-						opts.DiffGroups, len(groupedSpecs)-1)
+					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (large_diff_groups=%d, arch+%d diff groups)",
+						opts.LargeDiffGroups, len(groupedSpecs)-1)
 					// Per-phase model matrix rows — only meaningful once we
 					// know the grouped path will actually run. Before this
 					// point, a large→flat fallback would have made these rows
@@ -289,13 +289,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 					}
 				case apr.MediumDiffCount > 0 && apr.FallbackReason != "":
 					logger.Logf(terminal.StyleWarning,
-						"Auto-phase: arch,diff (medium_diff_reviewers=%d) — fallback: %s",
+						"Auto-phase: medium (medium_diff_reviewers=%d) — fallback: %s",
 						apr.MediumDiffCount, apr.FallbackReason)
 				case apr.MediumDiffCount > 0:
 					logger.Logf(terminal.StyleInfo,
-						"Auto-phase: arch,diff (medium_diff_reviewers=%d)", apr.MediumDiffCount)
+						"Auto-phase: medium (medium_diff_reviewers=%d)", apr.MediumDiffCount)
 				case apr.FallbackReason != "":
-					logger.Logf(terminal.StyleWarning, "Auto-phase: falling back to arch,diff (%s)", apr.FallbackReason)
+					logger.Logf(terminal.StyleWarning, "Auto-phase: falling back to medium (%s)", apr.FallbackReason)
 				}
 			}
 		}
@@ -331,13 +331,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		// Auto-phase medium/large fallback paths supply MediumDiffCount so the
 		// diff phase reviewer count comes from medium_diff_reviewers (NOT
 		// --reviewers is for --no-auto-phase (flat review). Phase-based
-		// paths use the corresponding knob: small_diff_reviewers for "diff",
-		// medium_diff_reviewers (+1 arch) for "arch,diff".
+		// paths use the corresponding knob: small_diff_reviewers for "small",
+		// medium_diff_reviewers (+1 arch) for "medium".
 		totalForParse := opts.Reviewers
 		switch phaseStr {
-		case "diff":
+		case "small":
 			totalForParse = opts.SmallDiffReviewers
-		case "arch,diff":
+		case "medium":
 			totalForParse = opts.MediumDiffReviewers + 1
 		}
 		phases, phaseErr := parsePhases(phaseStr, totalForParse)
@@ -483,7 +483,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		}
 		// Lazy CLI availability check: only verify cross-check agent CLIs are
 		// installed when we are about to actually run cross-check. Non-grouped
-		// paths (small diff / explicit --phase / --no-auto-phase / arch,diff)
+		// paths (small diff / explicit --phase / --no-auto-phase / medium)
 		// skip this entirely so users without the cross-check CLI can still
 		// run those review modes.
 		if err := agent.ValidateAgentNames(ccAgentNames); err != nil {
@@ -702,53 +702,29 @@ func isLGTM(grouped domain.GroupedFindings, cc *summarizer.CrossCheckResult) boo
 	return !grouped.HasFindings() && !cc.HasBlockingFindings()
 }
 
-// parsePhases converts a comma-separated phase string into PhaseConfigs.
-// "arch" → 1 arch reviewer; "diff" → N diff reviewers; "arch,diff" → 1 arch + remaining diff.
-// Returns an error for unknown phase tokens, duplicates, or insufficient reviewer budget.
+// parsePhases converts a phase string into PhaseConfigs.
+// "small" → N diff reviewers; "medium" → 1 arch + remaining diff.
+// Returns an error for unknown phase values or insufficient reviewer budget.
 func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, error) {
 	if totalReviewers < 1 {
 		return nil, fmt.Errorf("totalReviewers must be >= 1, got %d", totalReviewers)
 	}
-
-	var phases []runner.PhaseConfig
-	remaining := totalReviewers
-	seen := map[string]bool{}
-
-	parts := strings.Split(phaseStr, ",")
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
+	switch phaseStr {
+	case "small":
+		return []runner.PhaseConfig{
+			{Phase: "diff", ReviewerCount: totalReviewers},
+		}, nil
+	case "medium":
+		if totalReviewers < 2 {
+			return nil, fmt.Errorf("phase %q requires >= 2 reviewers (1 arch + >= 1 diff), got %d", phaseStr, totalReviewers)
 		}
-		if seen[p] {
-			return nil, fmt.Errorf("duplicate phase %q", p)
-		}
-		switch p {
-		case "arch":
-			if remaining < 1 {
-				return nil, fmt.Errorf("not enough reviewers for phase %q (need 1, have %d)", p, remaining)
-			}
-			phases = append(phases, runner.PhaseConfig{
-				Phase:         "arch",
-				ReviewerCount: 1,
-			})
-			remaining--
-			seen[p] = true
-		case "diff":
-			if remaining < 1 {
-				return nil, fmt.Errorf("not enough reviewers for phase %q (need 1, have %d)", p, remaining)
-			}
-			phases = append(phases, runner.PhaseConfig{
-				Phase:         "diff",
-				ReviewerCount: remaining,
-			})
-			remaining = 0
-			seen[p] = true
-		default:
-			return nil, fmt.Errorf("unknown phase %q (valid: arch, diff)", p)
-		}
+		return []runner.PhaseConfig{
+			{Phase: "arch", ReviewerCount: 1},
+			{Phase: "diff", ReviewerCount: totalReviewers - 1},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown phase %q (valid: small, medium)", phaseStr)
 	}
-	return phases, nil
 }
 
 // resolveCrossCheckAgents returns the resolved cross-check agent names and
@@ -773,7 +749,7 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 // resolveAutoPhase). The defense-in-depth log helper logCrossCheckModelMatrix
 // also calls this with the same sizeStr just before the gate, so the size
 // argument is consistent across both call sites. Non-grouped review paths
-// (small / medium / `--phase` / `--no-auto-phase` / arch,diff fallback) skip
+// (small / medium / `--phase` / `--no-auto-phase` / medium fallback) skip
 // cross-check entirely and never invoke this function — that is the entire
 // point of Round-14 F#1's resolve deferral.
 //
@@ -907,16 +883,16 @@ type autoPhaseResult struct {
 	GroupedSpecs    []runner.ReviewerSpec // non-nil → use grouped diff path
 	UseGrouped      bool
 	FallbackReason  string // non-empty when UseGrouped was downgraded to false
-	MediumDiffCount int    // 0 = not an arch,diff fallback; otherwise the diff-phase reviewer count to use with parsePhases (arch=1 + this)
+	MediumDiffCount int    // 0 = not a medium fallback; otherwise the diff-phase reviewer count to use with parsePhases (arch=1 + this)
 }
 
 // resolveAutoPhase determines phase configuration based on diff size and the
 // new auto-phase knobs.
 //
-//   - diffGroups: target group count for the grouped (large) path; capped by
+//   - largeDiffGroups: target group count for the grouped (large) path; capped by
 //     the actual file count to keep at least 1 file per group.
 //   - mediumDiffReviewers: diff-phase reviewer count for the medium path
-//     (arch,diff) and for any large fallback to arch,diff.
+//     (medium) and for any large fallback to medium.
 //
 // archAgent and diffAgents are passed through to buildGroupedDiffSpecs so the
 // arch and diff phases can use distinct agent backends per
@@ -930,31 +906,31 @@ func resolveAutoPhase(
 	diff, guidance string,
 	diffPrecomputed bool,
 	buildAgents func() (agent.Agent, []agent.Agent, error),
-	diffGroups int,
+	largeDiffGroups int,
 	mediumDiffReviewers int,
 ) (autoPhaseResult, error) {
 	switch size {
 	case git.DiffSizeSmall:
 		// Small: flat diff path; reviewer count comes from small_diff_reviewers.
-		return autoPhaseResult{PhaseStr: "diff"}, nil
+		return autoPhaseResult{PhaseStr: "small"}, nil
 	case git.DiffSizeLarge:
 		fileCount := len(git.ParseDiffSections(diff))
 		// Sanity cap: 1 group must contain at least 1 file.
-		effectiveGroups := diffGroups
+		effectiveGroups := largeDiffGroups
 		if effectiveGroups > fileCount {
 			effectiveGroups = fileCount
 		}
 		if effectiveGroups < 2 {
 			// Grouped path needs >=2 diff groups to be meaningful. Fall back to
-			// flat arch,diff (parsePhases + reviewAgents) without ever touching
+			// flat medium (parsePhases + reviewAgents) without ever touching
 			// buildAgents, so per-phase override CLI availability does not gate
 			// the fallback.
 			return autoPhaseResult{
-				PhaseStr:        "arch,diff",
+				PhaseStr:        "medium",
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason: fmt.Sprintf(
-					"only %d non-empty diff group(s) possible (file_count=%d, diff_groups=%d)",
-					effectiveGroups, fileCount, diffGroups),
+					"only %d non-empty diff group(s) possible (file_count=%d, large_diff_groups=%d)",
+					effectiveGroups, fileCount, largeDiffGroups),
 			}, nil
 		}
 		// Grouped path confirmed viable; now build the per-phase agents. An
@@ -969,7 +945,7 @@ func resolveAutoPhase(
 		specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, effectiveGroups)
 		if err != nil {
 			return autoPhaseResult{
-				PhaseStr:        "arch,diff",
+				PhaseStr:        "medium",
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason:  fmt.Sprintf("buildGroupedDiffSpecs failed: %v", err),
 			}, nil
@@ -978,7 +954,7 @@ func resolveAutoPhase(
 		diffGroupCount := len(specs) - 1
 		if diffGroupCount < 2 {
 			return autoPhaseResult{
-				PhaseStr:        "arch,diff",
+				PhaseStr:        "medium",
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason:  fmt.Sprintf("only %d non-empty diff group(s) after building", diffGroupCount),
 			}, nil
@@ -990,7 +966,7 @@ func resolveAutoPhase(
 	default: // medium
 		// Medium: arch (1) + diff (mediumDiffReviewers). Never calls buildAgents.
 		return autoPhaseResult{
-			PhaseStr:        "arch,diff",
+			PhaseStr:        "medium",
 			MediumDiffCount: mediumDiffReviewers,
 		}, nil
 	}
@@ -1139,7 +1115,7 @@ func logCrossCheckModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr 
 //     diffAgents assigned round-robin per non-empty diff group
 //
 // maxDiffGroups is supplied by the caller (resolveAutoPhase) from the
-// dedicated `diff_groups` knob, capped at the actual file count so that
+// dedicated `large_diff_groups` knob, capped at the actual file count so that
 // every group has at least 1 file.
 //
 // archAgent and diffAgents are independent so per-phase reviewer overrides

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -21,7 +21,7 @@ type ReviewOpts struct {
 	UseRefFile      bool
 	ExcludePatterns []string
 	WorkDir         string // Worktree path (empty = current directory)
-	Phase           string // Comma-separated phases: "arch", "diff", "arch,diff" (empty = legacy)
+	Phase           string // Review phase: "small", "medium" (empty = auto-phase / flat)
 	Format          string // Output format: "text" (default) or "json"
 	// AutoPhase is inherited from the embedded ResolvedConfig field.
 }

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -24,20 +24,20 @@ func TestParsePhases(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:      "single arch",
-			phaseStr:  "arch",
-			reviewers: 3,
-			want:      []runner.PhaseConfig{{Phase: "arch", ReviewerCount: 1}},
+			name:      "small with 1 reviewer",
+			phaseStr:  "small",
+			reviewers: 1,
+			want:      []runner.PhaseConfig{{Phase: "diff", ReviewerCount: 1}},
 		},
 		{
-			name:      "single diff",
-			phaseStr:  "diff",
+			name:      "small with 3 reviewers",
+			phaseStr:  "small",
 			reviewers: 3,
 			want:      []runner.PhaseConfig{{Phase: "diff", ReviewerCount: 3}},
 		},
 		{
-			name:      "arch,diff with enough reviewers",
-			phaseStr:  "arch,diff",
+			name:      "medium with 3 reviewers",
+			phaseStr:  "medium",
 			reviewers: 3,
 			want: []runner.PhaseConfig{
 				{Phase: "arch", ReviewerCount: 1},
@@ -45,8 +45,8 @@ func TestParsePhases(t *testing.T) {
 			},
 		},
 		{
-			name:      "arch,diff minimum reviewers",
-			phaseStr:  "arch,diff",
+			name:      "medium with 2 reviewers (minimum)",
+			phaseStr:  "medium",
 			reviewers: 2,
 			want: []runner.PhaseConfig{
 				{Phase: "arch", ReviewerCount: 1},
@@ -54,52 +54,40 @@ func TestParsePhases(t *testing.T) {
 			},
 		},
 		{
-			name:      "unknown phase token",
-			phaseStr:  "arch,dif",
-			reviewers: 3,
-			wantErr:   true,
-		},
-		{
-			name:      "duplicate phase",
-			phaseStr:  "arch,arch",
-			reviewers: 3,
-			wantErr:   true,
-		},
-		{
-			name:      "budget exhausted by arch,diff with 1 reviewer",
-			phaseStr:  "arch,diff",
+			name:      "medium with 1 reviewer errors (needs >= 2)",
+			phaseStr:  "medium",
 			reviewers: 1,
 			wantErr:   true,
 		},
 		{
-			name:      "zero reviewers",
+			name:      "unknown phase",
+			phaseStr:  "unknown",
+			reviewers: 3,
+			wantErr:   true,
+		},
+		{
+			name:      "old phase name diff is rejected",
 			phaseStr:  "diff",
+			reviewers: 3,
+			wantErr:   true,
+		},
+		{
+			name:      "old phase name arch is rejected",
+			phaseStr:  "arch",
+			reviewers: 3,
+			wantErr:   true,
+		},
+		{
+			name:      "zero reviewers",
+			phaseStr:  "small",
 			reviewers: 0,
 			wantErr:   true,
 		},
 		{
 			name:      "negative reviewers",
-			phaseStr:  "arch",
+			phaseStr:  "small",
 			reviewers: -1,
 			wantErr:   true,
-		},
-		{
-			name:      "whitespace trimmed",
-			phaseStr:  " arch , diff ",
-			reviewers: 3,
-			want: []runner.PhaseConfig{
-				{Phase: "arch", ReviewerCount: 1},
-				{Phase: "diff", ReviewerCount: 2},
-			},
-		},
-		{
-			name:      "empty parts ignored",
-			phaseStr:  "arch,,diff",
-			reviewers: 3,
-			want: []runner.PhaseConfig{
-				{Phase: "arch", ReviewerCount: 1},
-				{Phase: "diff", ReviewerCount: 2},
-			},
 		},
 	}
 
@@ -271,7 +259,7 @@ func TestBuildGroupedDiffSpecs_FallbackOnError(t *testing.T) {
 //
 // Signature: resolveAutoPhase(size, diff, guidance, diffPrecomputed,
 //   buildAgents func() (agent.Agent, []agent.Agent, error),
-//   diffGroups, mediumDiffReviewers) (autoPhaseResult, error)
+//   largeDiffGroups, mediumDiffReviewers) (autoPhaseResult, error)
 //
 // Tests use testBuildAgents to return pre-constructed agents synchronously.
 // The closure is only invoked when the large grouped path decides to proceed,
@@ -284,7 +272,7 @@ func testBuildAgents(arch agent.Agent, diffs []agent.Agent) func() (agent.Agent,
 }
 
 func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
-	// Large diff with diff_groups=3 → grouped specs
+	// Large diff with large_diff_groups=3 → grouped specs
 	sections := makeSectionsForReview(12, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -292,7 +280,7 @@ func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
 
 	if !apr.UseGrouped {
-		t.Fatal("expected UseGrouped=true for large diff with diff_groups=3")
+		t.Fatal("expected UseGrouped=true for large diff with large_diff_groups=3")
 	}
 	if apr.PhaseStr != "" {
 		t.Errorf("expected empty PhaseStr, got %q", apr.PhaseStr)
@@ -311,8 +299,8 @@ func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when buildGroupedDiffSpecs fails")
 	}
-	if apr.PhaseStr != "arch,diff" {
-		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
+	if apr.PhaseStr != "medium" {
+		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 2 {
 		t.Errorf("expected MediumDiffCount=2 (from medium_diff_reviewers), got %d", apr.MediumDiffCount)
@@ -624,9 +612,9 @@ func TestResolveCrossCheckAgents_AgentDefaultsToSummarizer(t *testing.T) {
 
 // TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat verifies that exactly
 // 1 non-empty diff group (< 2) still triggers the fallback. With
-// diff_groups=1 the file_count cap also kicks in early.
+// large_diff_groups=1 the file_count cap also kicks in early.
 func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
-	// 2 files, diff_groups=1 → file_count cap → effectiveGroups=1 → fallback.
+	// 2 files, large_diff_groups=1 → file_count cap → effectiveGroups=1 → fallback.
 	sections := makeSectionsForReview(2, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -634,10 +622,10 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 1, 2)
 
 	if apr.UseGrouped {
-		t.Fatal("expected UseGrouped=false for diff_groups=1")
+		t.Fatal("expected UseGrouped=false for large_diff_groups=1")
 	}
-	if apr.PhaseStr != "arch,diff" {
-		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
+	if apr.PhaseStr != "medium" {
+		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.FallbackReason == "" {
 		t.Error("expected non-empty FallbackReason")
@@ -647,10 +635,10 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	}
 }
 
-// TestResolveAutoPhase_TwoDiffGroups_KeepsGrouped verifies that 2 or more
+// TestResolveAutoPhase_TwoLargeDiffGroups_KeepsGrouped verifies that 2 or more
 // non-empty diff groups result in UseGrouped=true (no fallback).
-func TestResolveAutoPhase_TwoDiffGroups_KeepsGrouped(t *testing.T) {
-	// 6 files, diff_groups=2 → expect 2 diff groups.
+func TestResolveAutoPhase_TwoLargeDiffGroups_KeepsGrouped(t *testing.T) {
+	// 6 files, large_diff_groups=2 → expect 2 diff groups.
 	sections := makeSectionsForReview(6, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -677,7 +665,7 @@ func TestLargeReview_GroupedSpecsProduceCrossCheckableTopology(t *testing.T) {
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
 	if !apr.UseGrouped {
-		t.Fatal("expected UseGrouped=true for large diff with diff_groups=3")
+		t.Fatal("expected UseGrouped=true for large diff with large_diff_groups=3")
 	}
 	if apr.GroupedSpecs[0].GroupKey != "arch" {
 		t.Errorf("expected first spec GroupKey=arch, got %q", apr.GroupedSpecs[0].GroupKey)
@@ -823,12 +811,12 @@ func TestExecuteReview_NoArgs_UsesAutoPhasePath(t *testing.T) {
 	}
 }
 
-// TestExecuteReview_PhaseDiff_UsesFlatPath: explicit --phase diff → auto-phase
+// TestExecuteReview_PhaseSmall_UsesFlatPath: explicit --phase small → auto-phase
 // is ignored regardless of AutoPhase value.
-func TestExecuteReview_PhaseDiff_UsesFlatPath(t *testing.T) {
+func TestExecuteReview_PhaseSmall_UsesFlatPath(t *testing.T) {
 	opts := ReviewOpts{
 		ResolvedConfig: config.ResolvedConfig{AutoPhase: true},
-		Phase:          "diff",
+		Phase:          "small",
 	}
 	if shouldUseAutoPhase(opts) {
 		t.Error("expected shouldUseAutoPhase=false when Phase is explicitly set")
@@ -913,7 +901,7 @@ func TestReview_ExitCodePolicy_PropagatesErrors(t *testing.T) {
 // --- Flat-path verdict pipeline tests (Part D) ---
 
 // TestFlatPath_VerdictRendered verifies that on the flat path (AutoPhase=false,
-// Phase="diff") ComputeVerdict produces the correct verdict for each severity
+// Phase="small") ComputeVerdict produces the correct verdict for each severity
 // class, and that RenderReport + RenderJSON both include the verdict string.
 // This is a seam-level test — no subprocess is spawned.
 func TestFlatPath_VerdictRendered(t *testing.T) {
@@ -993,14 +981,14 @@ func TestFlatPath_VerdictRendered(t *testing.T) {
 	}
 }
 
-// --- New auto-phase knob tests (diff_groups / medium_diff_reviewers) ---
+// --- New auto-phase knob tests (large_diff_groups / medium_diff_reviewers) ---
 
-// TestResolveAutoPhase_LargeUsesDiffGroupsKnob verifies that the diff_groups
+// TestResolveAutoPhase_LargeUsesLargeDiffGroupsKnob verifies that the large_diff_groups
 // knob caps the grouped diff path. With many files / lines the greedy packer
-// would normally produce > diffGroups groups; diffGroups=3 caps the result.
-func TestResolveAutoPhase_LargeUsesDiffGroupsKnob(t *testing.T) {
+// would normally produce > largeDiffGroups groups; largeDiffGroups=3 caps the result.
+func TestResolveAutoPhase_LargeUsesLargeDiffGroupsKnob(t *testing.T) {
 	// 25 files × 50 lines (1250 lines, default 200/group) → ~7 groups
-	// without cap; diff_groups=3 caps to 3.
+	// without cap; large_diff_groups=3 caps to 3.
 	sections := makeSectionsForReview(25, 50)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -1012,18 +1000,18 @@ func TestResolveAutoPhase_LargeUsesDiffGroupsKnob(t *testing.T) {
 	}
 	diffGroupCount := len(apr.GroupedSpecs) - 1
 	if diffGroupCount > 3 {
-		t.Errorf("expected at most 3 diff groups (diff_groups=3 cap), got %d", diffGroupCount)
+		t.Errorf("expected at most 3 diff groups (large_diff_groups=3 cap), got %d", diffGroupCount)
 	}
 	if diffGroupCount < 2 {
 		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
 	}
 }
 
-// TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall verifies
+// TestResolveAutoPhase_LargeFallbackToMedium_WhenFileCountTooSmall verifies
 // that when file_count<2 the grouped path is impossible and falls back to
-// arch,diff carrying medium_diff_reviewers as MediumDiffCount.
-func TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall(t *testing.T) {
-	// 1 file, diff_groups=4 → effectiveGroups=1 → fallback.
+// medium carrying medium_diff_reviewers as MediumDiffCount.
+func TestResolveAutoPhase_LargeFallbackToMedium_WhenFileCountTooSmall(t *testing.T) {
+	// 1 file, large_diff_groups=4 → effectiveGroups=1 → fallback.
 	sections := makeSectionsForReview(1, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -1033,8 +1021,8 @@ func TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall(t *testi
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when fileCount<2")
 	}
-	if apr.PhaseStr != "arch,diff" {
-		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
+	if apr.PhaseStr != "medium" {
+		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 3 {
 		t.Errorf("expected MediumDiffCount=3 (from medium_diff_reviewers), got %d", apr.MediumDiffCount)
@@ -1045,15 +1033,15 @@ func TestResolveAutoPhase_LargeFallbackToArchDiff_WhenFileCountTooSmall(t *testi
 }
 
 // TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob verifies that medium
-// path returns arch,diff with MediumDiffCount=mediumDiffReviewers.
+// path returns medium with MediumDiffCount=mediumDiffReviewers.
 func TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob(t *testing.T) {
 	apr, _ := resolveAutoPhase(git.DiffSizeMedium, "", "", true, testBuildAgents(nil, nil), 4, 4)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false on medium")
 	}
-	if apr.PhaseStr != "arch,diff" {
-		t.Errorf("expected PhaseStr 'arch,diff', got %q", apr.PhaseStr)
+	if apr.PhaseStr != "medium" {
+		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 4 {
 		t.Errorf("expected MediumDiffCount=4, got %d", apr.MediumDiffCount)
@@ -1061,13 +1049,13 @@ func TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob(t *testing.T) {
 }
 
 // TestResolveAutoPhase_LargeRespectsFileCountUpperBound verifies that
-// effectiveGroups = min(diffGroups, fileCount). With diff_groups>>fileCount
+// effectiveGroups = min(largeDiffGroups, fileCount). With large_diff_groups>>fileCount
 // the cap is fileCount; the resulting group count never exceeds fileCount.
 func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 	// 12 files (> default 5 files/group) so the greedy packer naturally
-	// produces multiple groups; diff_groups=10 is capped to fileCount=12.
+	// produces multiple groups; large_diff_groups=10 is capped to fileCount=12.
 	// We assert the resulting count never exceeds fileCount and remains
-	// within the diff_groups cap.
+	// within the large_diff_groups cap.
 	sections := makeSectionsForReview(12, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -1075,14 +1063,14 @@ func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 10, 2)
 
 	if !apr.UseGrouped {
-		t.Fatalf("expected UseGrouped=true with 12 files / diff_groups=10; FallbackReason=%q", apr.FallbackReason)
+		t.Fatalf("expected UseGrouped=true with 12 files / large_diff_groups=10; FallbackReason=%q", apr.FallbackReason)
 	}
 	diffGroupCount := len(apr.GroupedSpecs) - 1
 	if diffGroupCount > 12 {
 		t.Errorf("expected diff group count capped at fileCount=12, got %d", diffGroupCount)
 	}
 	if diffGroupCount > 10 {
-		t.Errorf("expected diff group count capped at diff_groups=10, got %d", diffGroupCount)
+		t.Errorf("expected diff group count capped at large_diff_groups=10, got %d", diffGroupCount)
 	}
 	if diffGroupCount < 2 {
 		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
@@ -1095,8 +1083,8 @@ func TestResolveAutoPhase_Small(t *testing.T) {
 	if apr.UseGrouped {
 		t.Errorf("expected UseGrouped=false for small")
 	}
-	if apr.PhaseStr != "diff" {
-		t.Errorf("expected PhaseStr 'diff', got %q", apr.PhaseStr)
+	if apr.PhaseStr != "small" {
+		t.Errorf("expected PhaseStr 'small', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 0 {
 		t.Errorf("expected MediumDiffCount=0 on small, got %d", apr.MediumDiffCount)
@@ -1307,27 +1295,27 @@ func TestMaxPotentialReviewers(t *testing.T) {
 	}{
 		{
 			name: "flat dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 5, DiffGroups: 3, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 5, LargeDiffGroups: 3, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
 			want: 5, // max(5, 1+3, 1+2, 1) = 5
 		},
 		{
 			name: "grouped dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 8, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 3, LargeDiffGroups: 8, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
 			want: 9, // max(3, 1+8, 1+2, 1) = 9
 		},
 		{
 			name: "medium dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 2, DiffGroups: 1, MediumDiffReviewers: 5, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 2, LargeDiffGroups: 1, MediumDiffReviewers: 5, SmallDiffReviewers: 1},
 			want: 6, // max(2, 1+1, 1+5, 1) = 6
 		},
 		{
 			name: "all equal",
-			cfg:  config.ResolvedConfig{Reviewers: 3, DiffGroups: 2, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 3, LargeDiffGroups: 2, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
 			want: 3, // max(3, 1+2, 1+2, 1) = 3
 		},
 		{
 			name: "small dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 2, DiffGroups: 1, MediumDiffReviewers: 1, SmallDiffReviewers: 10},
+			cfg:  config.ResolvedConfig{Reviewers: 2, LargeDiffGroups: 1, MediumDiffReviewers: 1, SmallDiffReviewers: 10},
 			want: 10, // max(2, 1+1, 1+1, 10) = 10
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,7 +86,7 @@ type ModelsConfig struct {
 
 type Config struct {
 	Reviewers           *int      `yaml:"reviewers"`
-	DiffGroups          *int      `yaml:"diff_groups"`
+	LargeDiffGroups     *int      `yaml:"large_diff_groups"`
 	MediumDiffReviewers *int      `yaml:"medium_diff_reviewers"`
 	SmallDiffReviewers  *int      `yaml:"small_diff_reviewers"`
 	Concurrency         *int      `yaml:"concurrency"`
@@ -224,7 +224,7 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "diff_groups", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
+var knownTopLevelKeys = []string{"reviewers", "large_diff_groups", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
@@ -486,8 +486,8 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.Reviewers < 1 {
 		errs = append(errs, fmt.Sprintf("reviewers must be >= 1, got %d", r.Reviewers))
 	}
-	if r.DiffGroups < 1 {
-		errs = append(errs, fmt.Sprintf("diff_groups must be >= 1, got %d", r.DiffGroups))
+	if r.LargeDiffGroups < 1 {
+		errs = append(errs, fmt.Sprintf("large_diff_groups must be >= 1, got %d", r.LargeDiffGroups))
 	}
 	if r.MediumDiffReviewers < 1 {
 		errs = append(errs, fmt.Sprintf("medium_diff_reviewers must be >= 1, got %d", r.MediumDiffReviewers))
@@ -789,7 +789,7 @@ func (r *ResolvedConfig) Validate() error {
 
 var Defaults = ResolvedConfig{
 	Reviewers:           5,
-	DiffGroups:          4,
+	LargeDiffGroups:     4,
 	MediumDiffReviewers: 2,
 	SmallDiffReviewers:  1,
 	Concurrency:         0,
@@ -815,7 +815,7 @@ var Defaults = ResolvedConfig{
 
 type ResolvedConfig struct {
 	Reviewers           int
-	DiffGroups          int
+	LargeDiffGroups     int
 	MediumDiffReviewers int
 	SmallDiffReviewers  int
 	Concurrency         int
@@ -860,7 +860,7 @@ type ResolvedConfig struct {
 
 type FlagState struct {
 	ReviewersSet           bool
-	DiffGroupsSet          bool
+	LargeDiffGroupsSet     bool
 	MediumDiffReviewersSet bool
 	SmallDiffReviewersSet  bool
 	ConcurrencySet         bool
@@ -893,8 +893,8 @@ type FlagState struct {
 type EnvState struct {
 	Reviewers              int
 	ReviewersSet           bool
-	DiffGroups             int
-	DiffGroupsSet          bool
+	LargeDiffGroups        int
+	LargeDiffGroupsSet     bool
 	MediumDiffReviewers    int
 	MediumDiffReviewersSet bool
 	SmallDiffReviewers     int
@@ -965,12 +965,12 @@ func LoadEnvState() (EnvState, []string) {
 			warnings = append(warnings, fmt.Sprintf("ACR_REVIEWERS=%q is not a valid integer, ignoring", v))
 		}
 	}
-	if v := os.Getenv("ACR_DIFF_GROUPS"); v != "" {
+	if v := os.Getenv("ACR_LARGE_DIFF_GROUPS"); v != "" {
 		if i, err := strconv.Atoi(v); err == nil {
-			state.DiffGroups = i
-			state.DiffGroupsSet = true
+			state.LargeDiffGroups = i
+			state.LargeDiffGroupsSet = true
 		} else {
-			warnings = append(warnings, fmt.Sprintf("ACR_DIFF_GROUPS=%q is not a valid integer, ignoring", v))
+			warnings = append(warnings, fmt.Sprintf("ACR_LARGE_DIFF_GROUPS=%q is not a valid integer, ignoring", v))
 		}
 	}
 	if v := os.Getenv("ACR_MEDIUM_DIFF_REVIEWERS"); v != "" {
@@ -1207,8 +1207,8 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.Reviewers != nil {
 			result.Reviewers = *cfg.Reviewers
 		}
-		if cfg.DiffGroups != nil {
-			result.DiffGroups = *cfg.DiffGroups
+		if cfg.LargeDiffGroups != nil {
+			result.LargeDiffGroups = *cfg.LargeDiffGroups
 		}
 		if cfg.MediumDiffReviewers != nil {
 			result.MediumDiffReviewers = *cfg.MediumDiffReviewers
@@ -1293,8 +1293,8 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if envState.ReviewersSet {
 		result.Reviewers = envState.Reviewers
 	}
-	if envState.DiffGroupsSet {
-		result.DiffGroups = envState.DiffGroups
+	if envState.LargeDiffGroupsSet {
+		result.LargeDiffGroups = envState.LargeDiffGroups
 	}
 	if envState.MediumDiffReviewersSet {
 		result.MediumDiffReviewers = envState.MediumDiffReviewers
@@ -1375,8 +1375,8 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if flagState.ReviewersSet {
 		result.Reviewers = flagValues.Reviewers
 	}
-	if flagState.DiffGroupsSet {
-		result.DiffGroups = flagValues.DiffGroups
+	if flagState.LargeDiffGroupsSet {
+		result.LargeDiffGroups = flagValues.LargeDiffGroups
 	}
 	if flagState.MediumDiffReviewersSet {
 		result.MediumDiffReviewers = flagValues.MediumDiffReviewers

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1202,7 +1202,7 @@ func TestResolveGuidance_ConfigFileAbsolutePath(t *testing.T) {
 func clearACREnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"ACR_REVIEWERS", "ACR_DIFF_GROUPS", "ACR_MEDIUM_DIFF_REVIEWERS", "ACR_SMALL_DIFF_REVIEWERS",
+		"ACR_REVIEWERS", "ACR_LARGE_DIFF_GROUPS", "ACR_MEDIUM_DIFF_REVIEWERS", "ACR_SMALL_DIFF_REVIEWERS",
 		"ACR_CONCURRENCY", "ACR_BASE_REF", "ACR_TIMEOUT",
 		"ACR_RETRIES", "ACR_FETCH", "ACR_REVIEWER_AGENT", "ACR_SUMMARIZER_AGENT",
 		"ACR_ARCH_REVIEWER_AGENT", "ACR_DIFF_REVIEWER_AGENTS",
@@ -2621,44 +2621,44 @@ func TestLoadEnvState_DiffReviewerAgents(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests for diff_groups and medium_diff_reviewers (auto-phase reviewer knobs)
+// Tests for large_diff_groups and medium_diff_reviewers (auto-phase reviewer knobs)
 // ---------------------------------------------------------------------------
 
-func TestResolve_DiffGroups_FromYAML(t *testing.T) {
-	cfg := &Config{DiffGroups: ptr(7)}
+func TestResolve_LargeDiffGroups_FromYAML(t *testing.T) {
+	cfg := &Config{LargeDiffGroups: ptr(7)}
 	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
-	if result.DiffGroups != 7 {
-		t.Errorf("expected diff_groups=7 from yaml, got %d", result.DiffGroups)
+	if result.LargeDiffGroups != 7 {
+		t.Errorf("expected large_diff_groups=7 from yaml, got %d", result.LargeDiffGroups)
 	}
 }
 
-func TestResolve_DiffGroups_EnvOverridesYAML(t *testing.T) {
-	cfg := &Config{DiffGroups: ptr(7)}
-	envState := EnvState{DiffGroups: 9, DiffGroupsSet: true}
+func TestResolve_LargeDiffGroups_EnvOverridesYAML(t *testing.T) {
+	cfg := &Config{LargeDiffGroups: ptr(7)}
+	envState := EnvState{LargeDiffGroups: 9, LargeDiffGroupsSet: true}
 	result := Resolve(cfg, envState, FlagState{}, ResolvedConfig{})
-	if result.DiffGroups != 9 {
-		t.Errorf("expected env diff_groups=9 to override yaml, got %d", result.DiffGroups)
+	if result.LargeDiffGroups != 9 {
+		t.Errorf("expected env large_diff_groups=9 to override yaml, got %d", result.LargeDiffGroups)
 	}
 }
 
-func TestResolve_DiffGroups_CLIOverridesEnv(t *testing.T) {
-	cfg := &Config{DiffGroups: ptr(7)}
-	envState := EnvState{DiffGroups: 9, DiffGroupsSet: true}
-	flagState := FlagState{DiffGroupsSet: true}
-	flagValues := ResolvedConfig{DiffGroups: 12}
+func TestResolve_LargeDiffGroups_CLIOverridesEnv(t *testing.T) {
+	cfg := &Config{LargeDiffGroups: ptr(7)}
+	envState := EnvState{LargeDiffGroups: 9, LargeDiffGroupsSet: true}
+	flagState := FlagState{LargeDiffGroupsSet: true}
+	flagValues := ResolvedConfig{LargeDiffGroups: 12}
 	result := Resolve(cfg, envState, flagState, flagValues)
-	if result.DiffGroups != 12 {
-		t.Errorf("expected CLI diff_groups=12 to override env, got %d", result.DiffGroups)
+	if result.LargeDiffGroups != 12 {
+		t.Errorf("expected CLI large_diff_groups=12 to override env, got %d", result.LargeDiffGroups)
 	}
 }
 
-func TestResolve_DiffGroups_DefaultsTo4(t *testing.T) {
+func TestResolve_LargeDiffGroups_DefaultsTo4(t *testing.T) {
 	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
-	if result.DiffGroups != 4 {
-		t.Errorf("expected default diff_groups=4, got %d", result.DiffGroups)
+	if result.LargeDiffGroups != 4 {
+		t.Errorf("expected default large_diff_groups=4, got %d", result.LargeDiffGroups)
 	}
-	if Defaults.DiffGroups != 4 {
-		t.Errorf("expected Defaults.DiffGroups=4, got %d", Defaults.DiffGroups)
+	if Defaults.LargeDiffGroups != 4 {
+		t.Errorf("expected Defaults.LargeDiffGroups=4, got %d", Defaults.LargeDiffGroups)
 	}
 }
 
@@ -2700,15 +2700,15 @@ func TestResolve_MediumDiffReviewers_DefaultsTo2(t *testing.T) {
 	}
 }
 
-func TestValidate_RejectsZeroDiffGroups(t *testing.T) {
+func TestValidate_RejectsZeroLargeDiffGroups(t *testing.T) {
 	cfg := Defaults
-	cfg.DiffGroups = 0
+	cfg.LargeDiffGroups = 0
 	err := cfg.Validate()
 	if err == nil {
-		t.Fatal("expected error for diff_groups=0, got nil")
+		t.Fatal("expected error for large_diff_groups=0, got nil")
 	}
-	if !strings.Contains(err.Error(), "diff_groups must be >= 1") {
-		t.Errorf("expected 'diff_groups must be >= 1' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "large_diff_groups must be >= 1") {
+		t.Errorf("expected 'large_diff_groups must be >= 1' in error, got: %v", err)
 	}
 }
 
@@ -2724,30 +2724,30 @@ func TestValidate_RejectsZeroMediumDiffReviewers(t *testing.T) {
 	}
 }
 
-func TestLoadEnvState_DiffGroups(t *testing.T) {
+func TestLoadEnvState_LargeDiffGroups(t *testing.T) {
 	clearACREnv(t)
-	t.Setenv("ACR_DIFF_GROUPS", "6")
+	t.Setenv("ACR_LARGE_DIFF_GROUPS", "6")
 	state, warnings := LoadEnvState()
 	if len(warnings) != 0 {
 		t.Errorf("expected no warnings, got %v", warnings)
 	}
-	if !state.DiffGroupsSet {
-		t.Error("expected DiffGroupsSet=true")
+	if !state.LargeDiffGroupsSet {
+		t.Error("expected LargeDiffGroupsSet=true")
 	}
-	if state.DiffGroups != 6 {
-		t.Errorf("expected DiffGroups=6, got %d", state.DiffGroups)
+	if state.LargeDiffGroups != 6 {
+		t.Errorf("expected LargeDiffGroups=6, got %d", state.LargeDiffGroups)
 	}
 }
 
-func TestLoadEnvState_DiffGroups_Malformed(t *testing.T) {
+func TestLoadEnvState_LargeDiffGroups_Malformed(t *testing.T) {
 	clearACREnv(t)
-	t.Setenv("ACR_DIFF_GROUPS", "abc")
+	t.Setenv("ACR_LARGE_DIFF_GROUPS", "abc")
 	state, warnings := LoadEnvState()
-	if state.DiffGroupsSet {
-		t.Error("expected DiffGroupsSet=false for invalid value")
+	if state.LargeDiffGroupsSet {
+		t.Error("expected LargeDiffGroupsSet=false for invalid value")
 	}
-	if !hasWarningContaining(warnings, "ACR_DIFF_GROUPS") {
-		t.Errorf("expected warning about ACR_DIFF_GROUPS, got %v", warnings)
+	if !hasWarningContaining(warnings, "ACR_LARGE_DIFF_GROUPS") {
+		t.Errorf("expected warning about ACR_LARGE_DIFF_GROUPS, got %v", warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `--phase diff` → `--phase small`, `--phase arch,diff` → `--phase medium` にリネーム
- `diff_groups` → `large_diff_groups` (YAML key, CLI flag `--large-diff-groups`, env var `ACR_LARGE_DIFF_GROUPS`)
- `parsePhases` をカンマ区切りトークンパーサーから SIZE ベース switch に書き換え
- Runner 層の内部 phase 文字列 (`"arch"`, `"diff"`) は変更なし
- 後方互換性なし (旧名は即時削除、トリアージログで決定済み)

Closes #8 の命名規則統一部分。

## 変更ファイル (9 files)

| ファイル | 変更内容 |
|----------|----------|
| `internal/config/config.go` | `DiffGroups` → `LargeDiffGroups` (struct, defaults, validate, env, resolve) |
| `cmd/acr/main.go` | `--diff-groups` → `--large-diff-groups`, `--phase` help text 更新 |
| `cmd/acr/review.go` | `parsePhases` 書き換え、`resolveAutoPhase` 戻り値更新、ログ更新 |
| `cmd/acr/review_opts.go` | Phase フィールドコメント更新 |
| `internal/config/config_test.go` | テスト関数リネーム、YAML key / env var 更新 |
| `cmd/acr/review_test.go` | `TestParsePhases` 全面書き換え、PhaseStr アサーション更新 |
| `.acr.yaml` | `diff_groups` → `large_diff_groups`, コメント更新 |
| `README.md` | `--phase diff/arch,diff` → `--phase small/medium` |
| `CLAUDE.md` | `--phase diff` → `--phase small` |

## ACR セルフレビュー結果

4 findings (2/3 reviewer, Gemini 認証失敗):

| # | 判定 | 内容 |
|---|------|------|
| F1 | **真陽性** → 修正済み | `--medium-diff-reviewers` / `--small-diff-reviewers` ヘルプ文の旧 phase 名残存 |
| F2 | 偽陽性 | 旧 env var / CLI flag のシムなし削除 (設計判断: 後方互換不要) |
| F3 | 偽陽性 | F2 と同根 |
| F4 | 偽陽性 | `--phase` セマンティクス変更 (PR C の設計意図そのもの) |

## Test plan

- [x] `go build ./cmd/acr` — ビルド成功
- [x] `go test ./... -count=1` — 全 14 パッケージパス
- [x] 旧名 (`"diff_groups"`, `"ACR_DIFF_GROUPS"`, `"arch,diff"` as PhaseStr) の残存チェック — 0 件
- [x] CI (Lint, Build, Test, Race Detection, Staticcheck, Vet, Format Check, Security Scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)