### PR TITLE
feat: config show 拡張 + large_diff_groups リネーム

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -9,8 +9,8 @@ reviewers: 5
 
 # Number of diff groups in auto-phase grouped path (large diff). Default: 4.
 # Each group reviews a subset of changed files. arch reviewer is always 1
-# (sees full diff). Total reviewers in grouped path = 1 + large_diff_groups.
-large_diff_groups: 4
+# (sees full diff). Total reviewers in grouped path = 1 + large_diff_reviewers.
+large_diff_reviewers: 4
 
 # Number of reviewers in auto-phase small path. Default: 1.
 # Small diff = files <= 3 AND lines <= 100. Flat diff-only review (no arch).

--- a/.acr.yaml
+++ b/.acr.yaml
@@ -74,7 +74,7 @@ summarizer_agent: claude
 cross_check:
   enabled: true
   agent: "codex,claude,gemini"
-  model: "gpt-5.4,claude-opus-4-7,gemini-3.1-pro-preview"
+  model: "gpt-5.5,claude-opus-4-7,gemini-3.1-pro-preview"
 
 # PR feedback summarization
 # pr_feedback:
@@ -153,10 +153,10 @@ models:
       cross_check:   { effort: high }
   agents:
     codex:
-      reviewer:      { model: gpt-5.4 }
-      arch_reviewer: { model: gpt-5.4 }
-      diff_reviewer: { model: gpt-5.4 }
-      cross_check:   { model: gpt-5.4 }
+      reviewer:      { model: gpt-5.5 }
+      arch_reviewer: { model: gpt-5.5 }
+      diff_reviewer: { model: gpt-5.5 }
+      cross_check:   { model: gpt-5.5 }
     claude:
       reviewer:      { model: claude-sonnet-4-6 }
       arch_reviewer: { model: claude-opus-4-7 }

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -54,121 +54,128 @@ func newConfigShowCmd() *cobra.Command {
 				return fmt.Errorf("config error: %w", err)
 			}
 
-			envState, _ := config.LoadEnvState()
+			envState, envWarnings := config.LoadEnvState()
 
 			resolved := config.Resolve(result.Config, envState, config.FlagState{}, config.Defaults)
 
-			fmt.Println("Resolved configuration:")
-			fmt.Println()
+			// Display warnings from config loading
+			allWarnings := append(result.Warnings, envWarnings...)
+			for _, w := range allWarnings {
+				fmt.Fprintf(cmd.ErrOrStderr(), "[W] %s\n", w)
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, "Resolved configuration:")
+			fmt.Fprintln(out)
 
 			// General
-			fmt.Printf("  %-32s %d\n", "reviewers:", resolved.Reviewers)
+			fmt.Fprintf(out, "  %-32s %d\n", "reviewers:", resolved.Reviewers)
 			if resolved.Concurrency == 0 {
-				fmt.Printf("  %-32s %s\n", "concurrency:", "0 (auto)")
+				fmt.Fprintf(out, "  %-32s %s\n", "concurrency:", "0 (auto)")
 			} else {
-				fmt.Printf("  %-32s %d\n", "concurrency:", resolved.Concurrency)
+				fmt.Fprintf(out, "  %-32s %d\n", "concurrency:", resolved.Concurrency)
 			}
-			fmt.Printf("  %-32s %s\n", "base:", resolved.Base)
-			fmt.Printf("  %-32s %s\n", "timeout:", resolved.Timeout)
-			fmt.Printf("  %-32s %d\n", "retries:", resolved.Retries)
-			fmt.Printf("  %-32s %t\n", "fetch:", resolved.Fetch)
-			fmt.Printf("  %-32s %t\n", "auto_phase:", resolved.AutoPhase)
-			fmt.Printf("  %-32s %t\n", "strict:", resolved.Strict)
-			fmt.Println()
+			fmt.Fprintf(out, "  %-32s %s\n", "base:", resolved.Base)
+			fmt.Fprintf(out, "  %-32s %s\n", "timeout:", resolved.Timeout)
+			fmt.Fprintf(out, "  %-32s %d\n", "retries:", resolved.Retries)
+			fmt.Fprintf(out, "  %-32s %t\n", "fetch:", resolved.Fetch)
+			fmt.Fprintf(out, "  %-32s %t\n", "auto_phase:", resolved.AutoPhase)
+			fmt.Fprintf(out, "  %-32s %t\n", "strict:", resolved.Strict)
+			fmt.Fprintln(out)
 
 			// Agents
-			fmt.Printf("  %-32s %s\n", "reviewer_agents:", strings.Join(resolved.ReviewerAgents, ", "))
+			fmt.Fprintf(out, "  %-32s %s\n", "reviewer_agents:", strings.Join(resolved.ReviewerAgents, ", "))
 			if resolved.ArchReviewerAgent != "" {
-				fmt.Printf("  %-32s %s\n", "arch_reviewer_agent:", resolved.ArchReviewerAgent)
+				fmt.Fprintf(out, "  %-32s %s\n", "arch_reviewer_agent:", resolved.ArchReviewerAgent)
 			} else {
-				fmt.Printf("  %-32s %s\n", "arch_reviewer_agent:", "(first of reviewer_agents)")
+				fmt.Fprintf(out, "  %-32s %s\n", "arch_reviewer_agent:", "(first of reviewer_agents)")
 			}
 			if len(resolved.DiffReviewerAgents) > 0 {
-				fmt.Printf("  %-32s %s\n", "diff_reviewer_agents:", strings.Join(resolved.DiffReviewerAgents, ", "))
+				fmt.Fprintf(out, "  %-32s %s\n", "diff_reviewer_agents:", strings.Join(resolved.DiffReviewerAgents, ", "))
 			} else {
-				fmt.Printf("  %-32s %s\n", "diff_reviewer_agents:", "(reviewer_agents)")
+				fmt.Fprintf(out, "  %-32s %s\n", "diff_reviewer_agents:", "(reviewer_agents)")
 			}
-			fmt.Printf("  %-32s %s\n", "summarizer_agent:", resolved.SummarizerAgent)
-			fmt.Println()
+			fmt.Fprintf(out, "  %-32s %s\n", "summarizer_agent:", resolved.SummarizerAgent)
+			fmt.Fprintln(out)
 
 			// Models
 			if resolved.ReviewerModel != "" {
-				fmt.Printf("  %-32s %s\n", "reviewer_model:", resolved.ReviewerModel)
+				fmt.Fprintf(out, "  %-32s %s\n", "reviewer_model:", resolved.ReviewerModel)
 			} else {
-				fmt.Printf("  %-32s %s\n", "reviewer_model:", "(agent default)")
+				fmt.Fprintf(out, "  %-32s %s\n", "reviewer_model:", "(agent default)")
 			}
 			if resolved.SummarizerModel != "" {
-				fmt.Printf("  %-32s %s\n", "summarizer_model:", resolved.SummarizerModel)
+				fmt.Fprintf(out, "  %-32s %s\n", "summarizer_model:", resolved.SummarizerModel)
 			} else {
-				fmt.Printf("  %-32s %s\n", "summarizer_model:", "(agent default)")
+				fmt.Fprintf(out, "  %-32s %s\n", "summarizer_model:", "(agent default)")
 			}
-			fmt.Println()
+			fmt.Fprintln(out)
 
 			// Phase knobs
-			fmt.Printf("  %-32s %d\n", "large_diff_reviewers:", resolved.LargeDiffReviewers)
-			fmt.Printf("  %-32s %d\n", "medium_diff_reviewers:", resolved.MediumDiffReviewers)
-			fmt.Printf("  %-32s %d\n", "small_diff_reviewers:", resolved.SmallDiffReviewers)
-			fmt.Println()
+			fmt.Fprintf(out, "  %-32s %d\n", "large_diff_reviewers:", resolved.LargeDiffReviewers)
+			fmt.Fprintf(out, "  %-32s %d\n", "medium_diff_reviewers:", resolved.MediumDiffReviewers)
+			fmt.Fprintf(out, "  %-32s %d\n", "small_diff_reviewers:", resolved.SmallDiffReviewers)
+			fmt.Fprintln(out)
 
 			// Timeouts
