### PR TITLE
feat: medium パスの diff reviewer にファイル単位で分割した diff を割り当て (#13)

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -274,20 +274,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			phaseFromAuto = size != git.DiffSizeSmall
 			if opts.Verbose {
 				switch {
-				case apr.UseGrouped:
+				case apr.UseGrouped && sizeStr == "large":
 					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (large_diff_reviewers=%d, arch+%d diff groups)",
 						opts.LargeDiffReviewers, len(groupedSpecs)-1)
-					// Per-phase model matrix rows — only meaningful once we
-					// know the grouped path will actually run. Before this
-					// point, a large→flat fallback would have made these rows
-					// misleading, so emission is deferred until here.
 					logPerPhaseModelMatrix(logger, opts, sizeStr)
-					// cross_check rows — same rationale: cross-check fires only
-					// when useGroupedSpecs=true. Emitted here so the verbose
-					// log groups all grouped-path-specific rows together.
 					if opts.CrossCheckEnabled {
 						logCrossCheckModelMatrix(logger, opts, sizeStr)
 					}
+				case apr.UseGrouped:
+					logger.Logf(terminal.StyleInfo, "Auto-phase: medium split (medium_diff_reviewers=%d, arch+%d diff groups)",
+						opts.MediumDiffReviewers, len(groupedSpecs)-1)
+					logPerPhaseModelMatrix(logger, opts, sizeStr)
 				case apr.MediumDiffCount > 0 && apr.FallbackReason != "":
 					logger.Logf(terminal.StyleWarning,
 						"Auto-phase: medium (medium_diff_reviewers=%d) — fallback: %s",
@@ -331,11 +328,6 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		distributionStr = runner.FormatDistributionFromSpecs(groupedSpecs)
 		r, err = runner.NewWithSpecs(runnerConfig, groupedSpecs, logger)
 	} else if phaseStr != "" {
-		// Auto-phase medium/large fallback paths supply MediumDiffCount so the
-		// diff phase reviewer count comes from medium_diff_reviewers (NOT
-		// --reviewers is for --no-auto-phase (flat review). Phase-based
-		// paths use the corresponding knob: small_diff_reviewers for "small",
-		// medium_diff_reviewers (+1 arch) for "medium".
 		totalForParse := opts.Reviewers
 		switch phaseStr {
 		case "small":
@@ -358,9 +350,6 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			logger.Logf(terminal.StyleError, "Phase config error: %v", specErr)
 			return domain.ExitError
 		}
-		// Per-phase rebind: only when phases were produced by auto-phase.
-		// Explicit `--phase` flags use the generic reviewer role per the
-		// documented contract (flat review path).
 		if phaseFromAuto {
 			for i := range specs {
 				specs[i].Agent = rebindSpecAgent(specs[i].Agent, specs[i].Phase)
@@ -469,14 +458,14 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	allFindings := runner.CollectFindings(results)
 	aggregated := domain.AggregateFindings(allFindings)
 
-	// Cross-check: run only for grouped diff reviews with >=2 groups.
+	// Cross-check: run only for large grouped diff reviews with >=2 groups.
+	// Medium grouped specs also set useGroupedSpecs=true but cross-check
+	// config/model resolution only supports sizes.large.
 	var ccResult *summarizer.CrossCheckResult
-	if useGroupedSpecs && opts.CrossCheckEnabled && ctx.Err() == nil {
+	if useGroupedSpecs && sizeStr == "large" && opts.CrossCheckEnabled && ctx.Err() == nil {
 		// Lazy resolve: top-level cross_check.model parsing and per-agent
-		// modelconfig.Resolve happen here, NOT at startup. Round-14 F#1
-		// guarantees this gate is reached only when sizeStr=="large" (since
-		// useGroupedSpecs=true is exclusive to DiffSizeLarge in
-		// resolveAutoPhase), so the size layer cascade lines up with
+		// modelconfig.Resolve happen here, NOT at startup. The sizeStr=="large"
+		// guard ensures the size layer cascade lines up with
 		// canResolveCrossCheckModelForAgent's sizes["large"] view.
 		ccAgentNames, ccModels, ccErr := resolveCrossCheckAgents(opts, sizeStr)
 		if ccErr != nil {
@@ -1028,10 +1017,44 @@ func resolveAutoPhase(
 			UseGrouped:   true,
 		}, nil
 	default: // medium
-		// Medium: arch (1) + diff (mediumDiffReviewers). Never calls buildAgents.
+		if diff == "" {
+			return autoPhaseResult{
+				PhaseStr:        "medium",
+				MediumDiffCount: mediumDiffReviewers,
+			}, nil
+		}
+		fileCount := len(git.ParseDiffSections(diff))
+		effectiveGroups := mediumDiffReviewers
+		if effectiveGroups > fileCount {
+			effectiveGroups = fileCount
+		}
+		if effectiveGroups < 2 {
+			return autoPhaseResult{
+				PhaseStr:        "medium",
+				MediumDiffCount: mediumDiffReviewers,
+				FallbackReason: fmt.Sprintf(
+					"only %d non-empty diff group(s) possible (file_count=%d, medium_diff_reviewers=%d)",
+					effectiveGroups, fileCount, mediumDiffReviewers),
+			}, nil
+		}
+		archAgent, diffAgents, agentsErr := buildAgents()
+		if agentsErr != nil {
+			return autoPhaseResult{}, agentsErr
+		}
+		medSpecs, medErr := buildMediumDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, mediumDiffReviewers)
+		if medErr != nil {
+			return autoPhaseResult{}, medErr
+		}
+		if medSpecs == nil {
+			return autoPhaseResult{
+				PhaseStr:        "medium",
+				MediumDiffCount: mediumDiffReviewers,
+				FallbackReason:  "diff split not viable after grouping",
+			}, nil
+		}
 		return autoPhaseResult{
-			PhaseStr:        "medium",
-			MediumDiffCount: mediumDiffReviewers,
+			GroupedSpecs: medSpecs,
+			UseGrouped:   true,
 		}, nil
 	}
 }
@@ -1227,6 +1250,67 @@ func buildGroupedDiffSpecs(
 			// Empty group diff after splitting precomputed diff is unexpected.
 			// Skip (budget adjusts accordingly).
 			continue
+		}
+		var targetFiles []string
+		for _, s := range group.Sections {
+			targetFiles = append(targetFiles, s.FilePath)
+		}
+		reviewerID := len(specs) + 1
+		diffReviewerIdx++
+		diffAgent := agent.AgentForReviewer(diffAgents, diffReviewerIdx)
+		specs = append(specs, runner.ReviewerSpec{
+			ReviewerID:      reviewerID,
+			Agent:           diffAgent,
+			Phase:           "diff",
+			GroupKey:        group.Key,
+			Guidance:        guidance,
+			Diff:            groupDiff,
+			DiffPrecomputed: true,
+			TargetFiles:     targetFiles,
+		})
+	}
+
+	return specs, nil
+}
+
+func buildMediumDiffSpecs(
+	fullDiff, guidance string,
+	diffPrecomputed bool,
+	archAgent agent.Agent,
+	diffAgents []agent.Agent,
+	mediumDiffReviewers int,
+) ([]runner.ReviewerSpec, error) {
+	if mediumDiffReviewers < 2 {
+		return nil, nil
+	}
+	sections := git.ParseDiffSections(fullDiff)
+	if len(sections) < 2 {
+		return nil, nil
+	}
+
+	maxFilesPerGroup := (len(sections) + mediumDiffReviewers - 1) / mediumDiffReviewers
+	groups := git.GroupDiffSections(sections, maxFilesPerGroup, 0, mediumDiffReviewers)
+	if len(groups) < 2 {
+		return nil, nil
+	}
+
+	specs := make([]runner.ReviewerSpec, 0, 1+len(groups))
+
+	specs = append(specs, runner.ReviewerSpec{
+		ReviewerID:      1,
+		Agent:           archAgent,
+		Phase:           "arch",
+		GroupKey:        "arch",
+		Guidance:        guidance,
+		Diff:            fullDiff,
+		DiffPrecomputed: diffPrecomputed,
+	})
+
+	diffReviewerIdx := 0
+	for _, group := range groups {
+		groupDiff := git.JoinDiffSections(group.Sections)
+		if groupDiff == "" {
+			return nil, fmt.Errorf("medium diff split: group %q produced empty diff from %d section(s)", group.Key, len(group.Sections))
 		}
 		var targetFiles []string
 		for _, s := range group.Sections {

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1586,3 +1586,274 @@ func TestCollectAllCLINames_CrossCheckCommaSeparated(t *testing.T) {
 		t.Error("comma-separated value should be parsed, not passed as-is")
 	}
 }
+
+// --- buildMediumDiffSpecs tests ---
+
+func TestBuildMediumDiffSpecs_BasicSplit(t *testing.T) {
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	archAg := agent.NewCodexAgent("")
+	diffAgs := []agent.Agent{agent.NewCodexAgent("")}
+
+	specs, err := buildMediumDiffSpecs(fullDiff, "test guidance", true, archAg, diffAgs, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if specs == nil {
+		t.Fatalf("expected non-nil specs")
+	}
+	if len(specs) != 3 {
+		t.Fatalf("expected 3 specs (1 arch + 2 diff), got %d", len(specs))
+	}
+
+	if specs[0].Phase != "arch" {
+		t.Errorf("specs[0].Phase = %q, want %q", specs[0].Phase, "arch")
+	}
+	if specs[0].Diff != fullDiff {
+		t.Errorf("specs[0].Diff should equal fullDiff")
+	}
+	if specs[0].DiffPrecomputed != true {
+		t.Errorf("specs[0].DiffPrecomputed = %v, want true", specs[0].DiffPrecomputed)
+	}
+	if specs[0].GroupKey != "arch" {
+		t.Errorf("specs[0].GroupKey = %q, want %q", specs[0].GroupKey, "arch")
+	}
+	if specs[0].Guidance != "test guidance" {
+		t.Errorf("specs[0].Guidance = %q, want %q", specs[0].Guidance, "test guidance")
+	}
+
+	if specs[1].Phase != "diff" {
+		t.Errorf("specs[1].Phase = %q, want %q", specs[1].Phase, "diff")
+	}
+	if specs[2].Phase != "diff" {
+		t.Errorf("specs[2].Phase = %q, want %q", specs[2].Phase, "diff")
+	}
+	if specs[1].Diff == specs[2].Diff {
+		t.Errorf("specs[1].Diff should differ from specs[2].Diff")
+	}
+
+	pathSet1 := make(map[string]bool)
+	for _, s := range git.ParseDiffSections(specs[1].Diff) {
+		pathSet1[s.FilePath] = true
+	}
+	pathSet2 := make(map[string]bool)
+	for _, s := range git.ParseDiffSections(specs[2].Diff) {
+		pathSet2[s.FilePath] = true
+	}
+	allPaths := make(map[string]bool)
+	for _, s := range sections {
+		allPaths[s.FilePath] = true
+	}
+	for p := range pathSet1 {
+		if pathSet2[p] {
+			t.Errorf("file %q appears in both diff specs (should be disjoint)", p)
+		}
+	}
+	union := make(map[string]bool)
+	for p := range pathSet1 {
+		union[p] = true
+	}
+	for p := range pathSet2 {
+		union[p] = true
+	}
+	for p := range allPaths {
+		if !union[p] {
+			t.Errorf("file %q missing from diff specs union", p)
+		}
+	}
+}
+
+func TestBuildMediumDiffSpecs_SingleFile_Fallback(t *testing.T) {
+	sections := makeSectionsForReview(1, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	archAg := agent.NewCodexAgent("")
+	diffAgs := []agent.Agent{agent.NewCodexAgent("")}
+
+	specs, err := buildMediumDiffSpecs(fullDiff, "", false, archAg, diffAgs, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if specs != nil {
+		t.Errorf("expected nil for single file, got %d specs", len(specs))
+	}
+}
+
+func TestBuildMediumDiffSpecs_OneDiffReviewer_Fallback(t *testing.T) {
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	archAg := agent.NewCodexAgent("")
+	diffAgs := []agent.Agent{agent.NewCodexAgent("")}
+
+	specs, err := buildMediumDiffSpecs(fullDiff, "", false, archAg, diffAgs, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if specs != nil {
+		t.Errorf("expected nil for 1 diff reviewer, got %d specs", len(specs))
+	}
+}
+
+func TestBuildMediumDiffSpecs_TargetFiles(t *testing.T) {
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	archAg := agent.NewCodexAgent("")
+	diffAgs := []agent.Agent{agent.NewCodexAgent("")}
+
+	specs, err := buildMediumDiffSpecs(fullDiff, "", true, archAg, diffAgs, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if specs == nil {
+		t.Fatalf("expected non-nil specs")
+	}
+	if len(specs) < 3 {
+		t.Fatalf("expected at least 3 specs, got %d", len(specs))
+	}
+
+	for i := 1; i < len(specs); i++ {
+		if len(specs[i].TargetFiles) == 0 {
+			t.Errorf("specs[%d].TargetFiles is empty", i)
+			continue
+		}
+		parsed := git.ParseDiffSections(specs[i].Diff)
+		var parsedPaths []string
+		for _, s := range parsed {
+			parsedPaths = append(parsedPaths, s.FilePath)
+		}
+		if len(parsedPaths) != len(specs[i].TargetFiles) {
+			t.Errorf("specs[%d]: parsed paths len=%d, TargetFiles len=%d", i, len(parsedPaths), len(specs[i].TargetFiles))
+			continue
+		}
+		for j, p := range parsedPaths {
+			if p != specs[i].TargetFiles[j] {
+				t.Errorf("specs[%d]: parsed path[%d]=%q, TargetFiles[%d]=%q", i, j, p, j, specs[i].TargetFiles[j])
+			}
+		}
+	}
+}
+
+func TestBuildMediumDiffSpecs_AgentPerRole(t *testing.T) {
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	archAg := agent.NewClaudeAgent("")
+	diffAgs := []agent.Agent{agent.NewCodexAgent(""), agent.NewGeminiAgent("")}
+
+	specs, err := buildMediumDiffSpecs(fullDiff, "", true, archAg, diffAgs, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if specs == nil {
+		t.Fatalf("expected non-nil specs")
+	}
+	if len(specs) != 3 {
+		t.Fatalf("expected 3 specs, got %d", len(specs))
+	}
+
+	if specs[0].Agent.Name() != "claude" {
+		t.Errorf("arch agent: got %q, want %q", specs[0].Agent.Name(), "claude")
+	}
+	if specs[1].Agent.Name() != "codex" {
+		t.Errorf("diff[0] agent: got %q, want %q", specs[1].Agent.Name(), "codex")
+	}
+	if specs[2].Agent.Name() != "gemini" {
+		t.Errorf("diff[1] agent: got %q, want %q", specs[2].Agent.Name(), "gemini")
+	}
+}
+
+func TestBuildMediumDiffSpecs_FewFiles_Split(t *testing.T) {
+	tests := []struct {
+		name      string
+		fileCount int
+		reviewers int
+	}{
+		{"2 files 2 reviewers", 2, 2},
+		{"3 files 2 reviewers", 3, 2},
+		{"4 files 2 reviewers", 4, 2},
+		{"4 files 3 reviewers", 4, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sections := makeSectionsForReview(tc.fileCount, 10)
+			fullDiff := git.JoinDiffSections(sections)
+			archAg := agent.NewCodexAgent("")
+			diffAgs := []agent.Agent{agent.NewCodexAgent("")}
+
+			specs, err := buildMediumDiffSpecs(fullDiff, "", true, archAg, diffAgs, tc.reviewers)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if specs == nil {
+				t.Fatalf("expected non-nil specs for %d files / %d reviewers", tc.fileCount, tc.reviewers)
+			}
+			diffSpecs := specs[1:]
+			if len(diffSpecs) < 2 {
+				t.Fatalf("expected >=2 diff specs, got %d", len(diffSpecs))
+			}
+
+			seen := make(map[string]bool)
+			for i, s := range diffSpecs {
+				if len(s.TargetFiles) == 0 {
+					t.Errorf("diffSpecs[%d].TargetFiles is empty", i)
+				}
+				for _, f := range s.TargetFiles {
+					if seen[f] {
+						t.Errorf("file %q appears in multiple diff specs (should be disjoint)", f)
+					}
+					seen[f] = true
+				}
+			}
+			for _, s := range sections {
+				if !seen[s.FilePath] {
+					t.Errorf("file %q missing from diff specs union", s.FilePath)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildMediumDiffSpecs_DiffPrecomputed(t *testing.T) {
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	archAg := agent.NewCodexAgent("")
+	diffAgs := []agent.Agent{agent.NewCodexAgent("")}
+
+	specs, err := buildMediumDiffSpecs(fullDiff, "", true, archAg, diffAgs, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if specs == nil {
+		t.Fatalf("expected non-nil specs (diffPrecomputed=true)")
+	}
+	if len(specs) < 3 {
+		t.Fatalf("expected at least 3 specs, got %d", len(specs))
+	}
+	if specs[0].DiffPrecomputed != true {
+		t.Errorf("diffPrecomputed=true: specs[0].DiffPrecomputed = %v, want true", specs[0].DiffPrecomputed)
+	}
+	if specs[1].DiffPrecomputed != true {
+		t.Errorf("diffPrecomputed=true: specs[1].DiffPrecomputed = %v, want true", specs[1].DiffPrecomputed)
+	}
+	if specs[2].DiffPrecomputed != true {
+		t.Errorf("diffPrecomputed=true: specs[2].DiffPrecomputed = %v, want true", specs[2].DiffPrecomputed)
+	}
+
+	specsF, errF := buildMediumDiffSpecs(fullDiff, "", false, archAg, diffAgs, 2)
+	if errF != nil {
+		t.Fatalf("unexpected error: %v", errF)
+	}
+	if specsF == nil {
+		t.Fatalf("expected non-nil specs (diffPrecomputed=false)")
+	}
+	if len(specsF) < 3 {
+		t.Fatalf("expected at least 3 specs, got %d", len(specsF))
+	}
+	if specsF[0].DiffPrecomputed != false {
+		t.Errorf("diffPrecomputed=false: specs[0].DiffPrecomputed = %v, want false", specsF[0].DiffPrecomputed)
+	}
+	if specsF[1].DiffPrecomputed != true {
+		t.Errorf("diffPrecomputed=false: specs[1].DiffPrecomputed = %v, want true", specsF[1].DiffPrecomputed)
+	}
+	if specsF[2].DiffPrecomputed != true {
+		t.Errorf("diffPrecomputed=false: specs[2].DiffPrecomputed = %v, want true", specsF[2].DiffPrecomputed)
+	}
+}


### PR DESCRIPTION
## Summary

- medium auto-phase パスで diff reviewer が全員同一の full diff を受け取っていた問題を修正
- `ParseDiffSections` + `GroupDiffSections` で diff をファイル単位に分割し、各 diff reviewer に重複なく割り当て
- arch reviewer には引き続き full diff を渡す
- `resolveAutoPhase` の medium ケースで `buildAgents()` を呼び、large パスと同一の per-role agent 固定方式を採用
- 分割不可時 (1ファイル等) は従来の共有 diff パスにフォールバック
- cross-check ガードに `sizeStr=="large"` 条件を追加し、medium grouped path での誤発火を防止
- verbose ログを large/medium で分岐 (medium では cross-check model matrix を出力しない)

Closes #13

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `cmd/acr/review.go` | `buildMediumDiffSpecs` 関数追加、`resolveAutoPhase` medium ケース修正、cross-check ガード修正、verbose ログ分岐 |
| `cmd/acr/review_test.go` | 6 テストケース追加 (BasicSplit, SingleFile_Fallback, OneDiffReviewer_Fallback, TargetFiles, AgentPerRole, DiffPrecomputed) |

## Test plan

- [x] `go test ./cmd/acr/` — 新規 6 テスト + 既存テスト全通過
- [x] `go test ./...` — 全 14 パッケージ通過
- [x] `go build ./cmd/acr` — ビルド成功
- [x] ACR セルフレビューによる指摘対応完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)