### PR TITLE
feat: auto-phase 有効時に全 CLI の可用性を起動時に一括チェック (Issue #7)

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -34,6 +34,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		return domain.ExitError
 	}
 
+	// Early CLI availability preflight when auto-phase is active.
+	// Auto-phase may invoke any configured agent role (arch, diff, cross-check)
+	// depending on diff size, so verify all CLIs upfront to avoid wasting
+	// review cycles on a missing binary.
+	if shouldUseAutoPhase(opts) {
+		if err := agent.CheckCLIAvailability(collectAllCLINames(opts)); err != nil {
+			logger.Logf(terminal.StyleError, "Preflight check failed: %v", err)
+			return domain.ExitError
+		}
+	}
+
 	// Resolve the base ref once before launching parallel reviewers.
 	// This ensures all reviewers compare against the same ref, avoiding
 	// inconsistent results if network conditions vary during parallel execution.
@@ -689,13 +700,50 @@ func applyVerdictExitPolicy(verdict string, strict bool, findingsCode domain.Exi
 	return findingsCode
 }
 
-// isLGTM reports whether the review result qualifies for LGTM:
 // shouldUseAutoPhase returns true when auto-phase is enabled and no explicit
 // --phase override was provided. Explicit --phase always takes precedence.
 func shouldUseAutoPhase(opts ReviewOpts) bool {
 	return opts.AutoPhase && opts.Phase == ""
 }
 
+// collectAllCLINames returns CLI names that may be invoked during an auto-phase
+// review run. The returned slice may contain duplicates; deduplication is handled
+// by CheckCLIAvailability. Fallback defaults for optional fields are resolved here
+// (arch_reviewer_agent → ReviewerAgents[0], cross_check.agent → SummarizerAgent, etc.).
+func collectAllCLINames(opts ReviewOpts) []string {
+	names := make([]string, 0, 8)
+	names = append(names, opts.ReviewerAgents...)
+	names = append(names, opts.SummarizerAgent)
+
+	// Arch reviewer: explicit override or first reviewer agent
+	archName := opts.ArchReviewerAgent
+	if archName == "" && len(opts.ReviewerAgents) > 0 {
+		archName = opts.ReviewerAgents[0]
+	}
+	if archName != "" {
+		names = append(names, archName)
+	}
+
+	// Diff reviewers: explicit override or all reviewer agents
+	diffNames := opts.DiffReviewerAgents
+	if len(diffNames) == 0 {
+		diffNames = opts.ReviewerAgents
+	}
+	names = append(names, diffNames...)
+
+	// Cross-check: only if enabled; parse comma-separated names
+	if opts.CrossCheckEnabled {
+		ccName := opts.CrossCheckAgent
+		if ccName == "" {
+			ccName = opts.SummarizerAgent
+		}
+		names = append(names, agent.ParseAgentNames(ccName)...)
+	}
+
+	return names
+}
+
+// isLGTM reports whether the review result qualifies for LGTM:
 // no grouped findings AND no blocking cross-check findings.
 // ccResult may be nil (nil-safe via CrossCheckResult.HasBlockingFindings).
 func isLGTM(grouped domain.GroupedFindings, cc *summarizer.CrossCheckResult) bool {

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1477,3 +1477,112 @@ func TestLogCrossCheckModelMatrix_EmitsOneRowPerResolvedAgent(t *testing.T) {
 	}
 	logCrossCheckModelMatrix(terminal.NewLogger(), opts, "large")
 }
+
+// --- collectAllCLINames tests ---
+
+func TestCollectAllCLINames_Defaults(t *testing.T) {
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:    []string{"codex"},
+			SummarizerAgent:   "codex",
+			CrossCheckEnabled: true,
+		},
+	}
+	names := collectAllCLINames(opts)
+	// Should contain: codex (reviewer), codex (summarizer), codex (arch fallback),
+	// codex (diff fallback), codex (cross-check fallback).
+	// PR feedback is intentionally excluded from preflight (soft-failure design).
+	// Duplicates are deduplicated by CheckCLIAvailability, not here.
+	found := false
+	for _, n := range names {
+		if n == "codex" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'codex' in CLI names")
+	}
+}
+
+func TestCollectAllCLINames_WithOverrides(t *testing.T) {
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:     []string{"codex", "claude"},
+			SummarizerAgent:    "gemini",
+			ArchReviewerAgent:  "claude",
+			DiffReviewerAgents: []string{"codex", "gemini"},
+			CrossCheckEnabled:  true,
+			CrossCheckAgent:    "claude",
+			PRFeedbackEnabled:  true,
+			PRFeedbackAgent:    "gemini",
+		},
+	}
+	names := collectAllCLINames(opts)
+	// Should include all three: codex, claude, gemini
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	for _, expected := range []string{"codex", "claude", "gemini"} {
+		if !nameSet[expected] {
+			t.Errorf("expected %q in CLI names, got: %v", expected, names)
+		}
+	}
+}
+
+func TestCollectAllCLINames_CrossCheckDisabled(t *testing.T) {
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:    []string{"codex"},
+			SummarizerAgent:   "codex",
+			CrossCheckEnabled: false,
+			CrossCheckAgent:   "gemini",
+		},
+	}
+	names := collectAllCLINames(opts)
+	for _, n := range names {
+		if n == "gemini" {
+			t.Error("cross-check disabled: gemini should not be in CLI names")
+		}
+	}
+}
+
+func TestCollectAllCLINames_PRFeedbackEnabled_NotIncluded(t *testing.T) {
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:    []string{"codex"},
+			SummarizerAgent:   "codex",
+			PRFeedbackEnabled: true,
+			PRFeedbackAgent:   "gemini",
+		},
+	}
+	names := collectAllCLINames(opts)
+	for _, n := range names {
+		if n == "gemini" {
+			t.Error("PR feedback enabled: gemini should still not be in CLI names (soft-failure design)")
+		}
+	}
+}
+
+func TestCollectAllCLINames_CrossCheckCommaSeparated(t *testing.T) {
+	opts := ReviewOpts{
+		ResolvedConfig: config.ResolvedConfig{
+			ReviewerAgents:    []string{"codex"},
+			SummarizerAgent:   "codex",
+			CrossCheckEnabled: true,
+			CrossCheckAgent:   "codex,claude",
+		},
+	}
+	names := collectAllCLINames(opts)
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	if !nameSet["claude"] {
+		t.Errorf("expected 'claude' from comma-separated cross-check agent, got: %v", names)
+	}
+	if nameSet["codex,claude"] {
+		t.Error("comma-separated value should be parsed, not passed as-is")
+	}
+}