-			fmt.Printf("  %-32s %s\n", "summarizer_timeout:", resolved.SummarizerTimeout)
-			fmt.Printf("  %-32s %s\n", "fp_filter_timeout:", resolved.FPFilterTimeout)
-			fmt.Printf("  %-32s %s\n", "cross_check_timeout:", resolved.CrossCheckTimeout)
-			fmt.Println()
+			fmt.Fprintf(out, "  %-32s %s\n", "summarizer_timeout:", resolved.SummarizerTimeout)
+			fmt.Fprintf(out, "  %-32s %s\n", "fp_filter_timeout:", resolved.FPFilterTimeout)
+			fmt.Fprintf(out, "  %-32s %s\n", "cross_check_timeout:", resolved.CrossCheckTimeout)
+			fmt.Fprintln(out)
 
 			// FP filter
-			fmt.Printf("  %-32s %t\n", "fp_filter.enabled:", resolved.FPFilterEnabled)
-			fmt.Printf("  %-32s %d\n", "fp_filter.threshold:", resolved.FPThreshold)
-			fmt.Println()
+			fmt.Fprintf(out, "  %-32s %t\n", "fp_filter.enabled:", resolved.FPFilterEnabled)
+			fmt.Fprintf(out, "  %-32s %d\n", "fp_filter.threshold:", resolved.FPThreshold)
+			fmt.Fprintln(out)
 
 			// PR feedback
-			fmt.Printf("  %-32s %t\n", "pr_feedback.enabled:", resolved.PRFeedbackEnabled)
+			fmt.Fprintf(out, "  %-32s %t\n", "pr_feedback.enabled:", resolved.PRFeedbackEnabled)
 			if resolved.PRFeedbackAgent != "" {
-				fmt.Printf("  %-32s %s\n", "pr_feedback.agent:", resolved.PRFeedbackAgent)
+				fmt.Fprintf(out, "  %-32s %s\n", "pr_feedback.agent:", resolved.PRFeedbackAgent)
 			} else {
-				fmt.Printf("  %-32s %s\n", "pr_feedback.agent:", "(same as summarizer_agent)")
+				fmt.Fprintf(out, "  %-32s %s\n", "pr_feedback.agent:", "(same as summarizer_agent)")
 			}
-			fmt.Println()
+			fmt.Fprintln(out)
 
 			// Cross-check
-			fmt.Printf("  %-32s %t\n", "cross_check.enabled:", resolved.CrossCheckEnabled)
+			fmt.Fprintf(out, "  %-32s %t\n", "cross_check.enabled:", resolved.CrossCheckEnabled)
 			if resolved.CrossCheckAgent != "" {
-				fmt.Printf("  %-32s %s\n", "cross_check.agent:", resolved.CrossCheckAgent)
+				fmt.Fprintf(out, "  %-32s %s\n", "cross_check.agent:", resolved.CrossCheckAgent)
 			} else {
-				fmt.Printf("  %-32s %s\n", "cross_check.agent:", "(same as summarizer_agent)")
+				fmt.Fprintf(out, "  %-32s %s\n", "cross_check.agent:", "(same as summarizer_agent)")
 			}
 			if resolved.CrossCheckModel != "" {
-				fmt.Printf("  %-32s %s\n", "cross_check.model:", resolved.CrossCheckModel)
+				fmt.Fprintf(out, "  %-32s %s\n", "cross_check.model:", resolved.CrossCheckModel)
 			} else {
-				fmt.Printf("  %-32s %s\n", "cross_check.model:", "(from models config)")
+				fmt.Fprintf(out, "  %-32s %s\n", "cross_check.model:", "(from models config)")
 			}
-			fmt.Println()
+			fmt.Fprintln(out)
 
 			// Guidance
 			if resolved.GuidanceFile != "" {
-				fmt.Printf("  %-32s %s\n", "guidance_file:", resolved.GuidanceFile)
+				fmt.Fprintf(out, "  %-32s %s\n", "guidance_file:", resolved.GuidanceFile)
 			} else {
-				fmt.Printf("  %-32s %s\n", "guidance_file:", "(not set)")
+				fmt.Fprintf(out, "  %-32s %s\n", "guidance_file:", "(not set)")
 			}
-			fmt.Println()
+			fmt.Fprintln(out)
 
 			// Models config
-			fmt.Printf("  %-32s %s\n", "models.defaults.reviewer:", formatModelSpec(resolved.Models.Defaults.Reviewer))
-			fmt.Printf("  %-32s %s\n", "models.defaults.arch_reviewer:", formatModelSpec(resolved.Models.Defaults.ArchReviewer))
-			fmt.Printf("  %-32s %s\n", "models.defaults.diff_reviewer:", formatModelSpec(resolved.Models.Defaults.DiffReviewer))
-			fmt.Printf("  %-32s %s\n", "models.defaults.summarizer:", formatModelSpec(resolved.Models.Defaults.Summarizer))
-			fmt.Printf("  %-32s %s\n", "models.defaults.fp_filter:", formatModelSpec(resolved.Models.Defaults.FPFilter))
-			fmt.Printf("  %-32s %s\n", "models.defaults.cross_check:", formatModelSpec(resolved.Models.Defaults.CrossCheck))
-			fmt.Printf("  %-32s %s\n", "models.defaults.pr_feedback:", formatModelSpec(resolved.Models.Defaults.PRFeedback))
+			fmt.Fprintf(out, "  %-32s %s\n", "models.defaults.reviewer:", formatModelSpec(resolved.Models.Defaults.Reviewer))
+			fmt.Fprintf(out, "  %-32s %s\n", "models.defaults.arch_reviewer:", formatModelSpec(resolved.Models.Defaults.ArchReviewer))
+			fmt.Fprintf(out, "  %-32s %s\n", "models.defaults.diff_reviewer:", formatModelSpec(resolved.Models.Defaults.DiffReviewer))
+			fmt.Fprintf(out, "  %-32s %s\n", "models.defaults.summarizer:", formatModelSpec(resolved.Models.Defaults.Summarizer))
+			fmt.Fprintf(out, "  %-32s %s\n", "models.defaults.fp_filter:", formatModelSpec(resolved.Models.Defaults.FPFilter))
+			fmt.Fprintf(out, "  %-32s %s\n", "models.defaults.cross_check:", formatModelSpec(resolved.Models.Defaults.CrossCheck))
+			fmt.Fprintf(out, "  %-32s %s\n", "models.defaults.pr_feedback:", formatModelSpec(resolved.Models.Defaults.PRFeedback))
 			if len(resolved.Models.Sizes) > 0 {
-				fmt.Printf("  %-32s (%d entries)\n", "models.sizes:", len(resolved.Models.Sizes))
+				fmt.Fprintf(out, "  %-32s (%d entries)\n", "models.sizes:", len(resolved.Models.Sizes))
 			} else {
-				fmt.Printf("  %-32s %s\n", "models.sizes:", "(none)")
+				fmt.Fprintf(out, "  %-32s %s\n", "models.sizes:", "(none)")
 			}
 			if len(resolved.Models.Agents) > 0 {
-				fmt.Printf("  %-32s (%d entries)\n", "models.agents:", len(resolved.Models.Agents))
+				fmt.Fprintf(out, "  %-32s (%d entries)\n", "models.agents:", len(resolved.Models.Agents))
 			} else {
-				fmt.Printf("  %-32s %s\n", "models.agents:", "(none)")
+				fmt.Fprintf(out, "  %-32s %s\n", "models.agents:", "(none)")
 			}
 
 			return nil

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -27,6 +27,22 @@ func newConfigCmd() *cobra.Command {
 	return cmd
 }
 
+func formatModelSpec(ms *config.ModelSpec) string {
+	if ms == nil {
+		return "(not set)"
+	}
+	if ms.Model != "" && ms.Effort != "" {
+		return fmt.Sprintf("%s (effort: %s)", ms.Model, ms.Effort)
+	}
+	if ms.Model != "" {
+		return ms.Model
+	}
+	if ms.Effort != "" {
+		return fmt.Sprintf("(effort: %s)", ms.Effort)
+	}
+	return "(not set)"
+}
+
 func newConfigShowCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "show",
