### PR TITLE
fix: FormatDistribution ログを auto-phase 解決後に移動 (Issue #12)

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -194,16 +194,6 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		logger.Logf(terminal.StyleDim, "  pr_feedback       : %s", formatSpec(agent.AgentOptions{Model: prFeedbackSpecLog.Model, Effort: prFeedbackSpecLog.Effort}))
 	}
 
-	// Show agent distribution if multiple agents
-	if len(reviewAgents) > 1 {
-		distribution := agent.FormatDistribution(reviewAgents, opts.Reviewers)
-		logger.Logf(terminal.StyleInfo, "Agent distribution: %s%s%s",
-			terminal.Color(terminal.Dim), distribution, terminal.Color(terminal.Reset))
-	} else if opts.Verbose && len(opts.ReviewerAgents) > 0 {
-		logger.Logf(terminal.StyleDim, "%sUsing agent: %s%s",
-			terminal.Color(terminal.Dim), opts.ReviewerAgents[0], terminal.Color(terminal.Reset))
-	}
-
 	// Pre-compute the git diff once and share it across all reviewers.
 	// Always compute (even for codex-only) so we can short-circuit empty diffs.
 	diff, err := git.GetDiff(ctx, resolvedBaseRef, opts.WorkDir)
@@ -317,6 +307,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	}
 
 	var r *runner.Runner
+	var distributionStr string
 	actualReviewers := opts.Reviewers
 	if useGroupedSpecs {
 		// Auto-phase grouped path: per-phase model/effort rebind using
@@ -326,6 +317,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			groupedSpecs[i].Agent = rebindSpecAgent(groupedSpecs[i].Agent, groupedSpecs[i].Phase)
 		}
 		actualReviewers = len(groupedSpecs)
+		distributionStr = runner.FormatDistributionFromSpecs(groupedSpecs)
 		r, err = runner.NewWithSpecs(runnerConfig, groupedSpecs, logger)
 	} else if phaseStr != "" {
 		// Auto-phase medium/large fallback paths supply MediumDiffCount so the
@@ -364,13 +356,26 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			}
 		}
 		actualReviewers = len(specs)
+		distributionStr = runner.FormatDistributionFromSpecs(specs)
 		r, err = runner.NewWithSpecs(runnerConfig, specs, logger)
 	} else {
+		if len(reviewAgents) > 1 {
+			distributionStr = agent.FormatDistribution(reviewAgents, opts.Reviewers)
+		}
 		r, err = runner.New(runnerConfig, reviewAgents, logger)
 	}
+
 	if err != nil {
 		logger.Logf(terminal.StyleError, "Runner initialization failed: %v", err)
 		return domain.ExitError
+	}
+
+	if distributionStr != "" {
+		logger.Logf(terminal.StyleInfo, "Agent distribution: %s%s%s",
+			terminal.Color(terminal.Dim), distributionStr, terminal.Color(terminal.Reset))
+	} else if opts.Verbose && len(opts.ReviewerAgents) > 0 {
+		logger.Logf(terminal.StyleDim, "%sUsing agent: %s%s",
+			terminal.Color(terminal.Dim), opts.ReviewerAgents[0], terminal.Color(terminal.Reset))
 	}
 
 	if opts.Concurrency < actualReviewers {

--- a/internal/runner/spec.go
+++ b/internal/runner/spec.go
@@ -1,6 +1,42 @@
 package runner
 
-import "github.com/richhaase/agentic-code-reviewer/internal/agent"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+)
+
+// FormatDistributionFromSpecs returns a human-readable distribution summary
+// derived from the actual reviewer specs. Unlike agent.FormatDistribution
+// (which simulates round-robin), this counts the real agent assignments.
+// Returns "" when specs is empty or only a single agent type is present.
+func FormatDistributionFromSpecs(specs []ReviewerSpec) string {
+	if len(specs) == 0 {
+		return ""
+	}
+	counts := make(map[string]int)
+	for _, s := range specs {
+		if s.Agent == nil {
+			continue
+		}
+		counts[s.Agent.Name()]++
+	}
+	if len(counts) <= 1 {
+		return ""
+	}
+	names := make([]string, 0, len(counts))
+	for name := range counts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		parts = append(parts, fmt.Sprintf("%d×%s", counts[name], name))
+	}
+	return strings.Join(parts, ", ")
+}
 
 // ReviewerSpec defines the configuration for a single reviewer instance.
 // It replaces round-robin agent assignment with explicit per-reviewer specs.

