### PR TITLE
feat: N/M 表記をフェーズ別に分離 (PR F)

### DIFF
--- a/cmd/acr/pr_submit.go
+++ b/cmd/acr/pr_submit.go
@@ -155,7 +155,7 @@ func handleLGTM(ctx context.Context, opts ReviewOpts, allFindings []domain.Findi
 		annotatedComments[f.ReviewerID] = append(annotatedComments[f.ReviewerID], ac)
 	}
 
-	lgtmBody := runner.RenderLGTMMarkdown(stats.TotalReviewers, stats.SuccessfulReviewers, annotatedComments, version)
+	lgtmBody := runner.RenderLGTMMarkdown(stats, annotatedComments, version)
 	pr := getPRContext(ctx, opts)
 
 	if err := confirmAndSubmitLGTM(ctx, lgtmBody, pr, opts, logger); err != nil {
@@ -290,8 +290,8 @@ func sanitizeCrossCheckSkipReason(reason string) string {
 // optional cross-check results. RenderCommentMarkdown returns "" when there
 // are no grouped findings, so this function handles the cross-check-only
 // path cleanly without leaving stray leading/trailing blank sections.
-func buildReviewBody(grouped domain.GroupedFindings, totalReviewers int, aggregated []domain.AggregatedFinding, cc *summarizer.CrossCheckResult, ver string) string {
-	body := runner.RenderCommentMarkdown(grouped, totalReviewers, aggregated, ver)
+func buildReviewBody(grouped domain.GroupedFindings, stats domain.ReviewStats, aggregated []domain.AggregatedFinding, cc *summarizer.CrossCheckResult, ver string) string {
+	body := runner.RenderCommentMarkdown(grouped, stats, aggregated, ver)
 	ccSection := formatCrossCheckForPR(cc)
 	switch {
 	case body == "" && ccSection == "":
@@ -316,7 +316,7 @@ func handleFindings(ctx context.Context, opts ReviewOpts, grouped domain.Grouped
 	// Interactive selection when in TTY and not auto-submitting (skip in local mode).
 	// Only show selector when there are grouped findings to choose from.
 	if !opts.Local && !opts.AutoYes && terminal.IsStdoutTTY() && len(grouped.Findings) > 0 {
-		indices, canceled, err := terminal.RunSelector(grouped.Findings)
+		indices, canceled, err := terminal.RunSelector(grouped.Findings, stats)
 		if err != nil {
 			logger.Logf(terminal.StyleError, "Selector error: %v", err)
 			return domain.ExitError, verdict
@@ -361,7 +361,7 @@ func handleFindings(ctx context.Context, opts ReviewOpts, grouped domain.Grouped
 		Findings: selectedFindings,
 		Info:     grouped.Info,
 	}
-	reviewBody := buildReviewBody(filteredGrouped, stats.TotalReviewers, aggregated, ccResult, version)
+	reviewBody := buildReviewBody(filteredGrouped, stats, aggregated, ccResult, version)
 
 	if err := confirmAndSubmitReview(ctx, reviewBody, pr, verdict, strict, opts, logger); err != nil {
 		return domain.ExitError, verdict

--- a/cmd/acr/pr_submit_test.go
+++ b/cmd/acr/pr_submit_test.go
@@ -142,7 +142,7 @@ func TestBuildReviewBody_EmptyGroupedWithCC_UsesCCOnly(t *testing.T) {
 		},
 	}
 
-	body := buildReviewBody(grouped, 0, nil, cc, "test")
+	body := buildReviewBody(grouped, domain.ReviewStats{}, nil, cc, "test")
 
 	if body == "" {
 		t.Fatal("expected cross-check-only body, got empty string")
@@ -160,7 +160,7 @@ func TestBuildReviewBody_EmptyGroupedWithCC_UsesCCOnly(t *testing.T) {
 
 func TestBuildReviewBody_EmptyBoth_ReturnsEmpty(t *testing.T) {
 	grouped := domain.GroupedFindings{}
-	got := buildReviewBody(grouped, 0, nil, nil, "test")
+	got := buildReviewBody(grouped, domain.ReviewStats{}, nil, nil, "test")
 	if got != "" {
 		t.Errorf("expected empty body, got %q", got)
 	}
@@ -172,7 +172,7 @@ func TestBuildReviewBody_GroupedOnly_NoCC_ReturnsFindingsBody(t *testing.T) {
 			{Title: "Some Issue", Summary: "Details"},
 		},
 	}
-	got := buildReviewBody(grouped, 1, nil, nil, "test")
+	got := buildReviewBody(grouped, domain.ReviewStats{TotalReviewers: 1}, nil, nil, "test")
 	if !strings.Contains(got, "## Findings") {
 		t.Errorf("expected '## Findings' header; got:\n%s", got)
 	}
@@ -360,7 +360,7 @@ func TestPRBody_IncludesCrossCheckWhenGroupedEmpty(t *testing.T) {
 		},
 	}
 
-	body := buildReviewBody(grouped, 2, nil, cc, "test")
+	body := buildReviewBody(grouped, domain.ReviewStats{TotalReviewers: 2}, nil, cc, "test")
 
 	if !strings.Contains(body, "Cross-Group Findings") {
 		t.Errorf("PR body missing cross-check section; got:\n%s", body)

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -576,6 +576,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 	stats.SummarizerDuration = summaryResult.Duration
 
+	// Backfill per-phase reviewer counts for role-separated display
+	reviewerPhases := make(map[int]string, len(results))
+	for _, r := range results {
+		if r.Phase != "" {
+			reviewerPhases[r.ReviewerID] = r.Phase
+		}
+	}
+	if len(reviewerPhases) > 0 {
+		domain.BackfillPhaseReviewerCounts(&summaryResult.Grouped, aggregated, reviewerPhases)
+	}
+
 	// Wait for PR feedback summarizer to complete
 	feedbackWg.Wait()
 

--- a/internal/domain/finding.go
+++ b/internal/domain/finding.go
@@ -26,13 +26,15 @@ type AggregatedFinding struct {
 
 // FindingGroup represents a grouped/clustered finding from the summarizer.
 type FindingGroup struct {
-	Title         string   `json:"title"`
-	Summary       string   `json:"summary"`
-	Messages      []string `json:"messages"`
-	ReviewerCount int      `json:"reviewer_count"`
-	Sources       []int    `json:"sources"`
-	GroupKey      string   `json:"group_key,omitempty"` // propagated from source findings
-	Severity      string   `json:"severity,omitempty"`  // "blocking" | "advisory" | "" (empty = advisory)
+	Title             string   `json:"title"`
+	Summary           string   `json:"summary"`
+	Messages          []string `json:"messages"`
+	ReviewerCount     int      `json:"reviewer_count"`
+	ArchReviewerCount int      `json:"arch_reviewer_count,omitempty"`
+	DiffReviewerCount int      `json:"diff_reviewer_count,omitempty"`
+	Sources           []int    `json:"sources"`
+	GroupKey          string   `json:"group_key,omitempty"` // propagated from source findings
+	Severity          string   `json:"severity,omitempty"`  // "blocking" | "advisory" | "" (empty = advisory)
 }
 
 // GroupedFindings represents the output from the summarizer.
@@ -175,6 +177,38 @@ func BuildDispositions(
 	}
 
 	return dispositions
+}
+
+// BackfillPhaseReviewerCounts populates ArchReviewerCount and DiffReviewerCount
+// on each FindingGroup by partitioning source reviewer IDs by phase.
+func BackfillPhaseReviewerCounts(
+	grouped *GroupedFindings,
+	aggregated []AggregatedFinding,
+	reviewerPhases map[int]string,
+) {
+	fill := func(groups []FindingGroup) {
+		for i := range groups {
+			archSet := make(map[int]struct{})
+			diffSet := make(map[int]struct{})
+			for _, srcIdx := range groups[i].Sources {
+				if srcIdx < 0 || srcIdx >= len(aggregated) {
+					continue
+				}
+				for _, rid := range aggregated[srcIdx].Reviewers {
+					switch reviewerPhases[rid] {
+					case "arch":
+						archSet[rid] = struct{}{}
+					case "diff":
+						diffSet[rid] = struct{}{}
+					}
+				}
+			}
+			groups[i].ArchReviewerCount = len(archSet)
+			groups[i].DiffReviewerCount = len(diffSet)
+		}
+	}
+	fill(grouped.Findings)
+	fill(grouped.Info)
 }
 
 // addGroupKeyTokens splits raw by "," and inserts each non-empty trimmed token into tokens.

--- a/internal/domain/finding_test.go
+++ b/internal/domain/finding_test.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -372,5 +374,227 @@ func TestReviewStats_AllFailed(t *testing.T) {
 				t.Errorf("AllFailed() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_ArchOnly(t *testing.T) {
+	aggregated := []AggregatedFinding{
+		{Text: "f1", Reviewers: []int{1}},
+	}
+	grouped := &GroupedFindings{
+		Findings: []FindingGroup{
+			{Sources: []int{0}},
+		},
+	}
+	reviewerPhases := map[int]string{1: "arch"}
+
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	fg := grouped.Findings[0]
+	if fg.ArchReviewerCount != 1 {
+		t.Errorf("ArchReviewerCount = %d, want 1", fg.ArchReviewerCount)
+	}
+	if fg.DiffReviewerCount != 0 {
+		t.Errorf("DiffReviewerCount = %d, want 0", fg.DiffReviewerCount)
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_DiffOnly(t *testing.T) {
+	aggregated := []AggregatedFinding{
+		{Text: "f1", Reviewers: []int{2}},
+	}
+	grouped := &GroupedFindings{
+		Findings: []FindingGroup{
+			{Sources: []int{0}},
+		},
+	}
+	reviewerPhases := map[int]string{2: "diff"}
+
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	fg := grouped.Findings[0]
+	if fg.ArchReviewerCount != 0 {
+		t.Errorf("ArchReviewerCount = %d, want 0", fg.ArchReviewerCount)
+	}
+	if fg.DiffReviewerCount != 1 {
+		t.Errorf("DiffReviewerCount = %d, want 1", fg.DiffReviewerCount)
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_Mixed(t *testing.T) {
+	aggregated := []AggregatedFinding{
+		{Text: "f1", Reviewers: []int{1, 2}},
+		{Text: "f2", Reviewers: []int{3}},
+	}
+	grouped := &GroupedFindings{
+		Findings: []FindingGroup{
+			{Sources: []int{0, 1}},
+		},
+	}
+	reviewerPhases := map[int]string{1: "arch", 2: "diff", 3: "diff"}
+
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	fg := grouped.Findings[0]
+	if fg.ArchReviewerCount != 1 {
+		t.Errorf("ArchReviewerCount = %d, want 1", fg.ArchReviewerCount)
+	}
+	if fg.DiffReviewerCount != 2 {
+		t.Errorf("DiffReviewerCount = %d, want 2", fg.DiffReviewerCount)
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_DeduplicatesReviewerIDs(t *testing.T) {
+	// Two aggregated findings both reference reviewer 1 (arch).
+	// The function should count reviewer 1 only once.
+	aggregated := []AggregatedFinding{
+		{Text: "f1", Reviewers: []int{1}},
+		{Text: "f2", Reviewers: []int{1}},
+	}
+	grouped := &GroupedFindings{
+		Findings: []FindingGroup{
+			{Sources: []int{0, 1}},
+		},
+	}
+	reviewerPhases := map[int]string{1: "arch"}
+
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	fg := grouped.Findings[0]
+	if fg.ArchReviewerCount != 1 {
+		t.Errorf("ArchReviewerCount = %d, want 1 (deduplicated)", fg.ArchReviewerCount)
+	}
+	if fg.DiffReviewerCount != 0 {
+		t.Errorf("DiffReviewerCount = %d, want 0", fg.DiffReviewerCount)
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_EmptySources(t *testing.T) {
+	aggregated := []AggregatedFinding{
+		{Text: "f1", Reviewers: []int{1}},
+	}
+	grouped := &GroupedFindings{
+		Findings: []FindingGroup{
+			{Sources: []int{}},
+		},
+	}
+	reviewerPhases := map[int]string{1: "arch"}
+
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	fg := grouped.Findings[0]
+	if fg.ArchReviewerCount != 0 {
+		t.Errorf("ArchReviewerCount = %d, want 0", fg.ArchReviewerCount)
+	}
+	if fg.DiffReviewerCount != 0 {
+		t.Errorf("DiffReviewerCount = %d, want 0", fg.DiffReviewerCount)
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_OutOfRangeIndex(t *testing.T) {
+	aggregated := []AggregatedFinding{
+		{Text: "f1", Reviewers: []int{1}},
+	}
+	grouped := &GroupedFindings{
+		Findings: []FindingGroup{
+			{Sources: []int{-1, 5, 100}},
+		},
+	}
+	reviewerPhases := map[int]string{1: "arch"}
+
+	// Must not panic
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	fg := grouped.Findings[0]
+	if fg.ArchReviewerCount != 0 {
+		t.Errorf("ArchReviewerCount = %d, want 0", fg.ArchReviewerCount)
+	}
+	if fg.DiffReviewerCount != 0 {
+		t.Errorf("DiffReviewerCount = %d, want 0", fg.DiffReviewerCount)
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_NoPhaseInfo(t *testing.T) {
+	aggregated := []AggregatedFinding{
+		{Text: "f1", Reviewers: []int{1, 2}},
+	}
+	grouped := &GroupedFindings{
+		Findings: []FindingGroup{
+			{Sources: []int{0}},
+		},
+	}
+	// Empty map simulates flat review (no phase info)
+	reviewerPhases := map[int]string{}
+
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	fg := grouped.Findings[0]
+	if fg.ArchReviewerCount != 0 {
+		t.Errorf("ArchReviewerCount = %d, want 0", fg.ArchReviewerCount)
+	}
+	if fg.DiffReviewerCount != 0 {
+		t.Errorf("DiffReviewerCount = %d, want 0", fg.DiffReviewerCount)
+	}
+}
+
+func TestBackfillPhaseReviewerCounts_InfoGroups(t *testing.T) {
+	aggregated := []AggregatedFinding{
+		{Text: "info1", Reviewers: []int{1}},
+		{Text: "info2", Reviewers: []int{2}},
+	}
+	grouped := &GroupedFindings{
+		Info: []FindingGroup{
+			{Sources: []int{0}},
+			{Sources: []int{1}},
+		},
+	}
+	reviewerPhases := map[int]string{1: "arch", 2: "diff"}
+
+	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
+
+	info0 := grouped.Info[0]
+	if info0.ArchReviewerCount != 1 {
+		t.Errorf("Info[0].ArchReviewerCount = %d, want 1", info0.ArchReviewerCount)
+	}
+	if info0.DiffReviewerCount != 0 {
+		t.Errorf("Info[0].DiffReviewerCount = %d, want 0", info0.DiffReviewerCount)
+	}
+
+	info1 := grouped.Info[1]
+	if info1.ArchReviewerCount != 0 {
+		t.Errorf("Info[1].ArchReviewerCount = %d, want 0", info1.ArchReviewerCount)
+	}
+	if info1.DiffReviewerCount != 1 {
+		t.Errorf("Info[1].DiffReviewerCount = %d, want 1", info1.DiffReviewerCount)
+	}
+}
+
+func TestFindingGroup_JSON_OmitsZeroPhaseReviewerCounts(t *testing.T) {
+	fg := FindingGroup{Title: "test", ReviewerCount: 3}
+	b, err := json.Marshal(fg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "arch_reviewer_count") {
+		t.Errorf("expected arch_reviewer_count omitted when zero; got %s", s)
+	}
+	if strings.Contains(s, "diff_reviewer_count") {
+		t.Errorf("expected diff_reviewer_count omitted when zero; got %s", s)
+	}
+}
+
+func TestFindingGroup_JSON_IncludesNonZeroPhaseReviewerCounts(t *testing.T) {
+	fg := FindingGroup{Title: "test", ReviewerCount: 3, ArchReviewerCount: 1, DiffReviewerCount: 2}
+	b, err := json.Marshal(fg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"arch_reviewer_count":1`) {
+		t.Errorf("expected arch_reviewer_count:1 in JSON; got %s", s)
+	}
+	if !strings.Contains(s, `"diff_reviewer_count":2`) {
+		t.Errorf("expected diff_reviewer_count:2 in JSON; got %s", s)
 	}
 }

--- a/internal/domain/result.go
+++ b/internal/domain/result.go
@@ -6,6 +6,7 @@ import "time"
 type ReviewerResult struct {
 	ReviewerID  int
 	AgentName   string // Which agent type was used (codex, claude, gemini)
+	Phase       string // "arch" | "diff" | ""
 	Findings    []Finding
 	ExitCode    int
 	ParseErrors int
@@ -15,19 +16,23 @@ type ReviewerResult struct {
 }
 
 type ReviewStats struct {
-	TotalReviewers      int
-	SuccessfulReviewers int
-	FailedReviewers     []int
-	TimedOutReviewers   []int
-	AuthFailedReviewers []int
-	ParseErrors         int
-	ReviewerDurations   map[int]time.Duration
-	ReviewerAgentNames  map[int]string
-	WallClockDuration   time.Duration
-	SummarizerDuration  time.Duration
-	FPFilterDuration    time.Duration
-	CrossCheckDuration  time.Duration
-	FPFilteredCount     int
+	TotalReviewers          int
+	SuccessfulReviewers     int
+	ArchReviewers           int
+	DiffReviewers           int
+	SuccessfulArchReviewers int
+	SuccessfulDiffReviewers int
+	FailedReviewers         []int
+	TimedOutReviewers       []int
+	AuthFailedReviewers     []int
+	ParseErrors             int
+	ReviewerDurations       map[int]time.Duration
+	ReviewerAgentNames      map[int]string
+	WallClockDuration       time.Duration
+	SummarizerDuration      time.Duration
+	FPFilterDuration        time.Duration
+	CrossCheckDuration      time.Duration
+	FPFilteredCount         int
 }
 
 // AllFailed returns true if all reviewers failed.

--- a/internal/runner/report.go
+++ b/internal/runner/report.go
@@ -289,7 +289,7 @@ func formatVerdictLine(verdict string) string {
 
 // formatPhaseReviewerCount returns a per-phase or flat reviewer count string for findings.
 func formatPhaseReviewerCount(finding domain.FindingGroup, stats domain.ReviewStats) string {
-	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+	if stats.ArchReviewers > 0 && stats.DiffReviewers > 0 {
 		var parts []string
 		if finding.ArchReviewerCount > 0 {
 			parts = append(parts, fmt.Sprintf("arch: %d/%d", finding.ArchReviewerCount, stats.ArchReviewers))
@@ -309,7 +309,7 @@ func formatPhaseReviewerCount(finding domain.FindingGroup, stats domain.ReviewSt
 
 // formatPhaseLGTMCount returns a per-phase or flat reviewer count string for LGTM banners.
 func formatPhaseLGTMCount(stats domain.ReviewStats) string {
-	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+	if stats.ArchReviewers > 0 && stats.DiffReviewers > 0 {
 		var parts []string
 		if stats.ArchReviewers > 0 {
 			parts = append(parts, fmt.Sprintf("arch: %d/%d", stats.SuccessfulArchReviewers, stats.ArchReviewers))
@@ -326,7 +326,7 @@ func formatPhaseLGTMCount(stats domain.ReviewStats) string {
 
 // formatPhaseLGTMSentence returns a sentence-form per-phase or flat reviewer count for LGTM markdown.
 func formatPhaseLGTMSentence(stats domain.ReviewStats) string {
-	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+	if stats.ArchReviewers > 0 && stats.DiffReviewers > 0 {
 		var parts []string
 		if stats.ArchReviewers > 0 {
 			parts = append(parts, fmt.Sprintf("%d of %d arch", stats.SuccessfulArchReviewers, stats.ArchReviewers))
@@ -341,7 +341,7 @@ func formatPhaseLGTMSentence(stats domain.ReviewStats) string {
 
 // formatPhaseLGTMCompletedSentence returns a sentence-form per-phase or flat reviewer count for dismissed LGTM.
 func formatPhaseLGTMCompletedSentence(stats domain.ReviewStats) string {
-	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+	if stats.ArchReviewers > 0 && stats.DiffReviewers > 0 {
 		var parts []string
 		if stats.ArchReviewers > 0 {
 			parts = append(parts, fmt.Sprintf("%d of %d arch", stats.SuccessfulArchReviewers, stats.ArchReviewers))

--- a/internal/runner/report.go
+++ b/internal/runner/report.go
@@ -102,9 +102,8 @@ func RenderReport(
 
 			lines = append(lines, "")
 			confidence := ""
-			if stats.TotalReviewers > 0 && finding.ReviewerCount > 0 {
-				confidence = fmt.Sprintf(" %s(%d/%d reviewers)%s",
-					terminal.Color(terminal.Dim), finding.ReviewerCount, stats.TotalReviewers, terminal.Color(terminal.Reset))
+			if rc := formatPhaseReviewerCount(finding, stats); rc != "" {
+				confidence = fmt.Sprintf(" %s%s%s", terminal.Color(terminal.Dim), rc, terminal.Color(terminal.Reset))
 			}
 			severityLabel := formatSeverityLabel(finding.Severity)
 			lines = append(lines, fmt.Sprintf("%s%s%d.%s %s%s%s%s%s",
@@ -247,10 +246,10 @@ func RenderReport(
 		(!ccResult.Skipped || summarizer.IsStructuralSkipReason(ccResult.SkipReason)))
 	if !grouped.HasFindings() && ccQuiet {
 		lines = append(lines, "")
-		lines = append(lines, fmt.Sprintf("%s✓%s %s%sLGTM%s %s(%d/%d reviewers)%s",
+		lines = append(lines, fmt.Sprintf("%s✓%s %s%sLGTM%s %s%s%s",
 			terminal.Color(terminal.Green), terminal.Color(terminal.Reset),
 			terminal.Color(terminal.Green), terminal.Color(terminal.Bold), terminal.Color(terminal.Reset),
-			terminal.Color(terminal.Dim), stats.SuccessfulReviewers, stats.TotalReviewers, terminal.Color(terminal.Reset)))
+			terminal.Color(terminal.Dim), formatPhaseLGTMCount(stats), terminal.Color(terminal.Reset)))
 	}
 
 	return strings.Join(lines, "\n")
@@ -288,12 +287,79 @@ func formatVerdictLine(verdict string) string {
 	}
 }
 
+// formatPhaseReviewerCount returns a per-phase or flat reviewer count string for findings.
+func formatPhaseReviewerCount(finding domain.FindingGroup, stats domain.ReviewStats) string {
+	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+		var parts []string
+		if finding.ArchReviewerCount > 0 {
+			parts = append(parts, fmt.Sprintf("arch: %d/%d", finding.ArchReviewerCount, stats.ArchReviewers))
+		}
+		if finding.DiffReviewerCount > 0 {
+			parts = append(parts, fmt.Sprintf("diff: %d/%d", finding.DiffReviewerCount, stats.DiffReviewers))
+		}
+		if len(parts) > 0 {
+			return fmt.Sprintf("(%s reviewers)", strings.Join(parts, ", "))
+		}
+	}
+	if stats.TotalReviewers > 0 && finding.ReviewerCount > 0 {
+		return fmt.Sprintf("(%d/%d reviewers)", finding.ReviewerCount, stats.TotalReviewers)
+	}
+	return ""
+}
+
+// formatPhaseLGTMCount returns a per-phase or flat reviewer count string for LGTM banners.
+func formatPhaseLGTMCount(stats domain.ReviewStats) string {
+	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+		var parts []string
+		if stats.ArchReviewers > 0 {
+			parts = append(parts, fmt.Sprintf("arch: %d/%d", stats.SuccessfulArchReviewers, stats.ArchReviewers))
+		}
+		if stats.DiffReviewers > 0 {
+			parts = append(parts, fmt.Sprintf("diff: %d/%d", stats.SuccessfulDiffReviewers, stats.DiffReviewers))
+		}
+		if len(parts) > 0 {
+			return fmt.Sprintf("(%s reviewers)", strings.Join(parts, ", "))
+		}
+	}
+	return fmt.Sprintf("(%d/%d reviewers)", stats.SuccessfulReviewers, stats.TotalReviewers)
+}
+
+// formatPhaseLGTMSentence returns a sentence-form per-phase or flat reviewer count for LGTM markdown.
+func formatPhaseLGTMSentence(stats domain.ReviewStats) string {
+	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+		var parts []string
+		if stats.ArchReviewers > 0 {
+			parts = append(parts, fmt.Sprintf("%d of %d arch", stats.SuccessfulArchReviewers, stats.ArchReviewers))
+		}
+		if stats.DiffReviewers > 0 {
+			parts = append(parts, fmt.Sprintf("%d of %d diff", stats.SuccessfulDiffReviewers, stats.DiffReviewers))
+		}
+		return strings.Join(parts, " and ") + " reviewers found no issues."
+	}
+	return fmt.Sprintf("%d of %d reviewers found no issues.", stats.SuccessfulReviewers, stats.TotalReviewers)
+}
+
+// formatPhaseLGTMCompletedSentence returns a sentence-form per-phase or flat reviewer count for dismissed LGTM.
+func formatPhaseLGTMCompletedSentence(stats domain.ReviewStats) string {
+	if stats.ArchReviewers > 0 || stats.DiffReviewers > 0 {
+		var parts []string
+		if stats.ArchReviewers > 0 {
+			parts = append(parts, fmt.Sprintf("%d of %d arch", stats.SuccessfulArchReviewers, stats.ArchReviewers))
+		}
+		if stats.DiffReviewers > 0 {
+			parts = append(parts, fmt.Sprintf("%d of %d diff", stats.SuccessfulDiffReviewers, stats.DiffReviewers))
+		}
+		return strings.Join(parts, " and ") + " reviewers completed review."
+	}
+	return fmt.Sprintf("%d of %d reviewers completed review.", stats.SuccessfulReviewers, stats.TotalReviewers)
+}
+
 // RenderCommentMarkdown renders GitHub comment markdown for findings.
 // Returns an empty string when there are no findings so callers can
 // compose cross-check sections independently.
 func RenderCommentMarkdown(
 	grouped domain.GroupedFindings,
-	totalReviewers int,
+	stats domain.ReviewStats,
 	aggregated []domain.AggregatedFinding,
 	version string,
 ) string {
@@ -310,8 +376,8 @@ func RenderCommentMarkdown(
 		}
 
 		confidence := ""
-		if finding.ReviewerCount > 0 {
-			confidence = fmt.Sprintf(" (%d/%d reviewers)", finding.ReviewerCount, totalReviewers)
+		if rc := formatPhaseReviewerCount(finding, stats); rc != "" {
+			confidence = " " + rc
 		}
 
 		lines = append(lines, "")
@@ -335,7 +401,7 @@ func RenderCommentMarkdown(
 
 	// Raw findings section
 	rawIndices := collectSourceIndices(grouped.Findings)
-	rawSection := formatRawFindings(aggregated, rawIndices, totalReviewers)
+	rawSection := formatRawFindings(aggregated, rawIndices, stats)
 	if rawSection != "" {
 		lines = append(lines, "")
 		lines = append(lines, "_Expand for verbatim findings._")
@@ -361,11 +427,11 @@ type AnnotatedComment struct {
 // RenderLGTMMarkdown renders approval comment markdown.
 // annotatedComments maps reviewer ID to their findings with disposition annotations.
 // If nil, falls back to unannotated rendering.
-func RenderLGTMMarkdown(totalReviewers, successfulReviewers int, annotatedComments map[int][]AnnotatedComment, version string) string {
+func RenderLGTMMarkdown(stats domain.ReviewStats, annotatedComments map[int][]AnnotatedComment, version string) string {
 	var lines []string
 	lines = append(lines, "## LGTM :white_check_mark:")
 	lines = append(lines, "")
-	lines = append(lines, fmt.Sprintf("**%d of %d reviewers found no issues.**", successfulReviewers, totalReviewers))
+	lines = append(lines, fmt.Sprintf("**%s**", formatPhaseLGTMSentence(stats)))
 
 	if len(annotatedComments) > 0 {
 		lines = append(lines, "")
@@ -419,8 +485,7 @@ func RenderDismissedLGTMMarkdown(findings []domain.FindingGroup, stats domain.Re
 	var lines []string
 	lines = append(lines, "## LGTM :white_check_mark:")
 	lines = append(lines, "")
-	lines = append(lines, fmt.Sprintf("**%d of %d reviewers completed review. All findings dismissed after human review.**",
-		stats.SuccessfulReviewers, stats.TotalReviewers))
+	lines = append(lines, fmt.Sprintf("**%s All findings dismissed after human review.**", formatPhaseLGTMCompletedSentence(stats)))
 	lines = append(lines, "")
 
 	count := len(findings)
@@ -508,7 +573,7 @@ func collectSourceIndices(groups []domain.FindingGroup) []int {
 	return indices
 }
 
-func formatRawFindings(aggregated []domain.AggregatedFinding, indices []int, totalReviewers int) string {
+func formatRawFindings(aggregated []domain.AggregatedFinding, indices []int, stats domain.ReviewStats) string {
 	if len(indices) == 0 {
 		return ""
 	}
@@ -521,7 +586,7 @@ func formatRawFindings(aggregated []domain.AggregatedFinding, indices []int, tot
 		entry := aggregated[src]
 		reviewerCount := len(entry.Reviewers)
 		lines = append(lines, "")
-		lines = append(lines, fmt.Sprintf("%d. (%d/%d reviewers)", idx+1, reviewerCount, totalReviewers))
+		lines = append(lines, fmt.Sprintf("%d. (%d/%d reviewers)", idx+1, reviewerCount, stats.TotalReviewers))
 		lines = append(lines, "```")
 		lines = append(lines, strings.TrimRight(entry.Text, " \n"))
 		lines = append(lines, "```")

--- a/internal/runner/report_test.go
+++ b/internal/runner/report_test.go
@@ -51,12 +51,12 @@ func TestFormatRawFindings_ReturnsEmptyForNoIndices(t *testing.T) {
 		{Text: "Finding 1", Reviewers: []int{1, 2}},
 	}
 
-	result := formatRawFindings(aggregated, nil, 5)
+	result := formatRawFindings(aggregated, nil, domain.ReviewStats{TotalReviewers: 5})
 	if result != "" {
 		t.Errorf("expected empty string for nil indices, got %q", result)
 	}
 
-	result = formatRawFindings(aggregated, []int{}, 5)
+	result = formatRawFindings(aggregated, []int{}, domain.ReviewStats{TotalReviewers: 5})
 	if result != "" {
 		t.Errorf("expected empty string for empty indices, got %q", result)
 	}
@@ -69,7 +69,7 @@ func TestFormatRawFindings_SkipsOutOfBoundsIndices(t *testing.T) {
 	}
 
 	// Index 5 is out of bounds, -1 is invalid
-	result := formatRawFindings(aggregated, []int{0, 5, -1, 1}, 3)
+	result := formatRawFindings(aggregated, []int{0, 5, -1, 1}, domain.ReviewStats{TotalReviewers: 3})
 
 	// Should only include indices 0 and 1
 	if !strings.Contains(result, "Finding 0") {
@@ -85,7 +85,7 @@ func TestFormatRawFindings_FormatsAsMarkdownCodeBlocks(t *testing.T) {
 		{Text: "This is a finding", Reviewers: []int{1, 2}},
 	}
 
-	result := formatRawFindings(aggregated, []int{0}, 5)
+	result := formatRawFindings(aggregated, []int{0}, domain.ReviewStats{TotalReviewers: 5})
 
 	if !strings.Contains(result, "```") {
 		t.Error("expected markdown code blocks")
@@ -103,7 +103,7 @@ func TestFormatRawFindings_TrimsTrailingWhitespace(t *testing.T) {
 		{Text: "Finding with trailing space   \n\n", Reviewers: []int{1}},
 	}
 
-	result := formatRawFindings(aggregated, []int{0}, 3)
+	result := formatRawFindings(aggregated, []int{0}, domain.ReviewStats{TotalReviewers: 3})
 
 	// Text should be trimmed of trailing whitespace
 	lines := strings.Split(result, "\n")
@@ -115,7 +115,7 @@ func TestFormatRawFindings_TrimsTrailingWhitespace(t *testing.T) {
 }
 
 func TestRenderLGTMMarkdown_BasicFormat(t *testing.T) {
-	result := RenderLGTMMarkdown(5, 5, nil, "dev")
+	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 5, SuccessfulReviewers: 5}, nil, "dev")
 
 	if !strings.Contains(result, "LGTM") {
 		t.Error("expected 'LGTM' in output")
@@ -134,7 +134,7 @@ func TestRenderLGTMMarkdown_WithComments(t *testing.T) {
 		1: {{Text: "Code looks clean"}},
 	}
 
-	result := RenderLGTMMarkdown(3, 3, comments, "dev")
+	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 3, SuccessfulReviewers: 3}, comments, "dev")
 
 	if !strings.Contains(result, "Reviewer comments") {
 		t.Error("expected 'Reviewer comments' section")
@@ -157,7 +157,7 @@ func TestRenderLGTMMarkdown_SortsCommentsByReviewerID(t *testing.T) {
 		2: {{Text: "Second"}},
 	}
 
-	result := RenderLGTMMarkdown(3, 3, comments, "dev")
+	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 3, SuccessfulReviewers: 3}, comments, "dev")
 
 	// Reviewer 1 should appear before Reviewer 2, which should appear before Reviewer 3
 	idx1 := strings.Index(result, "Reviewer 1")
@@ -194,7 +194,7 @@ func TestRenderLGTMMarkdown_WithDispositionAnnotations(t *testing.T) {
 		},
 	}
 
-	result := RenderLGTMMarkdown(3, 3, comments, "dev")
+	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 3, SuccessfulReviewers: 3}, comments, "dev")
 
 	if !strings.Contains(result, "Categorized as informational during summarization") {
 		t.Error("expected info disposition annotation")
@@ -215,7 +215,7 @@ func TestRenderLGTMMarkdown_MultipleCommentsPerReviewer(t *testing.T) {
 		},
 	}
 
-	result := RenderLGTMMarkdown(3, 3, comments, "dev")
+	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 3, SuccessfulReviewers: 3}, comments, "dev")
 
 	if strings.Count(result, "Reviewer 1") != 2 {
 		t.Errorf("expected 2 entries for Reviewer 1, got %d", strings.Count(result, "Reviewer 1"))
@@ -238,7 +238,7 @@ func TestRenderLGTMMarkdown_UnmappedDispositionNoAnnotation(t *testing.T) {
 		},
 	}
 
-	result := RenderLGTMMarkdown(3, 3, comments, "dev")
+	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 3, SuccessfulReviewers: 3}, comments, "dev")
 
 	// Unmapped should render as plain comment without annotation
 	if !strings.Contains(result, "- **Reviewer 1:** Some comment") {
@@ -263,7 +263,7 @@ func TestRenderCommentMarkdown_BasicFormat(t *testing.T) {
 		},
 	}
 
-	result := RenderCommentMarkdown(grouped, 5, nil, "dev")
+	result := RenderCommentMarkdown(grouped, domain.ReviewStats{TotalReviewers: 5}, nil, "dev")
 
 	if !strings.Contains(result, "## Findings") {
 		t.Error("expected '## Findings' header")
@@ -288,7 +288,7 @@ func TestRenderCommentMarkdown_NumbersFindings(t *testing.T) {
 		},
 	}
 
-	result := RenderCommentMarkdown(grouped, 3, nil, "dev")
+	result := RenderCommentMarkdown(grouped, domain.ReviewStats{TotalReviewers: 3}, nil, "dev")
 
 	if !strings.Contains(result, "1. **First**") {
 		t.Error("expected first finding to be numbered 1")
@@ -308,7 +308,7 @@ func TestRenderCommentMarkdown_UntitledFindingsFallback(t *testing.T) {
 		},
 	}
 
-	result := RenderCommentMarkdown(grouped, 3, nil, "dev")
+	result := RenderCommentMarkdown(grouped, domain.ReviewStats{TotalReviewers: 3}, nil, "dev")
 
 	if !strings.Contains(result, "**Untitled**") {
 		t.Error("expected 'Untitled' fallback for empty title")
@@ -325,7 +325,7 @@ func TestRenderCommentMarkdown_IncludesEvidence(t *testing.T) {
 		},
 	}
 
-	result := RenderCommentMarkdown(grouped, 3, nil, "dev")
+	result := RenderCommentMarkdown(grouped, domain.ReviewStats{TotalReviewers: 3}, nil, "dev")
 
 	if !strings.Contains(result, "Evidence:") {
 		t.Error("expected 'Evidence:' label")
@@ -353,7 +353,7 @@ func TestRenderCommentMarkdown_IncludesRawSection(t *testing.T) {
 		{Text: "Raw finding text", Reviewers: []int{1, 2}},
 	}
 
-	result := RenderCommentMarkdown(grouped, 5, aggregated, "dev")
+	result := RenderCommentMarkdown(grouped, domain.ReviewStats{TotalReviewers: 5}, aggregated, "dev")
 
 	if !strings.Contains(result, "<details>") {
 		t.Error("expected collapsible details section")
@@ -1104,7 +1104,7 @@ func TestRenderReport_CCSkippedAllAgentsFailed_NoLGTM(t *testing.T) {
 func TestRenderCommentMarkdown_EmptyFindings_ReturnsEmpty(t *testing.T) {
 	grouped := domain.GroupedFindings{}
 
-	result := RenderCommentMarkdown(grouped, 5, nil, "dev")
+	result := RenderCommentMarkdown(grouped, domain.ReviewStats{TotalReviewers: 5}, nil, "dev")
 
 	if result != "" {
 		t.Errorf("expected empty string for empty findings, got %q", result)
@@ -1118,7 +1118,7 @@ func TestRenderCommentMarkdown_WithFindings_ReturnsBody(t *testing.T) {
 		},
 	}
 
-	result := RenderCommentMarkdown(grouped, 3, nil, "dev")
+	result := RenderCommentMarkdown(grouped, domain.ReviewStats{TotalReviewers: 3}, nil, "dev")
 
 	if !strings.Contains(result, "## Findings") {
 		t.Error("expected '## Findings' header in non-empty output")
@@ -1126,4 +1126,157 @@ func TestRenderCommentMarkdown_WithFindings_ReturnsBody(t *testing.T) {
 	if !strings.Contains(result, "Some Issue") {
 		t.Error("expected finding title in output")
 	}
+}
+
+func TestFormatPhaseReviewerCount_Grouped(t *testing.T) {
+	finding := domain.FindingGroup{
+		ArchReviewerCount: 1,
+		DiffReviewerCount: 2,
+	}
+	stats := domain.ReviewStats{
+		ArchReviewers: 1,
+		DiffReviewers: 4,
+	}
+	got := formatPhaseReviewerCount(finding, stats)
+	expected := "(arch: 1/1, diff: 2/4 reviewers)"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatPhaseReviewerCount_ArchOnly(t *testing.T) {
+	finding := domain.FindingGroup{
+		ArchReviewerCount: 1,
+		DiffReviewerCount: 0,
+	}
+	stats := domain.ReviewStats{
+		ArchReviewers: 1,
+		DiffReviewers: 4,
+	}
+	got := formatPhaseReviewerCount(finding, stats)
+	expected := "(arch: 1/1 reviewers)"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatPhaseReviewerCount_FlatFallback(t *testing.T) {
+	finding := domain.FindingGroup{
+		ReviewerCount: 3,
+	}
+	stats := domain.ReviewStats{
+		ArchReviewers:  0,
+		DiffReviewers:  0,
+		TotalReviewers: 5,
+	}
+	got := formatPhaseReviewerCount(finding, stats)
+	expected := "(3/5 reviewers)"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatPhaseReviewerCount_EmptyStats(t *testing.T) {
+	finding := domain.FindingGroup{}
+	stats := domain.ReviewStats{}
+	got := formatPhaseReviewerCount(finding, stats)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestFormatPhaseLGTMCount_Grouped(t *testing.T) {
+	stats := domain.ReviewStats{
+		ArchReviewers:           1,
+		DiffReviewers:           4,
+		SuccessfulArchReviewers: 1,
+		SuccessfulDiffReviewers: 4,
+	}
+	got := formatPhaseLGTMCount(stats)
+	expected := "(arch: 1/1, diff: 4/4 reviewers)"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatPhaseLGTMCount_FlatFallback(t *testing.T) {
+	stats := domain.ReviewStats{
+		ArchReviewers:       0,
+		DiffReviewers:       0,
+		TotalReviewers:      5,
+		SuccessfulReviewers: 5,
+	}
+	got := formatPhaseLGTMCount(stats)
+	expected := "(5/5 reviewers)"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatPhaseLGTMSentence_Grouped(t *testing.T) {
+	stats := domain.ReviewStats{
+		ArchReviewers:           1,
+		DiffReviewers:           4,
+		SuccessfulArchReviewers: 1,
+		SuccessfulDiffReviewers: 4,
+	}
+	got := formatPhaseLGTMSentence(stats)
+	expected := "1 of 1 arch and 4 of 4 diff reviewers found no issues."
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatPhaseLGTMSentence_FlatFallback(t *testing.T) {
+	stats := domain.ReviewStats{
+		ArchReviewers:       0,
+		DiffReviewers:       0,
+		TotalReviewers:      3,
+		SuccessfulReviewers: 3,
+	}
+	got := formatPhaseLGTMSentence(stats)
+	expected := "3 of 3 reviewers found no issues."
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestFormatPhaseLGTMCompletedSentence_Grouped(t *testing.T) {
+	stats := domain.ReviewStats{
+		ArchReviewers:           1,
+		DiffReviewers:           4,
+		SuccessfulArchReviewers: 1,
+		SuccessfulDiffReviewers: 4,
+	}
+	got := formatPhaseLGTMCompletedSentence(stats)
+	expected := "1 of 1 arch and 4 of 4 diff reviewers completed review."
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestRenderReport_FlatReviewNoRegression(t *testing.T) {
+	terminal.WithColorsDisabled(func() {
+		grouped := domain.GroupedFindings{
+			Findings: []domain.FindingGroup{
+				{
+					Title:         "Some Issue",
+					Summary:       "Details",
+					ReviewerCount: 3,
+				},
+			},
+		}
+		summaryResult := &summarizer.Result{ExitCode: 0}
+		stats := domain.ReviewStats{
+			ArchReviewers:  0,
+			DiffReviewers:  0,
+			TotalReviewers: 5,
+		}
+
+		result := RenderReport(grouped, summaryResult, stats, nil)
+
+		if !strings.Contains(result, "(3/5 reviewers)") {
+			t.Errorf("expected flat '(N/M reviewers)' format in output, got:\n%s", result)
+		}
+	})
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -370,6 +370,9 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		}
 	}
 
+	// Stamp phase on the result itself
+	result.Phase = reviewConfig.Phase
+
 	// Stamp phase on all findings (parser has no access to ReviewConfig)
 	if reviewConfig.Phase != "" {
 		for i := range result.Findings {
@@ -454,6 +457,19 @@ func BuildStats(results []domain.ReviewerResult, totalReviewers int, wallClock t
 			stats.FailedReviewers = append(stats.FailedReviewers, r.ReviewerID)
 		} else {
 			stats.SuccessfulReviewers++
+		}
+
+		switch r.Phase {
+		case "arch":
+			stats.ArchReviewers++
+			if !r.TimedOut && !r.AuthFailed && r.ExitCode == 0 {
+				stats.SuccessfulArchReviewers++
+			}
+		case "diff":
+			stats.DiffReviewers++
+			if !r.TimedOut && !r.AuthFailed && r.ExitCode == 0 {
+				stats.SuccessfulDiffReviewers++
+			}
 		}
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -297,6 +297,10 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		TargetFiles:     spec.TargetFiles,
 	}
 
+	// Stamp phase early so that failed/timed-out reviewers are counted
+	// in per-phase denominators by BuildStats.
+	result.Phase = reviewConfig.Phase
+
 	// Execute the review
 	execResult, err := selectedAgent.ExecuteReview(timeoutCtx, reviewConfig)
 	if err != nil {
@@ -369,9 +373,6 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 				terminal.Color(terminal.Dim), text, terminal.Color(terminal.Reset))
 		}
 	}
-
-	// Stamp phase on the result itself
-	result.Phase = reviewConfig.Phase
 
 	// Stamp phase on all findings (parser has no access to ReviewConfig)
 	if reviewConfig.Phase != "" {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -506,3 +506,73 @@ func TestNewWithSpecs_DuplicateReviewerIDError(t *testing.T) {
 		t.Errorf("expected 'duplicate' in error message, got: %v", err)
 	}
 }
+
+func TestBuildStats_PerPhaseCount(t *testing.T) {
+	results := []domain.ReviewerResult{
+		{ReviewerID: 1, Phase: "arch", ExitCode: 0},
+		{ReviewerID: 2, Phase: "diff", ExitCode: 0},
+		{ReviewerID: 3, Phase: "diff", ExitCode: 0},
+		{ReviewerID: 4, Phase: "diff", ExitCode: 0},
+		{ReviewerID: 5, Phase: "diff", ExitCode: 0},
+	}
+	stats := BuildStats(results, 5, 0)
+
+	if stats.ArchReviewers != 1 {
+		t.Errorf("ArchReviewers = %d, want 1", stats.ArchReviewers)
+	}
+	if stats.DiffReviewers != 4 {
+		t.Errorf("DiffReviewers = %d, want 4", stats.DiffReviewers)
+	}
+	if stats.SuccessfulArchReviewers != 1 {
+		t.Errorf("SuccessfulArchReviewers = %d, want 1", stats.SuccessfulArchReviewers)
+	}
+	if stats.SuccessfulDiffReviewers != 4 {
+		t.Errorf("SuccessfulDiffReviewers = %d, want 4", stats.SuccessfulDiffReviewers)
+	}
+}
+
+func TestBuildStats_PerPhaseCount_FlatReview(t *testing.T) {
+	results := []domain.ReviewerResult{
+		{ReviewerID: 1, Phase: "", ExitCode: 0},
+		{ReviewerID: 2, Phase: "", ExitCode: 0},
+		{ReviewerID: 3, Phase: "", ExitCode: 0},
+	}
+	stats := BuildStats(results, 3, 0)
+
+	if stats.ArchReviewers != 0 {
+		t.Errorf("ArchReviewers = %d, want 0", stats.ArchReviewers)
+	}
+	if stats.DiffReviewers != 0 {
+		t.Errorf("DiffReviewers = %d, want 0", stats.DiffReviewers)
+	}
+	if stats.TotalReviewers != 3 {
+		t.Errorf("TotalReviewers = %d, want 3", stats.TotalReviewers)
+	}
+	if stats.SuccessfulReviewers != 3 {
+		t.Errorf("SuccessfulReviewers = %d, want 3", stats.SuccessfulReviewers)
+	}
+}
+
+func TestBuildStats_PerPhaseCount_PartialFailure(t *testing.T) {
+	results := []domain.ReviewerResult{
+		{ReviewerID: 1, Phase: "arch", ExitCode: 0},
+		{ReviewerID: 2, Phase: "diff", ExitCode: 0},
+		{ReviewerID: 3, Phase: "diff", ExitCode: 0},
+		{ReviewerID: 4, Phase: "diff", ExitCode: -1, TimedOut: true},
+		{ReviewerID: 5, Phase: "diff", ExitCode: 1},
+	}
+	stats := BuildStats(results, 5, 0)
+
+	if stats.ArchReviewers != 1 {
+		t.Errorf("ArchReviewers = %d, want 1", stats.ArchReviewers)
+	}
+	if stats.SuccessfulArchReviewers != 1 {
+		t.Errorf("SuccessfulArchReviewers = %d, want 1", stats.SuccessfulArchReviewers)
+	}
+	if stats.DiffReviewers != 4 {
+		t.Errorf("DiffReviewers = %d, want 4", stats.DiffReviewers)
+	}
+	if stats.SuccessfulDiffReviewers != 2 {
+		t.Errorf("SuccessfulDiffReviewers = %d, want 2", stats.SuccessfulDiffReviewers)
+	}
+}

--- a/internal/terminal/selector.go
+++ b/internal/terminal/selector.go
@@ -124,7 +124,7 @@ func (m SelectorModel) View() string {
 
 		// Title with number and reviewer count (per-phase when available)
 		title := fmt.Sprintf("%s %d. %s", checkbox, i+1, finding.Title)
-		if m.stats.ArchReviewers > 0 || m.stats.DiffReviewers > 0 {
+		if m.stats.ArchReviewers > 0 && m.stats.DiffReviewers > 0 {
 			var parts []string
 			if finding.ArchReviewerCount > 0 {
 				parts = append(parts, fmt.Sprintf("arch: %d/%d", finding.ArchReviewerCount, m.stats.ArchReviewers))
@@ -134,8 +134,10 @@ func (m SelectorModel) View() string {
 			}
 			if len(parts) > 0 {
 				title += fmt.Sprintf(" (%s reviewers)", strings.Join(parts, ", "))
+			} else if finding.ReviewerCount > 0 && m.stats.TotalReviewers > 0 {
+				title += fmt.Sprintf(" (%d/%d reviewers)", finding.ReviewerCount, m.stats.TotalReviewers)
 			}
-		} else if finding.ReviewerCount > 0 {
+		} else if finding.ReviewerCount > 0 && m.stats.TotalReviewers > 0 {
 			title += fmt.Sprintf(" (%d/%d reviewers)", finding.ReviewerCount, m.stats.TotalReviewers)
 		}
 

--- a/internal/terminal/selector.go
+++ b/internal/terminal/selector.go
@@ -38,21 +38,23 @@ var (
 // SelectorModel is the bubbletea model for the interactive finding selector.
 type SelectorModel struct {
 	findings  []domain.FindingGroup
-	selected  map[int]bool // selection state (kept out of domain types)
-	expanded  map[int]bool // which items show full details
+	stats     domain.ReviewStats // for per-phase reviewer count display
+	selected  map[int]bool       // selection state (kept out of domain types)
+	expanded  map[int]bool       // which items show full details
 	cursor    int
 	confirmed bool
 	quitted   bool
 }
 
 // NewSelector creates a new selector model with all findings selected by default.
-func NewSelector(findings []domain.FindingGroup) SelectorModel {
+func NewSelector(findings []domain.FindingGroup, stats domain.ReviewStats) SelectorModel {
 	selected := make(map[int]bool, len(findings))
 	for i := range findings {
 		selected[i] = true
 	}
 	return SelectorModel{
 		findings: findings,
+		stats:    stats,
 		selected: selected,
 		expanded: make(map[int]bool),
 		cursor:   0,
@@ -120,14 +122,21 @@ func (m SelectorModel) View() string {
 			checkbox = selectorCheckboxSelected
 		}
 
-		// Title with number and reviewer count
+		// Title with number and reviewer count (per-phase when available)
 		title := fmt.Sprintf("%s %d. %s", checkbox, i+1, finding.Title)
-		if finding.ReviewerCount > 0 {
-			title += fmt.Sprintf(" (%d reviewer", finding.ReviewerCount)
-			if finding.ReviewerCount > 1 {
-				title += "s"
+		if m.stats.ArchReviewers > 0 || m.stats.DiffReviewers > 0 {
+			var parts []string
+			if finding.ArchReviewerCount > 0 {
+				parts = append(parts, fmt.Sprintf("arch: %d/%d", finding.ArchReviewerCount, m.stats.ArchReviewers))
 			}
-			title += ")"
+			if finding.DiffReviewerCount > 0 {
+				parts = append(parts, fmt.Sprintf("diff: %d/%d", finding.DiffReviewerCount, m.stats.DiffReviewers))
+			}
+			if len(parts) > 0 {
+				title += fmt.Sprintf(" (%s reviewers)", strings.Join(parts, ", "))
+			}
+		} else if finding.ReviewerCount > 0 {
+			title += fmt.Sprintf(" (%d/%d reviewers)", finding.ReviewerCount, m.stats.TotalReviewers)
 		}
 
 		// Apply cursor highlighting
@@ -184,12 +193,12 @@ func (m SelectorModel) Quitted() bool {
 //   - selectedIndices: indices of findings the user selected
 //   - canceled: true if user quit without confirming
 //   - err: any error from the TUI program
-func RunSelector(findings []domain.FindingGroup) (selectedIndices []int, canceled bool, err error) {
+func RunSelector(findings []domain.FindingGroup, stats domain.ReviewStats) (selectedIndices []int, canceled bool, err error) {
 	if len(findings) == 0 {
 		return nil, false, nil
 	}
 
-	model := NewSelector(findings)
+	model := NewSelector(findings, stats)
 	p := tea.NewProgram(model)
 
 	finalModel, err := p.Run()

--- a/internal/terminal/selector_test.go
+++ b/internal/terminal/selector_test.go
@@ -15,7 +15,7 @@ func TestNewSelector_AllSelectedByDefault(t *testing.T) {
 		{Title: "Finding 3"},
 	}
 
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	for i := range findings {
 		if !m.selected[i] {
@@ -25,7 +25,7 @@ func TestNewSelector_AllSelectedByDefault(t *testing.T) {
 }
 
 func TestNewSelector_EmptyFindings(t *testing.T) {
-	m := NewSelector(nil)
+	m := NewSelector(nil, domain.ReviewStats{})
 
 	if len(m.findings) != 0 {
 		t.Errorf("expected 0 findings, got %d", len(m.findings))
@@ -42,7 +42,7 @@ func TestSelectedIndices_ReturnsCorrectIndices(t *testing.T) {
 		{Title: "Finding 3"},
 	}
 
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	m.selected[1] = false // Deselect middle finding
 
 	indices := m.SelectedIndices()
@@ -62,7 +62,7 @@ func TestSelectedIndices_Sorted(t *testing.T) {
 		{Title: "Finding 3"},
 	}
 
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	// Indices should be sorted regardless of iteration order
 	indices := m.SelectedIndices()
 
@@ -78,7 +78,7 @@ func TestUpdate_CursorMoveDown(t *testing.T) {
 		{Title: "Finding 1"},
 		{Title: "Finding 2"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	m = newModel.(SelectorModel)
@@ -93,7 +93,7 @@ func TestUpdate_CursorMoveUp(t *testing.T) {
 		{Title: "Finding 1"},
 		{Title: "Finding 2"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	m.cursor = 1
 
 	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
@@ -109,7 +109,7 @@ func TestUpdate_CursorStopsAtTop(t *testing.T) {
 		{Title: "Finding 1"},
 		{Title: "Finding 2"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	m.cursor = 0
 
 	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
@@ -125,7 +125,7 @@ func TestUpdate_CursorStopsAtBottom(t *testing.T) {
 		{Title: "Finding 1"},
 		{Title: "Finding 2"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	m.cursor = 1
 
 	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
@@ -144,7 +144,7 @@ func TestUpdate_VimKeybindings(t *testing.T) {
 	}
 
 	// Test j for down
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
 	m = newModel.(SelectorModel)
 
@@ -165,7 +165,7 @@ func TestUpdate_SpaceTogglesSelection(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding 1"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	// Initially selected, toggle off
 	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
@@ -190,7 +190,7 @@ func TestUpdate_SelectAll(t *testing.T) {
 		{Title: "Finding 2"},
 		{Title: "Finding 3"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	m.selected[0] = false
 	m.selected[1] = false
 
@@ -210,7 +210,7 @@ func TestUpdate_SelectNone(t *testing.T) {
 		{Title: "Finding 2"},
 		{Title: "Finding 3"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
 	m = newModel.(SelectorModel)
@@ -226,7 +226,7 @@ func TestUpdate_ExpandToggle(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding 1", Summary: "Summary 1"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	// Initially not expanded
 	if m.expanded[0] {
@@ -254,7 +254,7 @@ func TestUpdate_EnterConfirms(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding 1"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = newModel.(SelectorModel)
@@ -271,7 +271,7 @@ func TestUpdate_QuitQuitsImmediately(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding 1"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	m = newModel.(SelectorModel)
@@ -288,7 +288,7 @@ func TestUpdate_EscQuitsImmediately(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding 1"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 
 	newModel, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	m = newModel.(SelectorModel)
@@ -302,7 +302,7 @@ func TestUpdate_EscQuitsImmediately(t *testing.T) {
 }
 
 func TestView_EmptyFindings(t *testing.T) {
-	m := NewSelector(nil)
+	m := NewSelector(nil, domain.ReviewStats{})
 	view := m.View()
 
 	if view != "No findings to select.\n" {
@@ -314,7 +314,7 @@ func TestView_ContainsTitle(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Test Finding Title"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	view := m.View()
 
 	if !containsString(view, "Test Finding Title") {
@@ -326,23 +326,27 @@ func TestView_ContainsReviewerCount(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding", ReviewerCount: 3},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{TotalReviewers: 5})
 	view := m.View()
 
-	if !containsString(view, "3 reviewers") {
-		t.Error("expected view to contain reviewer count")
+	if !containsString(view, "3/5 reviewers") {
+		t.Error("expected view to contain reviewer count with denominator")
 	}
 }
 
-func TestView_SingleReviewerGrammar(t *testing.T) {
+func TestView_PhaseReviewerCount(t *testing.T) {
 	findings := []domain.FindingGroup{
-		{Title: "Finding", ReviewerCount: 1},
+		{Title: "Finding", ArchReviewerCount: 1, DiffReviewerCount: 2},
 	}
-	m := NewSelector(findings)
+	stats := domain.ReviewStats{ArchReviewers: 1, DiffReviewers: 4}
+	m := NewSelector(findings, stats)
 	view := m.View()
 
-	if !containsString(view, "1 reviewer)") {
-		t.Error("expected view to show '1 reviewer' (singular)")
+	if !containsString(view, "arch: 1/1") {
+		t.Error("expected view to contain arch reviewer count")
+	}
+	if !containsString(view, "diff: 2/4") {
+		t.Error("expected view to contain diff reviewer count")
 	}
 }
 
@@ -350,7 +354,7 @@ func TestView_ExpandedShowsSummary(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding", Summary: "This is the detailed summary"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	m.expanded[0] = true
 	view := m.View()
 
@@ -363,7 +367,7 @@ func TestView_CollapsedHidesSummary(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding", Summary: "This is the detailed summary"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	// expanded[0] is false by default
 	view := m.View()
 
@@ -376,7 +380,7 @@ func TestView_ContainsHelpText(t *testing.T) {
 	findings := []domain.FindingGroup{
 		{Title: "Finding"},
 	}
-	m := NewSelector(findings)
+	m := NewSelector(findings, domain.ReviewStats{})
 	view := m.View()
 
 	if !containsString(view, "navigate") || !containsString(view, "toggle") {


### PR DESCRIPTION
## Summary

- grouped review 時の `(N/M reviewers)` 表記を `(arch: X/Y, diff: A/B reviewers)` 形式に変更
- flat review (`--no-auto-phase` / `--phase small`) では従来の `(N/M reviewers)` にフォールバック
- LGTM banner, PR markdown, selector UI を含む全 7 表示箇所を統一的に per-phase 対応

## 変更内容

### データ層
- `ReviewerResult.Phase` フィールド追加 — 失敗/タイムアウト reviewer も含め早期に stamp
- `ReviewStats` に `ArchReviewers` / `DiffReviewers` / `SuccessfulArchReviewers` / `SuccessfulDiffReviewers` 追加
- `FindingGroup` に `ArchReviewerCount` / `DiffReviewerCount` 追加 (`json:"...,omitempty"`)
- `domain.BackfillPhaseReviewerCounts()` — summarizer 出力に Sources → reviewerPhases map でフェーズ別集計を注入

### 表示層
- `formatPhaseReviewerCount()` / `formatPhaseLGTMCount()` 等のヘルパーを追加
- Terminal report, PR markdown, LGTM banner, raw findings, selector UI の全 7 箇所を per-phase 対応
- `RenderCommentMarkdown` / `RenderLGTMMarkdown` / `RunSelector` の API を `ReviewStats` 受け取りに変更

### ACR レビュー指摘対応
- `runner.go`: Phase stamp を早期 return 前に移動 (失敗 reviewer の per-phase 分母漏れ防止)
- `selector.go`: per-phase parts 空時の flat fallback 追加 (report.go と一貫したフォールスルー)

## スコープ外 (明示)

- LLM clustering 非決定性の根本問題 (project memory 記載)
- phase 文字列リテラルの定数化 → Issue #18 として起票済み
- cross-check セクション (N/M 表記なし)

## Test plan

- [x] `go test ./...` 全 14 パッケージ PASS
- [x] `go vet ./...` クリーン
- [x] 新規テスト 25 件追加 (backfill 単体, BuildStats per-phase, format helpers, JSON omitempty, selector per-phase)
- [x] 既存テスト回帰なし (シグネチャ追従済み)
- [x] ACR 2 回実行 — 初回 blocking → 修正後 advisory (全件 FP/スコープ外)
- [ ] `.\acr.exe --local --reviewers 5 --base HEAD~1 --verbose` で grouped review 実動作確認 (手動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)