@@ -44,23 +60,115 @@ func newConfigShowCmd() *cobra.Command {
 
 			fmt.Println("Resolved configuration:")
 			fmt.Println()
-			fmt.Printf("  %-22s %d\n", "reviewers:", resolved.Reviewers)
-			fmt.Printf("  %-22s %d\n", "concurrency:", resolved.Concurrency)
-			fmt.Printf("  %-22s %s\n", "base:", resolved.Base)
-			fmt.Printf("  %-22s %s\n", "timeout:", resolved.Timeout)
-			fmt.Printf("  %-22s %d\n", "retries:", resolved.Retries)
-			fmt.Printf("  %-22s %t\n", "fetch:", resolved.Fetch)
-			fmt.Printf("  %-22s %s\n", "reviewer_agents:", strings.Join(resolved.ReviewerAgents, ", "))
-			fmt.Printf("  %-22s %s\n", "summarizer_agent:", resolved.SummarizerAgent)
-			fmt.Printf("  %-22s %s\n", "summarizer_timeout:", resolved.SummarizerTimeout)
-			fmt.Printf("  %-22s %s\n", "fp_filter_timeout:", resolved.FPFilterTimeout)
-			fmt.Printf("  %-22s %t\n", "fp_filter.enabled:", resolved.FPFilterEnabled)
-			fmt.Printf("  %-22s %d\n", "fp_filter.threshold:", resolved.FPThreshold)
-			fmt.Printf("  %-22s %t\n", "pr_feedback.enabled:", resolved.PRFeedbackEnabled)
-			if resolved.PRFeedbackAgent != "" {
-				fmt.Printf("  %-22s %s\n", "pr_feedback.agent:", resolved.PRFeedbackAgent)
+
+			// General
+			fmt.Printf("  %-32s %d\n", "reviewers:", resolved.Reviewers)
+			if resolved.Concurrency == 0 {
+				fmt.Printf("  %-32s %s\n", "concurrency:", "0 (auto)")
 			} else {
-				fmt.Printf("  %-22s %s\n", "pr_feedback.agent:", "(same as summarizer_agent)")
+				fmt.Printf("  %-32s %d\n", "concurrency:", resolved.Concurrency)
+			}
+			fmt.Printf("  %-32s %s\n", "base:", resolved.Base)
+			fmt.Printf("  %-32s %s\n", "timeout:", resolved.Timeout)
+			fmt.Printf("  %-32s %d\n", "retries:", resolved.Retries)
+			fmt.Printf("  %-32s %t\n", "fetch:", resolved.Fetch)
+			fmt.Printf("  %-32s %t\n", "auto_phase:", resolved.AutoPhase)
+			fmt.Printf("  %-32s %t\n", "strict:", resolved.Strict)
+			fmt.Println()
+
+			// Agents
+			fmt.Printf("  %-32s %s\n", "reviewer_agents:", strings.Join(resolved.ReviewerAgents, ", "))
+			if resolved.ArchReviewerAgent != "" {
+				fmt.Printf("  %-32s %s\n", "arch_reviewer_agent:", resolved.ArchReviewerAgent)
+			} else {
+				fmt.Printf("  %-32s %s\n", "arch_reviewer_agent:", "(first of reviewer_agents)")
+			}
+			if len(resolved.DiffReviewerAgents) > 0 {
+				fmt.Printf("  %-32s %s\n", "diff_reviewer_agents:", strings.Join(resolved.DiffReviewerAgents, ", "))
+			} else {
+				fmt.Printf("  %-32s %s\n", "diff_reviewer_agents:", "(reviewer_agents)")
+			}
+			fmt.Printf("  %-32s %s\n", "summarizer_agent:", resolved.SummarizerAgent)
+			fmt.Println()
+
+			// Models
+			if resolved.ReviewerModel != "" {
+				fmt.Printf("  %-32s %s\n", "reviewer_model:", resolved.ReviewerModel)
+			} else {
+				fmt.Printf("  %-32s %s\n", "reviewer_model:", "(agent default)")
+			}
+			if resolved.SummarizerModel != "" {
+				fmt.Printf("  %-32s %s\n", "summarizer_model:", resolved.SummarizerModel)
+			} else {
+				fmt.Printf("  %-32s %s\n", "summarizer_model:", "(agent default)")
+			}
+			fmt.Println()
+
+			// Phase knobs
+			fmt.Printf("  %-32s %d\n", "large_diff_reviewers:", resolved.LargeDiffReviewers)
+			fmt.Printf("  %-32s %d\n", "medium_diff_reviewers:", resolved.MediumDiffReviewers)
+			fmt.Printf("  %-32s %d\n", "small_diff_reviewers:", resolved.SmallDiffReviewers)
+			fmt.Println()
+
+			// Timeouts
+			fmt.Printf("  %-32s %s\n", "summarizer_timeout:", resolved.SummarizerTimeout)
+			fmt.Printf("  %-32s %s\n", "fp_filter_timeout:", resolved.FPFilterTimeout)
+			fmt.Printf("  %-32s %s\n", "cross_check_timeout:", resolved.CrossCheckTimeout)
+			fmt.Println()
+
+			// FP filter
+			fmt.Printf("  %-32s %t\n", "fp_filter.enabled:", resolved.FPFilterEnabled)
+			fmt.Printf("  %-32s %d\n", "fp_filter.threshold:", resolved.FPThreshold)
+			fmt.Println()
+
+			// PR feedback
+			fmt.Printf("  %-32s %t\n", "pr_feedback.enabled:", resolved.PRFeedbackEnabled)
+			if resolved.PRFeedbackAgent != "" {
+				fmt.Printf("  %-32s %s\n", "pr_feedback.agent:", resolved.PRFeedbackAgent)
+			} else {
+				fmt.Printf("  %-32s %s\n", "pr_feedback.agent:", "(same as summarizer_agent)")
+			}
+			fmt.Println()
+
+			// Cross-check
+			fmt.Printf("  %-32s %t\n", "cross_check.enabled:", resolved.CrossCheckEnabled)
+			if resolved.CrossCheckAgent != "" {
+				fmt.Printf("  %-32s %s\n", "cross_check.agent:", resolved.CrossCheckAgent)
+			} else {
+				fmt.Printf("  %-32s %s\n", "cross_check.agent:", "(same as summarizer_agent)")
+			}
+			if resolved.CrossCheckModel != "" {
+				fmt.Printf("  %-32s %s\n", "cross_check.model:", resolved.CrossCheckModel)
+			} else {
+				fmt.Printf("  %-32s %s\n", "cross_check.model:", "(from models config)")
+			}
+			fmt.Println()
+
+			// Guidance
+			if resolved.GuidanceFile != "" {
+				fmt.Printf("  %-32s %s\n", "guidance_file:", resolved.GuidanceFile)
+			} else {
+				fmt.Printf("  %-32s %s\n", "guidance_file:", "(not set)")
+			}
+			fmt.Println()
+
+			// Models config
+			fmt.Printf("  %-32s %s\n", "models.defaults.reviewer:", formatModelSpec(resolved.Models.Defaults.Reviewer))
+			fmt.Printf("  %-32s %s\n", "models.defaults.arch_reviewer:", formatModelSpec(resolved.Models.Defaults.ArchReviewer))
+			fmt.Printf("  %-32s %s\n", "models.defaults.diff_reviewer:", formatModelSpec(resolved.Models.Defaults.DiffReviewer))
+			fmt.Printf("  %-32s %s\n", "models.defaults.summarizer:", formatModelSpec(resolved.Models.Defaults.Summarizer))
+			fmt.Printf("  %-32s %s\n", "models.defaults.fp_filter:", formatModelSpec(resolved.Models.Defaults.FPFilter))
+			fmt.Printf("  %-32s %s\n", "models.defaults.cross_check:", formatModelSpec(resolved.Models.Defaults.CrossCheck))
+			fmt.Printf("  %-32s %s\n", "models.defaults.pr_feedback:", formatModelSpec(resolved.Models.Defaults.PRFeedback))
+			if len(resolved.Models.Sizes) > 0 {
+				fmt.Printf("  %-32s (%d entries)\n", "models.sizes:", len(resolved.Models.Sizes))
+			} else {
+				fmt.Printf("  %-32s %s\n", "models.sizes:", "(none)")
+			}
+			if len(resolved.Models.Agents) > 0 {
+				fmt.Printf("  %-32s (%d entries)\n", "models.agents:", len(resolved.Models.Agents))
+			} else {
+				fmt.Printf("  %-32s %s\n", "models.agents:", "(none)")
 			}
 
 			return nil

--- a/cmd/acr/config_cmd_test.go
+++ b/cmd/acr/config_cmd_test.go
@@ -376,8 +376,8 @@ func TestConfigShow_EnvOverrideReflected(t *testing.T) {
 
 	output := buf.String()
 
-	if !strings.Contains(output, "strict:") || !strings.Contains(output, "true") {
-		t.Errorf("expected output to reflect ACR_STRICT=true.\nOutput:\n%s", output)
+	if !strings.Contains(output, "strict:                          true") {
+		t.Errorf("expected output to contain 'strict: true' reflecting ACR_STRICT=true.\nOutput:\n%s", output)
 	}
 	if !strings.Contains(output, "large_diff_reviewers:") || !strings.Contains(output, "8") {
 		t.Errorf("expected output to reflect ACR_LARGE_DIFF_REVIEWERS=8.\nOutput:\n%s", output)

--- a/cmd/acr/config_cmd_test.go
+++ b/cmd/acr/config_cmd_test.go
@@ -318,41 +318,20 @@ func TestConfigValidate_SyntaxErrorSkipsCrossCheckRuntimeFalsePositive(t *testin
 	}
 }
 
-// captureStdout captures os.Stdout output during fn execution.
-// config show uses fmt.Printf (not cmd.OutOrStdout()), so we must redirect os.Stdout.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	os.Stdout = w
-
-	fn()
-
-	w.Close()
-	os.Stdout = old
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatal(err)
-	}
-	return buf.String()
-}
-
 func TestConfigShow_DisplaysAllFields(t *testing.T) {
 	dir := t.TempDir()
 	chdir(t, dir)
 	initGitRepo(t, dir)
 
 	cmd := newConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"show"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	output := captureStdout(t, func() {
-		if err := cmd.Execute(); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
+	output := buf.String()
 
 	expectedKeys := []string{
 		"reviewers:", "concurrency:", "base:", "timeout:", "retries:", "fetch:",
@@ -388,13 +367,14 @@ func TestConfigShow_EnvOverrideReflected(t *testing.T) {
 	t.Setenv("ACR_LARGE_DIFF_REVIEWERS", "8")
 
 	cmd := newConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"show"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	output := captureStdout(t, func() {
-		if err := cmd.Execute(); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
+	output := buf.String()
 
 	if !strings.Contains(output, "strict:") || !strings.Contains(output, "true") {
 		t.Errorf("expected output to reflect ACR_STRICT=true.\nOutput:\n%s", output)
@@ -410,13 +390,14 @@ func TestConfigShow_FallbackDisplay(t *testing.T) {
 	initGitRepo(t, dir)
 
 	cmd := newConfigCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"show"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	output := captureStdout(t, func() {
-		if err := cmd.Execute(); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
+	output := buf.String()
 
 	// arch_reviewer_agent fallback
 	if !strings.Contains(output, "(first of reviewer_agents)") {

--- a/cmd/acr/config_cmd_test.go
+++ b/cmd/acr/config_cmd_test.go
@@ -317,3 +317,133 @@ func TestConfigValidate_SyntaxErrorSkipsCrossCheckRuntimeFalsePositive(t *testin
 		t.Errorf("expected exactly 1 error (config file syntax only) on syntax error, got %d: %q", n, err.Error())
 	}
 }
+
+// captureStdout captures os.Stdout output during fn execution.
+// config show uses fmt.Printf (not cmd.OutOrStdout()), so we must redirect os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+func TestConfigShow_DisplaysAllFields(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	initGitRepo(t, dir)
+
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"show"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	expectedKeys := []string{
+		"reviewers:", "concurrency:", "base:", "timeout:", "retries:", "fetch:",
+		"auto_phase:", "strict:",
+		"reviewer_agents:", "arch_reviewer_agent:", "diff_reviewer_agents:", "summarizer_agent:",
+		"reviewer_model:", "summarizer_model:",
+		"large_diff_reviewers:", "medium_diff_reviewers:", "small_diff_reviewers:",
+		"summarizer_timeout:", "fp_filter_timeout:", "cross_check_timeout:",
+		"fp_filter.enabled:", "fp_filter.threshold:",
+		"pr_feedback.enabled:", "pr_feedback.agent:",
+		"cross_check.enabled:", "cross_check.agent:", "cross_check.model:",
+		"guidance_file:",
+		"models.defaults.reviewer:", "models.defaults.arch_reviewer:",
+		"models.defaults.diff_reviewer:", "models.defaults.summarizer:",
+		"models.defaults.fp_filter:", "models.defaults.cross_check:",
+		"models.defaults.pr_feedback:",
+		"models.sizes:", "models.agents:",
+	}
+
+	for _, key := range expectedKeys {
+		if !strings.Contains(output, key) {
+			t.Errorf("expected output to contain %q, but it did not.\nOutput:\n%s", key, output)
+		}
+	}
+}
+
+func TestConfigShow_EnvOverrideReflected(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	initGitRepo(t, dir)
+
+	t.Setenv("ACR_STRICT", "true")
+	t.Setenv("ACR_LARGE_DIFF_REVIEWERS", "8")
+
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"show"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "strict:") || !strings.Contains(output, "true") {
+		t.Errorf("expected output to reflect ACR_STRICT=true.\nOutput:\n%s", output)
+	}
+	if !strings.Contains(output, "large_diff_reviewers:") || !strings.Contains(output, "8") {
+		t.Errorf("expected output to reflect ACR_LARGE_DIFF_REVIEWERS=8.\nOutput:\n%s", output)
+	}
+}
+
+func TestConfigShow_FallbackDisplay(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	initGitRepo(t, dir)
+
+	cmd := newConfigCmd()
+	cmd.SetArgs([]string{"show"})
+
+	output := captureStdout(t, func() {
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// arch_reviewer_agent fallback
+	if !strings.Contains(output, "(first of reviewer_agents)") {
+		t.Errorf("expected arch_reviewer_agent fallback text.\nOutput:\n%s", output)
+	}
+	// diff_reviewer_agents fallback
+	if !strings.Contains(output, "(reviewer_agents)") {
+		t.Errorf("expected diff_reviewer_agents fallback text.\nOutput:\n%s", output)
+	}
+	// reviewer_model and summarizer_model fallback
+	if !strings.Contains(output, "(agent default)") {
+		t.Errorf("expected model fallback text.\nOutput:\n%s", output)
+	}
+	// pr_feedback.agent and cross_check.agent fallback
+	if !strings.Contains(output, "(same as summarizer_agent)") {
+		t.Errorf("expected agent fallback text.\nOutput:\n%s", output)
+	}
+	// guidance_file and models.defaults.* fallback
+	if !strings.Contains(output, "(not set)") {
+		t.Errorf("expected '(not set)' fallback text.\nOutput:\n%s", output)
+	}
+	// models.sizes and models.agents fallback
+	if !strings.Contains(output, "(none)") {
+		t.Errorf("expected '(none)' fallback text.\nOutput:\n%s", output)
+	}
+	// concurrency: 0 fallback
+	if !strings.Contains(output, "(auto)") {
+		t.Errorf("expected concurrency fallback text.\nOutput:\n%s", output)
+	}
+}

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -43,7 +43,7 @@ func parseDiffReviewerAgentsFlag(input string) []string {
 
 var (
 	reviewers           int
-	largeDiffGroups     int
+	largeDiffReviewers  int
 	mediumDiffReviewers int
 	smallDiffReviewers  int
 	concurrency         int
@@ -111,8 +111,8 @@ Exit codes:
 	// Configuration flags (defaults are resolved via config.Resolve with precedence: flag > env > config > default)
 	rootCmd.Flags().IntVarP(&reviewers, "reviewers", "r", 0,
 		"Number of parallel reviewers for flat review path (auto-phase OFF, no --phase). --phase small uses --small-diff-reviewers; --phase medium uses --medium-diff-reviewers. (default: 5, env: ACR_REVIEWERS)")
-	rootCmd.Flags().IntVar(&largeDiffGroups, "large-diff-groups", 0,
-		"Number of diff groups in auto-phase grouped path (large diff) (default: 4, env: ACR_LARGE_DIFF_GROUPS)")
+	rootCmd.Flags().IntVar(&largeDiffReviewers, "large-diff-reviewers", 0,
+		"Number of diff reviewers in auto-phase grouped path (large diff) (default: 4, env: ACR_LARGE_DIFF_REVIEWERS)")
 	rootCmd.Flags().IntVar(&mediumDiffReviewers, "medium-diff-reviewers", 0,
 		"Number of diff reviewers for auto-phase medium and --phase medium (default: 2, env: ACR_MEDIUM_DIFF_REVIEWERS)")
 	rootCmd.Flags().IntVar(&smallDiffReviewers, "small-diff-reviewers", 0,
@@ -407,7 +407,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	autoPhaseAnySet := cmd.Flags().Changed("auto-phase") || cmd.Flags().Changed("no-auto-phase")
 	flagState := config.FlagState{
 		ReviewersSet:           cmd.Flags().Changed("reviewers"),
-		LargeDiffGroupsSet:     cmd.Flags().Changed("large-diff-groups"),
+		LargeDiffReviewersSet:  cmd.Flags().Changed("large-diff-reviewers"),
 		MediumDiffReviewersSet: cmd.Flags().Changed("medium-diff-reviewers"),
 		SmallDiffReviewersSet:  cmd.Flags().Changed("small-diff-reviewers"),
 		ConcurrencySet:         cmd.Flags().Changed("concurrency"),
@@ -457,7 +457,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	autoPhaseValue := autoPhase && !noAutoPhase
 	flagValues := config.ResolvedConfig{
 		Reviewers:           reviewers,
-		LargeDiffGroups:     largeDiffGroups,
+		LargeDiffReviewers:  largeDiffReviewers,
 		MediumDiffReviewers: mediumDiffReviewers,
 		SmallDiffReviewers:  smallDiffReviewers,
 		Concurrency:         concurrency,
@@ -562,7 +562,7 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 // Used to default/clamp Concurrency so no phase is bottlenecked.
 func maxPotentialReviewers(r config.ResolvedConfig) int {
 	m := r.Reviewers
-	if v := 1 + r.LargeDiffGroups; v > m {
+	if v := 1 + r.LargeDiffReviewers; v > m {
 		m = v
 	}
 	if v := 1 + r.MediumDiffReviewers; v > m {

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -259,7 +259,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				func() (agent.Agent, []agent.Agent, error) {
 					return buildPhaseAgents(opts, sizeStr)
 				},
-				opts.LargeDiffGroups, opts.MediumDiffReviewers)
+				opts.LargeDiffReviewers, opts.MediumDiffReviewers)
 			if agentsErr != nil {
 				logger.Logf(terminal.StyleError, "Failed to build per-phase reviewer agents: %v", agentsErr)
 				return domain.ExitError
@@ -274,8 +274,8 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			if opts.Verbose {
 				switch {
 				case apr.UseGrouped:
-					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (large_diff_groups=%d, arch+%d diff groups)",
-						opts.LargeDiffGroups, len(groupedSpecs)-1)
+					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (large_diff_reviewers=%d, arch+%d diff groups)",
+						opts.LargeDiffReviewers, len(groupedSpecs)-1)
 					// Per-phase model matrix rows — only meaningful once we
 					// know the grouped path will actually run. Before this
 					// point, a large→flat fallback would have made these rows
@@ -889,7 +889,7 @@ type autoPhaseResult struct {
 // resolveAutoPhase determines phase configuration based on diff size and the
 // new auto-phase knobs.
 //
-//   - largeDiffGroups: target group count for the grouped (large) path; capped by
+//   - largeDiffReviewers: target group count for the grouped (large) path; capped by
 //     the actual file count to keep at least 1 file per group.
 //   - mediumDiffReviewers: diff-phase reviewer count for the medium path
 //     (medium) and for any large fallback to medium.
@@ -906,7 +906,7 @@ func resolveAutoPhase(
 	diff, guidance string,
 	diffPrecomputed bool,
 	buildAgents func() (agent.Agent, []agent.Agent, error),
-	largeDiffGroups int,
+	largeDiffReviewers int,
 	mediumDiffReviewers int,
 ) (autoPhaseResult, error) {
 	switch size {
@@ -916,7 +916,7 @@ func resolveAutoPhase(
 	case git.DiffSizeLarge:
 		fileCount := len(git.ParseDiffSections(diff))
 		// Sanity cap: 1 group must contain at least 1 file.
-		effectiveGroups := largeDiffGroups
+		effectiveGroups := largeDiffReviewers
 		if effectiveGroups > fileCount {
 			effectiveGroups = fileCount
 		}
@@ -929,8 +929,8 @@ func resolveAutoPhase(
 				PhaseStr:        "medium",
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason: fmt.Sprintf(
-					"only %d non-empty diff group(s) possible (file_count=%d, large_diff_groups=%d)",
-					effectiveGroups, fileCount, largeDiffGroups),
+					"only %d non-empty diff group(s) possible (file_count=%d, large_diff_reviewers=%d)",
+					effectiveGroups, fileCount, largeDiffReviewers),
 			}, nil
 		}
 		// Grouped path confirmed viable; now build the per-phase agents. An
@@ -1115,7 +1115,7 @@ func logCrossCheckModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr 
 //     diffAgents assigned round-robin per non-empty diff group
 //
 // maxDiffGroups is supplied by the caller (resolveAutoPhase) from the
-// dedicated `large_diff_groups` knob, capped at the actual file count so that
+// dedicated `large_diff_reviewers` knob, capped at the actual file count so that
 // every group has at least 1 file.
 //
 // archAgent and diffAgents are independent so per-phase reviewer overrides

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -259,7 +259,7 @@ func TestBuildGroupedDiffSpecs_FallbackOnError(t *testing.T) {
 //
 // Signature: resolveAutoPhase(size, diff, guidance, diffPrecomputed,
 //   buildAgents func() (agent.Agent, []agent.Agent, error),
-//   largeDiffGroups, mediumDiffReviewers) (autoPhaseResult, error)
+//   largeDiffReviewers, mediumDiffReviewers) (autoPhaseResult, error)
 //
 // Tests use testBuildAgents to return pre-constructed agents synchronously.
 // The closure is only invoked when the large grouped path decides to proceed,
@@ -272,7 +272,7 @@ func testBuildAgents(arch agent.Agent, diffs []agent.Agent) func() (agent.Agent,
 }
 
 func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
-	// Large diff with large_diff_groups=3 → grouped specs
+	// Large diff with large_diff_reviewers=3 → grouped specs
 	sections := makeSectionsForReview(12, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -280,7 +280,7 @@ func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
 
 	if !apr.UseGrouped {
-		t.Fatal("expected UseGrouped=true for large diff with large_diff_groups=3")
+		t.Fatal("expected UseGrouped=true for large diff with large_diff_reviewers=3")
 	}
 	if apr.PhaseStr != "" {
 		t.Errorf("expected empty PhaseStr, got %q", apr.PhaseStr)
@@ -612,9 +612,9 @@ func TestResolveCrossCheckAgents_AgentDefaultsToSummarizer(t *testing.T) {
 
 // TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat verifies that exactly
 // 1 non-empty diff group (< 2) still triggers the fallback. With
-// large_diff_groups=1 the file_count cap also kicks in early.
+// large_diff_reviewers=1 the file_count cap also kicks in early.
 func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
-	// 2 files, large_diff_groups=1 → file_count cap → effectiveGroups=1 → fallback.
+	// 2 files, large_diff_reviewers=1 → file_count cap → effectiveGroups=1 → fallback.
 	sections := makeSectionsForReview(2, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -622,7 +622,7 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 1, 2)
 
 	if apr.UseGrouped {
-		t.Fatal("expected UseGrouped=false for large_diff_groups=1")
+		t.Fatal("expected UseGrouped=false for large_diff_reviewers=1")
 	}
 	if apr.PhaseStr != "medium" {
 		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
@@ -635,10 +635,10 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	}
 }
 
-// TestResolveAutoPhase_TwoLargeDiffGroups_KeepsGrouped verifies that 2 or more
+// TestResolveAutoPhase_TwoLargeDiffReviewers_KeepsGrouped verifies that 2 or more
 // non-empty diff groups result in UseGrouped=true (no fallback).
-func TestResolveAutoPhase_TwoLargeDiffGroups_KeepsGrouped(t *testing.T) {
-	// 6 files, large_diff_groups=2 → expect 2 diff groups.
+func TestResolveAutoPhase_TwoLargeDiffReviewers_KeepsGrouped(t *testing.T) {
+	// 6 files, large_diff_reviewers=2 → expect 2 diff groups.
 	sections := makeSectionsForReview(6, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -665,7 +665,7 @@ func TestLargeReview_GroupedSpecsProduceCrossCheckableTopology(t *testing.T) {
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
 	if !apr.UseGrouped {
-		t.Fatal("expected UseGrouped=true for large diff with large_diff_groups=3")
+		t.Fatal("expected UseGrouped=true for large diff with large_diff_reviewers=3")
 	}
 	if apr.GroupedSpecs[0].GroupKey != "arch" {
 		t.Errorf("expected first spec GroupKey=arch, got %q", apr.GroupedSpecs[0].GroupKey)
@@ -981,14 +981,14 @@ func TestFlatPath_VerdictRendered(t *testing.T) {
 	}
 }
 
-// --- New auto-phase knob tests (large_diff_groups / medium_diff_reviewers) ---
+// --- New auto-phase knob tests (large_diff_reviewers / medium_diff_reviewers) ---
 
-// TestResolveAutoPhase_LargeUsesLargeDiffGroupsKnob verifies that the large_diff_groups
+// TestResolveAutoPhase_LargeUsesLargeDiffReviewersKnob verifies that the large_diff_reviewers
 // knob caps the grouped diff path. With many files / lines the greedy packer
-// would normally produce > largeDiffGroups groups; largeDiffGroups=3 caps the result.
-func TestResolveAutoPhase_LargeUsesLargeDiffGroupsKnob(t *testing.T) {
+// would normally produce > largeDiffReviewers groups; largeDiffReviewers=3 caps the result.
+func TestResolveAutoPhase_LargeUsesLargeDiffReviewersKnob(t *testing.T) {
 	// 25 files × 50 lines (1250 lines, default 200/group) → ~7 groups
-	// without cap; large_diff_groups=3 caps to 3.
+	// without cap; large_diff_reviewers=3 caps to 3.
 	sections := makeSectionsForReview(25, 50)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -1000,7 +1000,7 @@ func TestResolveAutoPhase_LargeUsesLargeDiffGroupsKnob(t *testing.T) {
 	}
 	diffGroupCount := len(apr.GroupedSpecs) - 1
 	if diffGroupCount > 3 {
-		t.Errorf("expected at most 3 diff groups (large_diff_groups=3 cap), got %d", diffGroupCount)
+		t.Errorf("expected at most 3 diff groups (large_diff_reviewers=3 cap), got %d", diffGroupCount)
 	}
 	if diffGroupCount < 2 {
 		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
@@ -1011,7 +1011,7 @@ func TestResolveAutoPhase_LargeUsesLargeDiffGroupsKnob(t *testing.T) {
 // that when file_count<2 the grouped path is impossible and falls back to
 // medium carrying medium_diff_reviewers as MediumDiffCount.
 func TestResolveAutoPhase_LargeFallbackToMedium_WhenFileCountTooSmall(t *testing.T) {
-	// 1 file, large_diff_groups=4 → effectiveGroups=1 → fallback.
+	// 1 file, large_diff_reviewers=4 → effectiveGroups=1 → fallback.
 	sections := makeSectionsForReview(1, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -1049,13 +1049,13 @@ func TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob(t *testing.T) {
 }
 
 // TestResolveAutoPhase_LargeRespectsFileCountUpperBound verifies that
-// effectiveGroups = min(largeDiffGroups, fileCount). With large_diff_groups>>fileCount
+// effectiveGroups = min(largeDiffReviewers, fileCount). With large_diff_reviewers>>fileCount
 // the cap is fileCount; the resulting group count never exceeds fileCount.
 func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 	// 12 files (> default 5 files/group) so the greedy packer naturally
-	// produces multiple groups; large_diff_groups=10 is capped to fileCount=12.
+	// produces multiple groups; large_diff_reviewers=10 is capped to fileCount=12.
 	// We assert the resulting count never exceeds fileCount and remains
-	// within the large_diff_groups cap.
+	// within the large_diff_reviewers cap.
 	sections := makeSectionsForReview(12, 10)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
@@ -1063,14 +1063,14 @@ func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 10, 2)
 
 	if !apr.UseGrouped {
-		t.Fatalf("expected UseGrouped=true with 12 files / large_diff_groups=10; FallbackReason=%q", apr.FallbackReason)
+		t.Fatalf("expected UseGrouped=true with 12 files / large_diff_reviewers=10; FallbackReason=%q", apr.FallbackReason)
 	}
 	diffGroupCount := len(apr.GroupedSpecs) - 1
 	if diffGroupCount > 12 {
 		t.Errorf("expected diff group count capped at fileCount=12, got %d", diffGroupCount)
 	}
 	if diffGroupCount > 10 {
-		t.Errorf("expected diff group count capped at large_diff_groups=10, got %d", diffGroupCount)
+		t.Errorf("expected diff group count capped at large_diff_reviewers=10, got %d", diffGroupCount)
 	}
 	if diffGroupCount < 2 {
 		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
@@ -1295,27 +1295,27 @@ func TestMaxPotentialReviewers(t *testing.T) {
 	}{
 		{
 			name: "flat dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 5, LargeDiffGroups: 3, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 5, LargeDiffReviewers: 3, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
 			want: 5, // max(5, 1+3, 1+2, 1) = 5
 		},
 		{
 			name: "grouped dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 3, LargeDiffGroups: 8, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 3, LargeDiffReviewers: 8, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
 			want: 9, // max(3, 1+8, 1+2, 1) = 9
 		},
 		{
 			name: "medium dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 2, LargeDiffGroups: 1, MediumDiffReviewers: 5, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 2, LargeDiffReviewers: 1, MediumDiffReviewers: 5, SmallDiffReviewers: 1},
 			want: 6, // max(2, 1+1, 1+5, 1) = 6
 		},
 		{
 			name: "all equal",
-			cfg:  config.ResolvedConfig{Reviewers: 3, LargeDiffGroups: 2, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
+			cfg:  config.ResolvedConfig{Reviewers: 3, LargeDiffReviewers: 2, MediumDiffReviewers: 2, SmallDiffReviewers: 1},
 			want: 3, // max(3, 1+2, 1+2, 1) = 3
 		},
 		{
 			name: "small dominates",
-			cfg:  config.ResolvedConfig{Reviewers: 2, LargeDiffGroups: 1, MediumDiffReviewers: 1, SmallDiffReviewers: 10},
+			cfg:  config.ResolvedConfig{Reviewers: 2, LargeDiffReviewers: 1, MediumDiffReviewers: 1, SmallDiffReviewers: 10},
 			want: 10, // max(2, 1+1, 1+1, 10) = 10
 		},
 	}

--- a/docs/backlog-triage-2026-04-23.md
+++ b/docs/backlog-triage-2026-04-23.md
@@ -62,7 +62,7 @@ PR #4〜#6 の開発サイクル中に解決済みだが、バックログの持
 | `--phase diff` | `--phase small` | `parsePhases`, consumer switch, テスト |
 | `--phase arch,diff` | `--phase medium` | 同上 |
 | (Issue #11) `--phase grouped` | `--phase large` | 将来の実装時に反映 |
-| `diff_groups` (config/CLI/env) | `large_diff_groups` | Config struct, yaml tag, env var, CLI flag, Resolve, Validate, テスト |
+| `diff_groups` (config/CLI/env) | `large_diff_reviewers` | Config struct, yaml tag, env var, CLI flag, Resolve, Validate, テスト |
 
 実装方針:
 - `parsePhases` 内部で `small` → `"diff"`, `medium` → `"arch,diff"` に変換（runner 層は phase 名に依存）

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,7 +86,7 @@ type ModelsConfig struct {
 
 type Config struct {
 	Reviewers           *int      `yaml:"reviewers"`
-	LargeDiffReviewers     *int      `yaml:"large_diff_reviewers"`
+	LargeDiffReviewers  *int      `yaml:"large_diff_reviewers"`
 	MediumDiffReviewers *int      `yaml:"medium_diff_reviewers"`
 	SmallDiffReviewers  *int      `yaml:"small_diff_reviewers"`
 	Concurrency         *int      `yaml:"concurrency"`
@@ -789,7 +789,7 @@ func (r *ResolvedConfig) Validate() error {
 
 var Defaults = ResolvedConfig{
 	Reviewers:           5,
-	LargeDiffReviewers:     4,
+	LargeDiffReviewers:  4,
 	MediumDiffReviewers: 2,
 	SmallDiffReviewers:  1,
 	Concurrency:         0,
@@ -815,7 +815,7 @@ var Defaults = ResolvedConfig{
 
 type ResolvedConfig struct {
 	Reviewers           int
-	LargeDiffReviewers     int
+	LargeDiffReviewers  int
 	MediumDiffReviewers int
 	SmallDiffReviewers  int
 	Concurrency         int
@@ -860,7 +860,7 @@ type ResolvedConfig struct {
 
 type FlagState struct {
 	ReviewersSet           bool
-	LargeDiffReviewersSet     bool
+	LargeDiffReviewersSet  bool
 	MediumDiffReviewersSet bool
 	SmallDiffReviewersSet  bool
 	ConcurrencySet         bool
@@ -893,8 +893,8 @@ type FlagState struct {
 type EnvState struct {
 	Reviewers              int
 	ReviewersSet           bool
-	LargeDiffReviewers        int
-	LargeDiffReviewersSet     bool
+	LargeDiffReviewers     int
+	LargeDiffReviewersSet  bool
 	MediumDiffReviewers    int
 	MediumDiffReviewersSet bool
 	SmallDiffReviewers     int

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,7 +86,7 @@ type ModelsConfig struct {
 
 type Config struct {
 	Reviewers           *int      `yaml:"reviewers"`
-	LargeDiffGroups     *int      `yaml:"large_diff_groups"`
+	LargeDiffReviewers     *int      `yaml:"large_diff_reviewers"`
 	MediumDiffReviewers *int      `yaml:"medium_diff_reviewers"`
 	SmallDiffReviewers  *int      `yaml:"small_diff_reviewers"`
 	Concurrency         *int      `yaml:"concurrency"`
@@ -224,7 +224,7 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "large_diff_groups", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
+var knownTopLevelKeys = []string{"reviewers", "large_diff_reviewers", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
@@ -486,8 +486,8 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.Reviewers < 1 {
 		errs = append(errs, fmt.Sprintf("reviewers must be >= 1, got %d", r.Reviewers))
 	}
-	if r.LargeDiffGroups < 1 {
-		errs = append(errs, fmt.Sprintf("large_diff_groups must be >= 1, got %d", r.LargeDiffGroups))
+	if r.LargeDiffReviewers < 1 {
+		errs = append(errs, fmt.Sprintf("large_diff_reviewers must be >= 1, got %d", r.LargeDiffReviewers))
 	}
 	if r.MediumDiffReviewers < 1 {
 		errs = append(errs, fmt.Sprintf("medium_diff_reviewers must be >= 1, got %d", r.MediumDiffReviewers))
@@ -789,7 +789,7 @@ func (r *ResolvedConfig) Validate() error {
 
 var Defaults = ResolvedConfig{
 	Reviewers:           5,
-	LargeDiffGroups:     4,
+	LargeDiffReviewers:     4,
 	MediumDiffReviewers: 2,
 	SmallDiffReviewers:  1,
 	Concurrency:         0,
@@ -815,7 +815,7 @@ var Defaults = ResolvedConfig{
 
 type ResolvedConfig struct {
 	Reviewers           int
-	LargeDiffGroups     int
+	LargeDiffReviewers     int
 	MediumDiffReviewers int
 	SmallDiffReviewers  int
 	Concurrency         int
@@ -860,7 +860,7 @@ type ResolvedConfig struct {
 
 type FlagState struct {
 	ReviewersSet           bool
-	LargeDiffGroupsSet     bool
+	LargeDiffReviewersSet     bool
 	MediumDiffReviewersSet bool
 	SmallDiffReviewersSet  bool
 	ConcurrencySet         bool
@@ -893,8 +893,8 @@ type FlagState struct {
 type EnvState struct {
 	Reviewers              int
 	ReviewersSet           bool
-	LargeDiffGroups        int
-	LargeDiffGroupsSet     bool
+	LargeDiffReviewers        int
+	LargeDiffReviewersSet     bool
 	MediumDiffReviewers    int
 	MediumDiffReviewersSet bool
 	SmallDiffReviewers     int
@@ -965,12 +965,12 @@ func LoadEnvState() (EnvState, []string) {
 			warnings = append(warnings, fmt.Sprintf("ACR_REVIEWERS=%q is not a valid integer, ignoring", v))
 		}
 	}
-	if v := os.Getenv("ACR_LARGE_DIFF_GROUPS"); v != "" {
+	if v := os.Getenv("ACR_LARGE_DIFF_REVIEWERS"); v != "" {
 		if i, err := strconv.Atoi(v); err == nil {
-			state.LargeDiffGroups = i
-			state.LargeDiffGroupsSet = true
+			state.LargeDiffReviewers = i
+			state.LargeDiffReviewersSet = true
 		} else {
-			warnings = append(warnings, fmt.Sprintf("ACR_LARGE_DIFF_GROUPS=%q is not a valid integer, ignoring", v))
+			warnings = append(warnings, fmt.Sprintf("ACR_LARGE_DIFF_REVIEWERS=%q is not a valid integer, ignoring", v))
 		}
 	}
 	if v := os.Getenv("ACR_MEDIUM_DIFF_REVIEWERS"); v != "" {
@@ -1207,8 +1207,8 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.Reviewers != nil {
 			result.Reviewers = *cfg.Reviewers
 		}
-		if cfg.LargeDiffGroups != nil {
-			result.LargeDiffGroups = *cfg.LargeDiffGroups
+		if cfg.LargeDiffReviewers != nil {
+			result.LargeDiffReviewers = *cfg.LargeDiffReviewers
 		}
 		if cfg.MediumDiffReviewers != nil {
 			result.MediumDiffReviewers = *cfg.MediumDiffReviewers
@@ -1293,8 +1293,8 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if envState.ReviewersSet {
 		result.Reviewers = envState.Reviewers
 	}
-	if envState.LargeDiffGroupsSet {
-		result.LargeDiffGroups = envState.LargeDiffGroups
+	if envState.LargeDiffReviewersSet {
+		result.LargeDiffReviewers = envState.LargeDiffReviewers
 	}
 	if envState.MediumDiffReviewersSet {
 		result.MediumDiffReviewers = envState.MediumDiffReviewers
@@ -1375,8 +1375,8 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if flagState.ReviewersSet {
 		result.Reviewers = flagValues.Reviewers
 	}
-	if flagState.LargeDiffGroupsSet {
-		result.LargeDiffGroups = flagValues.LargeDiffGroups
+	if flagState.LargeDiffReviewersSet {
+		result.LargeDiffReviewers = flagValues.LargeDiffReviewers
 	}
 	if flagState.MediumDiffReviewersSet {
 		result.MediumDiffReviewers = flagValues.MediumDiffReviewers

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1202,7 +1202,7 @@ func TestResolveGuidance_ConfigFileAbsolutePath(t *testing.T) {
 func clearACREnv(t *testing.T) {
 	t.Helper()
 	for _, key := range []string{
-		"ACR_REVIEWERS", "ACR_LARGE_DIFF_GROUPS", "ACR_MEDIUM_DIFF_REVIEWERS", "ACR_SMALL_DIFF_REVIEWERS",
+		"ACR_REVIEWERS", "ACR_LARGE_DIFF_REVIEWERS", "ACR_MEDIUM_DIFF_REVIEWERS", "ACR_SMALL_DIFF_REVIEWERS",
 		"ACR_CONCURRENCY", "ACR_BASE_REF", "ACR_TIMEOUT",
 		"ACR_RETRIES", "ACR_FETCH", "ACR_REVIEWER_AGENT", "ACR_SUMMARIZER_AGENT",
 		"ACR_ARCH_REVIEWER_AGENT", "ACR_DIFF_REVIEWER_AGENTS",
@@ -2621,44 +2621,44 @@ func TestLoadEnvState_DiffReviewerAgents(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Tests for large_diff_groups and medium_diff_reviewers (auto-phase reviewer knobs)
+// Tests for large_diff_reviewers and medium_diff_reviewers (auto-phase reviewer knobs)
 // ---------------------------------------------------------------------------
 
-func TestResolve_LargeDiffGroups_FromYAML(t *testing.T) {
-	cfg := &Config{LargeDiffGroups: ptr(7)}
+func TestResolve_LargeDiffReviewers_FromYAML(t *testing.T) {
+	cfg := &Config{LargeDiffReviewers: ptr(7)}
 	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
-	if result.LargeDiffGroups != 7 {
-		t.Errorf("expected large_diff_groups=7 from yaml, got %d", result.LargeDiffGroups)
+	if result.LargeDiffReviewers != 7 {
+		t.Errorf("expected large_diff_reviewers=7 from yaml, got %d", result.LargeDiffReviewers)
 	}
 }
 
-func TestResolve_LargeDiffGroups_EnvOverridesYAML(t *testing.T) {
-	cfg := &Config{LargeDiffGroups: ptr(7)}
-	envState := EnvState{LargeDiffGroups: 9, LargeDiffGroupsSet: true}
+func TestResolve_LargeDiffReviewers_EnvOverridesYAML(t *testing.T) {
+	cfg := &Config{LargeDiffReviewers: ptr(7)}
+	envState := EnvState{LargeDiffReviewers: 9, LargeDiffReviewersSet: true}
 	result := Resolve(cfg, envState, FlagState{}, ResolvedConfig{})
-	if result.LargeDiffGroups != 9 {
-		t.Errorf("expected env large_diff_groups=9 to override yaml, got %d", result.LargeDiffGroups)
+	if result.LargeDiffReviewers != 9 {
+		t.Errorf("expected env large_diff_reviewers=9 to override yaml, got %d", result.LargeDiffReviewers)
 	}
 }
 
-func TestResolve_LargeDiffGroups_CLIOverridesEnv(t *testing.T) {
-	cfg := &Config{LargeDiffGroups: ptr(7)}
-	envState := EnvState{LargeDiffGroups: 9, LargeDiffGroupsSet: true}
-	flagState := FlagState{LargeDiffGroupsSet: true}
-	flagValues := ResolvedConfig{LargeDiffGroups: 12}
+func TestResolve_LargeDiffReviewers_CLIOverridesEnv(t *testing.T) {
+	cfg := &Config{LargeDiffReviewers: ptr(7)}
+	envState := EnvState{LargeDiffReviewers: 9, LargeDiffReviewersSet: true}
+	flagState := FlagState{LargeDiffReviewersSet: true}
+	flagValues := ResolvedConfig{LargeDiffReviewers: 12}
 	result := Resolve(cfg, envState, flagState, flagValues)
-	if result.LargeDiffGroups != 12 {
-		t.Errorf("expected CLI large_diff_groups=12 to override env, got %d", result.LargeDiffGroups)
+	if result.LargeDiffReviewers != 12 {
+		t.Errorf("expected CLI large_diff_reviewers=12 to override env, got %d", result.LargeDiffReviewers)
 	}
 }
 
-func TestResolve_LargeDiffGroups_DefaultsTo4(t *testing.T) {
+func TestResolve_LargeDiffReviewers_DefaultsTo4(t *testing.T) {
 	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
-	if result.LargeDiffGroups != 4 {
-		t.Errorf("expected default large_diff_groups=4, got %d", result.LargeDiffGroups)
+	if result.LargeDiffReviewers != 4 {
+		t.Errorf("expected default large_diff_reviewers=4, got %d", result.LargeDiffReviewers)
 	}
-	if Defaults.LargeDiffGroups != 4 {
-		t.Errorf("expected Defaults.LargeDiffGroups=4, got %d", Defaults.LargeDiffGroups)
+	if Defaults.LargeDiffReviewers != 4 {
+		t.Errorf("expected Defaults.LargeDiffReviewers=4, got %d", Defaults.LargeDiffReviewers)
 	}
 }
 
@@ -2700,15 +2700,15 @@ func TestResolve_MediumDiffReviewers_DefaultsTo2(t *testing.T) {
 	}
 }
 
-func TestValidate_RejectsZeroLargeDiffGroups(t *testing.T) {
+func TestValidate_RejectsZeroLargeDiffReviewers(t *testing.T) {
 	cfg := Defaults
-	cfg.LargeDiffGroups = 0
+	cfg.LargeDiffReviewers = 0
 	err := cfg.Validate()
 	if err == nil {
-		t.Fatal("expected error for large_diff_groups=0, got nil")
+		t.Fatal("expected error for large_diff_reviewers=0, got nil")
 	}
-	if !strings.Contains(err.Error(), "large_diff_groups must be >= 1") {
-		t.Errorf("expected 'large_diff_groups must be >= 1' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "large_diff_reviewers must be >= 1") {
+		t.Errorf("expected 'large_diff_reviewers must be >= 1' in error, got: %v", err)
 	}
 }
 
@@ -2724,30 +2724,30 @@ func TestValidate_RejectsZeroMediumDiffReviewers(t *testing.T) {
 	}
 }
 
-func TestLoadEnvState_LargeDiffGroups(t *testing.T) {
+func TestLoadEnvState_LargeDiffReviewers(t *testing.T) {
 	clearACREnv(t)
-	t.Setenv("ACR_LARGE_DIFF_GROUPS", "6")
+	t.Setenv("ACR_LARGE_DIFF_REVIEWERS", "6")
 	state, warnings := LoadEnvState()
 	if len(warnings) != 0 {
 		t.Errorf("expected no warnings, got %v", warnings)
 	}
-	if !state.LargeDiffGroupsSet {
-		t.Error("expected LargeDiffGroupsSet=true")
+	if !state.LargeDiffReviewersSet {
+		t.Error("expected LargeDiffReviewersSet=true")
 	}
-	if state.LargeDiffGroups != 6 {
-		t.Errorf("expected LargeDiffGroups=6, got %d", state.LargeDiffGroups)
+	if state.LargeDiffReviewers != 6 {
+		t.Errorf("expected LargeDiffReviewers=6, got %d", state.LargeDiffReviewers)
 	}
 }
 
-func TestLoadEnvState_LargeDiffGroups_Malformed(t *testing.T) {
+func TestLoadEnvState_LargeDiffReviewers_Malformed(t *testing.T) {
 	clearACREnv(t)
-	t.Setenv("ACR_LARGE_DIFF_GROUPS", "abc")
+	t.Setenv("ACR_LARGE_DIFF_REVIEWERS", "abc")
 	state, warnings := LoadEnvState()
-	if state.LargeDiffGroupsSet {
-		t.Error("expected LargeDiffGroupsSet=false for invalid value")
+	if state.LargeDiffReviewersSet {
+		t.Error("expected LargeDiffReviewersSet=false for invalid value")
 	}
-	if !hasWarningContaining(warnings, "ACR_LARGE_DIFF_GROUPS") {
-		t.Errorf("expected warning about ACR_LARGE_DIFF_GROUPS, got %v", warnings)
+	if !hasWarningContaining(warnings, "ACR_LARGE_DIFF_REVIEWERS") {
+		t.Errorf("expected warning about ACR_LARGE_DIFF_REVIEWERS, got %v", warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `acr config show` の表示フィールドを 14 → 37 行に拡充し、`ResolvedConfig` の全ユーザー向けフィールドを網羅
- `large_diff_groups` → `large_diff_reviewers` リネーム（`small_diff_reviewers` / `medium_diff_reviewers` との命名統一）
- `config show` を Cobra 出力ストリーム準拠に修正（`fmt.Printf` → `fmt.Fprintf(cmd.OutOrStdout())`）
- `config show` で設定読み込み時の警告を stderr に表示

## 変更内容

### リネーム (コミット 1)
| 現在 | 変更後 |
|---|---|
| `LargeDiffGroups` / `large_diff_groups` / `--large-diff-groups` / `ACR_LARGE_DIFF_GROUPS` | `LargeDiffReviewers` / `large_diff_reviewers` / `--large-diff-reviewers` / `ACR_LARGE_DIFF_REVIEWERS` |

### config show 拡張 (コミット 2)
新規追加フィールド:
- Phase 設定: `large_diff_reviewers`, `medium_diff_reviewers`, `small_diff_reviewers`, `auto_phase`
- Agent override: `arch_reviewer_agent`, `diff_reviewer_agents`
- Model: `reviewer_model`, `summarizer_model`
- Cross-check: `cross_check.enabled/agent/model`, `cross_check_timeout`
- その他: `strict`, `guidance_file`
- Models config: `models.defaults.*` (7 ロール), `models.sizes/agents` (件数)

### レビュー指摘対応 (コミット 3)
- `fmt.Printf` → `fmt.Fprintf(cmd.OutOrStdout())` 全面移行
- 設定読み込み警告の stderr 表示
- テストを `cmd.SetOut()` パターンに移行（unsafe な `os.Stdout` キャプチャを削除）
- concurrency フォールバック文言修正: `"0 (auto: same as reviewers)"` → `"0 (auto)"`

## Test plan

- [x] `go test ./internal/config ./cmd/acr ./integration` — 全 pass
- [x] `acr config show` — 37 行の完全出力を確認
- [x] env var override 反映確認
- [x] フォールバック表示の規約準拠確認
- [x] ACR セルフレビュー 2 回実施、blocking 指摘を修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)