--- a/internal/runner/spec_test.go
+++ b/internal/runner/spec_test.go
@@ -1,6 +1,82 @@
 package runner
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+)
+
+func TestFormatDistributionFromSpecs_Empty(t *testing.T) {
+	if got := FormatDistributionFromSpecs(nil); got != "" {
+		t.Errorf("nil specs: expected empty string, got %q", got)
+	}
+	if got := FormatDistributionFromSpecs([]ReviewerSpec{}); got != "" {
+		t.Errorf("empty specs: expected empty string, got %q", got)
+	}
+}
+
+func TestFormatDistributionFromSpecs_SingleAgentType(t *testing.T) {
+	a, err := agent.NewAgent("codex")
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+	specs := []ReviewerSpec{
+		{Agent: a},
+		{Agent: a},
+		{Agent: a},
+	}
+	if got := FormatDistributionFromSpecs(specs); got != "" {
+		t.Errorf("single agent type: expected empty string, got %q", got)
+	}
+}
+
+func TestFormatDistributionFromSpecs_MultiAgentTypes(t *testing.T) {
+	codex, err := agent.NewAgent("codex")
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+	claude, err := agent.NewAgent("claude")
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+	specs := []ReviewerSpec{
+		{Agent: codex},
+		{Agent: claude},
+		{Agent: codex},
+	}
+	got := FormatDistributionFromSpecs(specs)
+	expected := "1×claude, 2×codex"
+	if got != expected {
+		t.Errorf("multi agent: expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatDistributionFromSpecs_ThreeAgentTypes(t *testing.T) {
+	codex, err := agent.NewAgent("codex")
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+	claude, err := agent.NewAgent("claude")
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+	gemini, err := agent.NewAgent("gemini")
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+	specs := []ReviewerSpec{
+		{Agent: codex},
+		{Agent: claude},
+		{Agent: gemini},
+		{Agent: codex},
+		{Agent: claude},
+	}
+	got := FormatDistributionFromSpecs(specs)
+	expected := "2×claude, 2×codex, 1×gemini"
+	if got != expected {
+		t.Errorf("three agents: expected %q, got %q", expected, got)
+	}
+}
 
 func TestReviewerSpec_ZeroValue(t *testing.T) {
 	var spec ReviewerSpec


### PR DESCRIPTION
## Summary

- `FormatDistribution` の呼び出しを auto-phase 解決後（spec 構築後）に移動し、実効 reviewer 数とエージェント分配を正確に表示する
- `runner.FormatDistributionFromSpecs` を新設し、grouped/phase パスでは spec ベースの分配を算出
- flat パスは既存の `agent.FormatDistribution` を維持
- 単一 agent type 時は分配ログを出さない（verbose 時のみ "Using agent:" 表示、flat path と整合）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/runner/spec.go` | `FormatDistributionFromSpecs` 新設 |
| `internal/runner/spec_test.go` | テスト 4 件追加 |
| `cmd/acr/review.go` | 分配ログを spec 構築後・runner エラーチェック後に移動 |

## Test plan

- [x] `go test ./internal/runner` — pass
- [x] `go test ./cmd/acr` — pass
- [x] `go test ./...` — pass (integration/TestVersion は pre-existing failure)
- [x] ACR セルフレビュー 3 rounds — 真陽性なし

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)