--- a/internal/agent/cohort.go
+++ b/internal/agent/cohort.go
@@ -3,6 +3,7 @@ package agent
 
 import (
 	"fmt"
+	"os/exec"
 	"slices"
 	"sort"
 	"strings"
@@ -47,6 +48,28 @@ func ValidateAgentNames(names []string) error {
 			strings.Join(invalid, ", "), SupportedAgents)
 	}
 
+	return nil
+}
+
+// CheckCLIAvailability verifies that all named CLI binaries exist in PATH.
+// It does NOT construct agents or resolve models — just exec.LookPath.
+// Returns an error listing all missing CLIs (not just the first).
+func CheckCLIAvailability(names []string) error {
+	seen := make(map[string]bool)
+	var missing []string
+	for _, name := range names {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if _, err := exec.LookPath(name); err != nil {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return fmt.Errorf("CLI not found in PATH: %s", strings.Join(missing, ", "))
+	}
 	return nil
 }
 

--- a/internal/agent/cohort_test.go
+++ b/internal/agent/cohort_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -238,6 +239,43 @@ func TestFormatDistribution(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestCheckCLIAvailability_AllPresent(t *testing.T) {
+	// "go" and "git" are expected to exist in CI and local environments
+	err := CheckCLIAvailability([]string{"go", "git"})
+	if err != nil {
+		t.Fatalf("expected no error for present CLIs, got: %v", err)
+	}
+}
+
+func TestCheckCLIAvailability_SomeMissing(t *testing.T) {
+	err := CheckCLIAvailability([]string{"go", "nonexistent-cli-xyz-12345"})
+	if err == nil {
+		t.Fatal("expected error for missing CLI")
+	}
+	if !strings.Contains(err.Error(), "nonexistent-cli-xyz-12345") {
+		t.Errorf("error should mention missing CLI name, got: %v", err)
+	}
+}
+
+func TestCheckCLIAvailability_Dedup(t *testing.T) {
+	// Same name repeated — should only check once, no error
+	err := CheckCLIAvailability([]string{"go", "go", "go"})
+	if err != nil {
+		t.Fatalf("expected no error for duplicated present CLI, got: %v", err)
+	}
+}
+
+func TestCheckCLIAvailability_AllMissing(t *testing.T) {
+	err := CheckCLIAvailability([]string{"nonexistent-aaa", "nonexistent-bbb"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Both missing CLIs should be listed
+	if !strings.Contains(err.Error(), "nonexistent-aaa") || !strings.Contains(err.Error(), "nonexistent-bbb") {
+		t.Errorf("error should list all missing CLIs, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- auto-phase 有効時（デフォルト）に、config に記載の全 CLI バイナリを起動直後に `exec.LookPath` で一括チェック
- 不足 CLI があれば全不足分をまとめてエラー表示し、review サイクルの無駄を防止
- `--phase small/medium` 明示時・`--no-auto-phase` 時はチェックスキップ（既存 UX 温存）
- cross-check のカンマ区切り agent 名を `ParseAgentNames` で分解
- PR feedback agent は preflight 対象外（runtime で soft failure のため）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/agent/cohort.go` | `CheckCLIAvailability` 新設 |
| `internal/agent/cohort_test.go` | テスト 4 件追加 |
| `cmd/acr/review.go` | preflight チェック + `collectAllCLINames` ヘルパー |
| `cmd/acr/review_test.go` | テスト 5 件追加 |

## 設計判断

- **なぜ auto-phase 時のみか**: diff サイズ不明段階で fail-fast。`--phase small/medium` や `--no-auto-phase` では cross-check/arch/diff は起動しない
- **なぜ PR feedback を除外か**: runtime gate が `PRFeedbackEnabled && DetectedPR != "" && FPFilterEnabled` の 3 条件で、失敗時も warning のみ（soft failure）
- **既存の個別 IsAvailable() チェックは温存**: defense-in-depth

## Test plan

- [x] `go test ./internal/agent` — pass
- [x] `go test ./cmd/acr` — pass
- [x] `go test ./...` — pass
- [x] ACR セルフレビュー 3 rounds — 真陽性なし

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)