### PR TITLE
feat: --phase large で grouped review を明示的に強制可能に (#11)

### DIFF
--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -185,7 +185,7 @@ Exit codes:
 	rootCmd.Flags().DurationVar(&crossCheckTimeout, "cross-check-timeout", 0,
 		"Timeout for cross-check phase (default: 5m, env: ACR_CROSS_CHECK_TIMEOUT)")
 	rootCmd.Flags().StringVar(&phase, "phase", "",
-		"Override auto-phase: small, medium")
+		"Override auto-phase: small, medium, large (large falls back to medium if <2 splittable groups)")
 	rootCmd.Flags().StringVar(&formatOutput, "format", "text",
 		"Output format: text or json")
 	rootCmd.Flags().BoolVar(&autoPhase, "auto-phase", true,

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -93,6 +93,11 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		logger.Logf(terminal.StyleWarning, "Diff size classification failed: %v (model resolver will skip size layer)", classifyErr)
 	}
 
+	// --phase large: override sizeStr so model resolution uses sizes.large.
+	if opts.Phase == "large" && sizeStr != "large" {
+		sizeStr = "large"
+	}
+
 	// Resolve generic (phase="") reviewer specs with per-agent-name effort/model
 	// via the size-aware phase-aware model config resolver. This covers the flat
 	// review path (auto-phase OFF / size=small / explicit `--phase diff`); the
@@ -260,7 +265,8 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				func() (agent.Agent, []agent.Agent, error) {
 					return buildPhaseAgents(opts, sizeStr)
 				},
-				opts.LargeDiffReviewers, opts.MediumDiffReviewers)
+				opts.LargeDiffReviewers, opts.MediumDiffReviewers,
+				opts.MinLargeDiffReviewers, opts.MinMediumDiffReviewers)
 			if agentsErr != nil {
 				logger.Logf(terminal.StyleError, "Failed to build per-phase reviewer agents: %v", agentsErr)
 				return domain.ExitError
@@ -275,15 +281,15 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			if opts.Verbose {
 				switch {
 				case apr.UseGrouped && sizeStr == "large":
-					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (large_diff_reviewers=%d, arch+%d diff groups)",
-						opts.LargeDiffReviewers, len(groupedSpecs)-1)
+					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (arch+%d diff groups)",
+						len(groupedSpecs)-1)
 					logPerPhaseModelMatrix(logger, opts, sizeStr)
 					if opts.CrossCheckEnabled {
 						logCrossCheckModelMatrix(logger, opts, sizeStr)
 					}
 				case apr.UseGrouped:
-					logger.Logf(terminal.StyleInfo, "Auto-phase: medium split (medium_diff_reviewers=%d, arch+%d diff groups)",
-						opts.MediumDiffReviewers, len(groupedSpecs)-1)
+					logger.Logf(terminal.StyleInfo, "Auto-phase: medium split (arch+%d diff groups)",
+						len(groupedSpecs)-1)
 					logPerPhaseModelMatrix(logger, opts, sizeStr)
 				case apr.MediumDiffCount > 0 && apr.FallbackReason != "":
 					logger.Logf(terminal.StyleWarning,
@@ -295,6 +301,47 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				case apr.FallbackReason != "":
 					logger.Logf(terminal.StyleWarning, "Auto-phase: falling back to medium (%s)", apr.FallbackReason)
 				}
+			}
+		}
+	}
+
+	// --phase large: build grouped specs before dispatch (defensive fallback to medium)
+	if phaseStr == "large" && !useGroupedSpecs {
+		plr, agentsErr := resolvePhaseLarge(diff, opts.Guidance, diffPrecomputed,
+			func() (agent.Agent, []agent.Agent, error) {
+				return buildPhaseAgents(opts, sizeStr)
+			},
+			opts.LargeDiffReviewers, opts.MinLargeDiffReviewers, opts.MediumDiffReviewers)
+		if agentsErr != nil {
+			logger.Logf(terminal.StyleError, "Failed to build per-phase agents for --phase large: %v", agentsErr)
+			return domain.ExitError
+		}
+		if plr.UseGrouped {
+			groupedSpecs = plr.GroupedSpecs
+			useGroupedSpecs = true
+			if opts.Verbose {
+				effectiveReviewers := opts.LargeDiffReviewers
+				if effectiveReviewers < opts.MinLargeDiffReviewers {
+					effectiveReviewers = opts.MinLargeDiffReviewers
+					logger.Logf(terminal.StyleDim,
+						"--phase large: large_diff_reviewers=%d clamped to min_large_diff_reviewers=%d",
+						opts.LargeDiffReviewers, effectiveReviewers)
+				}
+				logger.Logf(terminal.StyleInfo,
+					"--phase large: grouped (effective_reviewers=%d, arch+%d diff groups)",
+					effectiveReviewers, len(groupedSpecs)-1)
+				logPerPhaseModelMatrix(logger, opts, sizeStr)
+				if opts.CrossCheckEnabled {
+					logCrossCheckModelMatrix(logger, opts, sizeStr)
+				}
+			}
+		} else {
+			phaseStr = plr.PhaseStr
+			logger.Logf(terminal.StyleWarning,
+				"--phase large: falling back to %s (%s)", plr.PhaseStr, plr.FallbackReason)
+			if opts.CrossCheckEnabled {
+				logger.Logf(terminal.StyleWarning,
+					"--phase large: cross-check requires grouped review; skipped after fallback to %s", plr.PhaseStr)
 			}
 		}
 	}
@@ -961,6 +1008,8 @@ func resolveAutoPhase(
 	buildAgents func() (agent.Agent, []agent.Agent, error),
 	largeDiffReviewers int,
 	mediumDiffReviewers int,
+	minLargeDiffReviewers int,
+	minMediumDiffReviewers int,
 ) (autoPhaseResult, error) {
 	switch size {
 	case git.DiffSizeSmall:
@@ -968,8 +1017,10 @@ func resolveAutoPhase(
 		return autoPhaseResult{PhaseStr: "small"}, nil
 	case git.DiffSizeLarge:
 		fileCount := len(git.ParseDiffSections(diff))
-		// Sanity cap: 1 group must contain at least 1 file.
 		effectiveGroups := largeDiffReviewers
+		if effectiveGroups < minLargeDiffReviewers {
+			effectiveGroups = minLargeDiffReviewers
+		}
 		if effectiveGroups > fileCount {
 			effectiveGroups = fileCount
 		}
@@ -1025,6 +1076,9 @@ func resolveAutoPhase(
 		}
 		fileCount := len(git.ParseDiffSections(diff))
 		effectiveGroups := mediumDiffReviewers
+		if effectiveGroups < minMediumDiffReviewers {
+			effectiveGroups = minMediumDiffReviewers
+		}
 		if effectiveGroups > fileCount {
 			effectiveGroups = fileCount
 		}
@@ -1041,7 +1095,7 @@ func resolveAutoPhase(
 		if agentsErr != nil {
 			return autoPhaseResult{}, agentsErr
 		}
-		medSpecs, medErr := buildMediumDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, mediumDiffReviewers)
+		medSpecs, medErr := buildMediumDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, effectiveGroups)
 		if medErr != nil {
 			return autoPhaseResult{}, medErr
 		}
@@ -1057,6 +1111,59 @@ func resolveAutoPhase(
 			UseGrouped:   true,
 		}, nil
 	}
+}
+
+// resolvePhaseLarge handles the --phase large explicit override path.
+// It builds grouped specs (arch + N diff groups) or falls back to medium.
+func resolvePhaseLarge(
+	diff, guidance string,
+	diffPrecomputed bool,
+	buildAgents func() (agent.Agent, []agent.Agent, error),
+	largeDiffReviewers int,
+	minLargeDiffReviewers int,
+	mediumDiffReviewers int,
+) (autoPhaseResult, error) {
+	sections := git.ParseDiffSections(diff)
+	fileCount := len(sections)
+	effectiveReviewers := largeDiffReviewers
+	if effectiveReviewers < minLargeDiffReviewers {
+		effectiveReviewers = minLargeDiffReviewers
+	}
+	effectiveGroups := effectiveReviewers
+	if effectiveGroups > fileCount {
+		effectiveGroups = fileCount
+	}
+	if effectiveGroups < 2 {
+		return autoPhaseResult{
+			PhaseStr:        "medium",
+			MediumDiffCount: mediumDiffReviewers,
+			FallbackReason:  fmt.Sprintf("only %d file(s), need >=2 for grouped review", fileCount),
+		}, nil
+	}
+	archAgent, diffAgents, agentsErr := buildAgents()
+	if agentsErr != nil {
+		return autoPhaseResult{}, agentsErr
+	}
+	specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, effectiveGroups)
+	if err != nil {
+		return autoPhaseResult{
+			PhaseStr:        "medium",
+			MediumDiffCount: mediumDiffReviewers,
+			FallbackReason:  fmt.Sprintf("buildGroupedDiffSpecs failed: %v", err),
+		}, nil
+	}
+	diffGroupCount := len(specs) - 1
+	if diffGroupCount < 2 {
+		return autoPhaseResult{
+			PhaseStr:        "medium",
+			MediumDiffCount: mediumDiffReviewers,
+			FallbackReason:  fmt.Sprintf("only %d non-empty diff group(s) after building", diffGroupCount),
+		}, nil
+	}
+	return autoPhaseResult{
+		GroupedSpecs: specs,
+		UseGrouped:   true,
+	}, nil
 }
 
 // buildPhaseAgents constructs the arch-phase agent and diff-phase agent slice

--- a/cmd/acr/review_opts.go
+++ b/cmd/acr/review_opts.go
@@ -21,7 +21,7 @@ type ReviewOpts struct {
 	UseRefFile      bool
 	ExcludePatterns []string
 	WorkDir         string // Worktree path (empty = current directory)
-	Phase           string // Review phase: "small", "medium" (empty = auto-phase / flat)
+	Phase           string // Review phase: "small", "medium", "large" (empty = auto-phase / flat)
 	Format          string // Output format: "text" (default) or "json"
 	// AutoPhase is inherited from the embedded ResolvedConfig field.
 }

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -259,7 +259,8 @@ func TestBuildGroupedDiffSpecs_FallbackOnError(t *testing.T) {
 //
 // Signature: resolveAutoPhase(size, diff, guidance, diffPrecomputed,
 //   buildAgents func() (agent.Agent, []agent.Agent, error),
-//   largeDiffReviewers, mediumDiffReviewers) (autoPhaseResult, error)
+//   largeDiffReviewers, mediumDiffReviewers,
+//   minLargeDiffReviewers, minMediumDiffReviewers) (autoPhaseResult, error)
 //
 // Tests use testBuildAgents to return pre-constructed agents synchronously.
 // The closure is only invoked when the large grouped path decides to proceed,
@@ -277,7 +278,7 @@ func TestAutoPhase_Large_GroupedSpecs(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2, 2, 2)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for large diff with large_diff_reviewers=3")
@@ -294,7 +295,7 @@ func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 	// Large diff but empty diff content → buildGroupedDiffSpecs fails → fallback
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, "", "", true, testBuildAgents(agents[0], agents), 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, "", "", true, testBuildAgents(agents[0], agents), 3, 2, 2, 2)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when buildGroupedDiffSpecs fails")
@@ -619,7 +620,7 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 1, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 1, 2, 1, 1)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false for large_diff_reviewers=1")
@@ -643,7 +644,7 @@ func TestResolveAutoPhase_TwoLargeDiffReviewers_KeepsGrouped(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 2, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 2, 2, 2, 2)
 
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for 2+ diff groups")
@@ -663,7 +664,7 @@ func TestLargeReview_GroupedSpecsProduceCrossCheckableTopology(t *testing.T) {
 	sections := makeSectionsForReview(8, 5)
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2, 2, 2)
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for large diff with large_diff_reviewers=3")
 	}
@@ -993,7 +994,7 @@ func TestResolveAutoPhase_LargeUsesLargeDiffReviewersKnob(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2, 2, 2)
 
 	if !apr.UseGrouped {
 		t.Fatalf("expected UseGrouped=true; FallbackReason=%q", apr.FallbackReason)
@@ -1016,7 +1017,7 @@ func TestResolveAutoPhase_LargeFallbackToMedium_WhenFileCountTooSmall(t *testing
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 4, 3)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 4, 3, 2, 2)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when fileCount<2")
@@ -1035,7 +1036,7 @@ func TestResolveAutoPhase_LargeFallbackToMedium_WhenFileCountTooSmall(t *testing
 // TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob verifies that medium
 // path returns medium with MediumDiffCount=mediumDiffReviewers.
 func TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob(t *testing.T) {
-	apr, _ := resolveAutoPhase(git.DiffSizeMedium, "", "", true, testBuildAgents(nil, nil), 4, 4)
+	apr, _ := resolveAutoPhase(git.DiffSizeMedium, "", "", true, testBuildAgents(nil, nil), 4, 4, 2, 2)
 
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false on medium")
@@ -1060,7 +1061,7 @@ func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 	fullDiff := git.JoinDiffSections(sections)
 	agents := []agent.Agent{agent.NewCodexAgent("")}
 
-	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 10, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 10, 2, 2, 2)
 
 	if !apr.UseGrouped {
 		t.Fatalf("expected UseGrouped=true with 12 files / large_diff_reviewers=10; FallbackReason=%q", apr.FallbackReason)
@@ -1079,7 +1080,7 @@ func TestResolveAutoPhase_LargeRespectsFileCountUpperBound(t *testing.T) {
 
 // TestResolveAutoPhase_Small returns flat diff regardless of knobs.
 func TestResolveAutoPhase_Small(t *testing.T) {
-	apr, _ := resolveAutoPhase(git.DiffSizeSmall, "irrelevant", "", true, testBuildAgents(nil, nil), 4, 2)
+	apr, _ := resolveAutoPhase(git.DiffSizeSmall, "irrelevant", "", true, testBuildAgents(nil, nil), 4, 2, 2, 2)
 	if apr.UseGrouped {
 		t.Errorf("expected UseGrouped=false for small")
 	}
@@ -1088,6 +1089,131 @@ func TestResolveAutoPhase_Small(t *testing.T) {
 	}
 	if apr.MediumDiffCount != 0 {
 		t.Errorf("expected MediumDiffCount=0 on small, got %d", apr.MediumDiffCount)
+	}
+}
+
+// TestResolveAutoPhase_LargeFloorClampsReviewers verifies that
+// minLargeDiffReviewers floors effectiveGroups when largeDiffReviewers < min.
+func TestResolveAutoPhase_LargeFloorClampsReviewers(t *testing.T) {
+	// 6 files, largeDiffReviewers=1, minLargeDiffReviewers=2 → floor to 2 → grouped succeeds.
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 1, 2, 2, 2)
+
+	if !apr.UseGrouped {
+		t.Fatalf("expected UseGrouped=true when floor clamps largeDiffReviewers=1 to min=2; FallbackReason=%q", apr.FallbackReason)
+	}
+	diffGroupCount := len(apr.GroupedSpecs) - 1
+	if diffGroupCount < 2 {
+		t.Errorf("expected >=2 diff groups after floor, got %d", diffGroupCount)
+	}
+}
+
+// TestResolveAutoPhase_MediumFloorClampsReviewers verifies that
+// minMediumDiffReviewers floors effectiveGroups on the medium path.
+func TestResolveAutoPhase_MediumFloorClampsReviewers(t *testing.T) {
+	// 6 files, mediumDiffReviewers=1, minMediumDiffReviewers=2 → floor to 2 → grouped succeeds.
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	apr, _ := resolveAutoPhase(git.DiffSizeMedium, fullDiff, "", true, testBuildAgents(agents[0], agents), 4, 1, 2, 2)
+
+	if !apr.UseGrouped {
+		t.Fatalf("expected UseGrouped=true when floor clamps mediumDiffReviewers=1 to min=2; FallbackReason=%q", apr.FallbackReason)
+	}
+	diffGroupCount := len(apr.GroupedSpecs) - 1
+	if diffGroupCount < 2 {
+		t.Errorf("expected >=2 diff groups after floor, got %d", diffGroupCount)
+	}
+}
+
+// TestResolveAutoPhase_FloorNotApplied_WhenAboveMin verifies that when
+// largeDiffReviewers >= minLargeDiffReviewers the floor does not activate.
+func TestResolveAutoPhase_FloorNotApplied_WhenAboveMin(t *testing.T) {
+	// 25 files, largeDiffReviewers=4, minLargeDiffReviewers=2 → no floor, same as before.
+	sections := makeSectionsForReview(25, 50)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	apr, _ := resolveAutoPhase(git.DiffSizeLarge, fullDiff, "", true, testBuildAgents(agents[0], agents), 4, 2, 2, 2)
+
+	if !apr.UseGrouped {
+		t.Fatalf("expected UseGrouped=true; FallbackReason=%q", apr.FallbackReason)
+	}
+	diffGroupCount := len(apr.GroupedSpecs) - 1
+	if diffGroupCount > 4 {
+		t.Errorf("expected at most 4 diff groups (largeDiffReviewers=4 cap), got %d", diffGroupCount)
+	}
+	if diffGroupCount < 2 {
+		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
+	}
+}
+
+// --- resolvePhaseLarge tests ---
+
+// TestResolvePhaseLarge_SufficientFiles_GroupedSpecs verifies that --phase large
+// with enough files builds grouped specs successfully.
+func TestResolvePhaseLarge_SufficientFiles_GroupedSpecs(t *testing.T) {
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	result, err := resolvePhaseLarge(fullDiff, "", true, testBuildAgents(agents[0], agents), 3, 2, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.UseGrouped {
+		t.Fatalf("expected UseGrouped=true for 6 files; FallbackReason=%q", result.FallbackReason)
+	}
+	diffGroupCount := len(result.GroupedSpecs) - 1
+	if diffGroupCount < 2 {
+		t.Errorf("expected >=2 diff groups, got %d", diffGroupCount)
+	}
+}
+
+// TestResolvePhaseLarge_InsufficientFiles_FallbackToMedium verifies that
+// --phase large with 1 file falls back to medium.
+func TestResolvePhaseLarge_InsufficientFiles_FallbackToMedium(t *testing.T) {
+	sections := makeSectionsForReview(1, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	result, err := resolvePhaseLarge(fullDiff, "", true, testBuildAgents(agents[0], agents), 4, 2, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.UseGrouped {
+		t.Fatal("expected UseGrouped=false for 1 file")
+	}
+	if result.PhaseStr != "medium" {
+		t.Errorf("expected PhaseStr 'medium', got %q", result.PhaseStr)
+	}
+	if result.FallbackReason == "" {
+		t.Error("expected non-empty FallbackReason")
+	}
+}
+
+// TestResolvePhaseLarge_FloorApplied verifies that minLargeDiffReviewers
+// floors the reviewer count in the --phase large path.
+func TestResolvePhaseLarge_FloorApplied(t *testing.T) {
+	// 6 files, largeDiffReviewers=1, minLargeDiffReviewers=2 → effective=2 → grouped.
+	sections := makeSectionsForReview(6, 10)
+	fullDiff := git.JoinDiffSections(sections)
+	agents := []agent.Agent{agent.NewCodexAgent("")}
+
+	result, err := resolvePhaseLarge(fullDiff, "", true, testBuildAgents(agents[0], agents), 1, 2, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.UseGrouped {
+		t.Fatalf("expected UseGrouped=true with floor; FallbackReason=%q", result.FallbackReason)
+	}
+	diffGroupCount := len(result.GroupedSpecs) - 1
+	if diffGroupCount < 2 {
+		t.Errorf("expected >=2 diff groups after floor, got %d", diffGroupCount)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,20 +103,22 @@ type Config struct {
 	// DiffReviewerAgents is the optional per-phase override for the diff phase
 	// in auto-phase grouped diff (round-robin). When empty, it falls back to
 	// ReviewerAgents.
-	DiffReviewerAgents []string         `yaml:"diff_reviewer_agents"`
-	SummarizerAgent    *string          `yaml:"summarizer_agent"`
-	ReviewerModel      *string          `yaml:"reviewer_model"`
-	SummarizerModel    *string          `yaml:"summarizer_model"`
-	SummarizerTimeout  *Duration        `yaml:"summarizer_timeout"`
-	FPFilterTimeout    *Duration        `yaml:"fp_filter_timeout"`
-	CrossCheckTimeout  *Duration        `yaml:"cross_check_timeout"`
-	GuidanceFile       *string          `yaml:"guidance_file"`
-	AutoPhase          *bool            `yaml:"auto_phase"`
-	Filters            FilterConfig     `yaml:"filters"`
-	FPFilter           FPFilterConfig   `yaml:"fp_filter"`
-	PRFeedback         PRFeedbackConfig `yaml:"pr_feedback"`
-	CrossCheck         CrossCheckConfig `yaml:"cross_check"`
-	Models             ModelsConfig     `yaml:"models"`
+	DiffReviewerAgents     []string         `yaml:"diff_reviewer_agents"`
+	SummarizerAgent        *string          `yaml:"summarizer_agent"`
+	ReviewerModel          *string          `yaml:"reviewer_model"`
+	SummarizerModel        *string          `yaml:"summarizer_model"`
+	SummarizerTimeout      *Duration        `yaml:"summarizer_timeout"`
+	FPFilterTimeout        *Duration        `yaml:"fp_filter_timeout"`
+	CrossCheckTimeout      *Duration        `yaml:"cross_check_timeout"`
+	GuidanceFile           *string          `yaml:"guidance_file"`
+	AutoPhase              *bool            `yaml:"auto_phase"`
+	Filters                FilterConfig     `yaml:"filters"`
+	FPFilter               FPFilterConfig   `yaml:"fp_filter"`
+	PRFeedback             PRFeedbackConfig `yaml:"pr_feedback"`
+	CrossCheck             CrossCheckConfig `yaml:"cross_check"`
+	Models                 ModelsConfig     `yaml:"models"`
+	MinLargeDiffReviewers  *int             `yaml:"min_large_diff_reviewers"`
+	MinMediumDiffReviewers *int             `yaml:"min_medium_diff_reviewers"`
 }
 
 // CrossCheckConfig holds cross-check verification settings.
@@ -224,7 +226,7 @@ func (c *Config) validatePatterns() error {
 	return nil
 }
 
-var knownTopLevelKeys = []string{"reviewers", "large_diff_reviewers", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models"}
+var knownTopLevelKeys = []string{"reviewers", "large_diff_reviewers", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models", "min_large_diff_reviewers", "min_medium_diff_reviewers"}
 
 var knownFPFilterKeys = []string{"enabled", "threshold"}
 
@@ -510,6 +512,12 @@ func (r *ResolvedConfig) ValidateAll() []string {
 	if r.FPFilterTimeout <= 0 {
 		errs = append(errs, fmt.Sprintf("fp_filter_timeout must be > 0, got %s", r.FPFilterTimeout))
 	}
+	if r.MinLargeDiffReviewers < 2 {
+		errs = append(errs, fmt.Sprintf("min_large_diff_reviewers must be >= 2, got %d", r.MinLargeDiffReviewers))
+	}
+	if r.MinMediumDiffReviewers < 2 {
+		errs = append(errs, fmt.Sprintf("min_medium_diff_reviewers must be >= 2, got %d", r.MinMediumDiffReviewers))
+	}
 	if len(r.ReviewerAgents) == 0 {
 		errs = append(errs, "reviewer_agents must not be empty")
 	}
@@ -788,29 +796,31 @@ func (r *ResolvedConfig) Validate() error {
 }
 
 var Defaults = ResolvedConfig{
-	Reviewers:           5,
-	LargeDiffReviewers:  4,
-	MediumDiffReviewers: 2,
-	SmallDiffReviewers:  1,
-	Concurrency:         0,
-	Base:                "main",
-	Timeout:             10 * time.Minute,
-	Retries:             1,
-	Fetch:               true,
-	ReviewerAgents:      []string{agent.DefaultAgent},
-	SummarizerAgent:     agent.DefaultSummarizerAgent,
-	SummarizerTimeout:   5 * time.Minute,
-	FPFilterTimeout:     5 * time.Minute,
-	CrossCheckTimeout:   5 * time.Minute,
-	FPFilterEnabled:     true,
-	FPThreshold:         75,
-	PRFeedbackEnabled:   true,
-	PRFeedbackAgent:     "", // empty means use summarizer agent
-	CrossCheckEnabled:   true,
-	CrossCheckAgent:     "", // empty means use summarizer agent
-	CrossCheckModel:     "", // empty: must resolve via models config or ValidateRuntime will error
-	AutoPhase:           true,
-	Strict:              false,
+	Reviewers:              5,
+	LargeDiffReviewers:     4,
+	MediumDiffReviewers:    2,
+	SmallDiffReviewers:     1,
+	Concurrency:            0,
+	Base:                   "main",
+	Timeout:                10 * time.Minute,
+	Retries:                1,
+	Fetch:                  true,
+	ReviewerAgents:         []string{agent.DefaultAgent},
+	SummarizerAgent:        agent.DefaultSummarizerAgent,
+	SummarizerTimeout:      5 * time.Minute,
+	FPFilterTimeout:        5 * time.Minute,
+	CrossCheckTimeout:      5 * time.Minute,
+	FPFilterEnabled:        true,
+	FPThreshold:            75,
+	PRFeedbackEnabled:      true,
+	PRFeedbackAgent:        "", // empty means use summarizer agent
+	CrossCheckEnabled:      true,
+	CrossCheckAgent:        "", // empty means use summarizer agent
+	CrossCheckModel:        "", // empty: must resolve via models config or ValidateRuntime will error
+	AutoPhase:              true,
+	Strict:                 false,
+	MinLargeDiffReviewers:  2,
+	MinMediumDiffReviewers: 2,
 }
 
 type ResolvedConfig struct {
@@ -831,24 +841,26 @@ type ResolvedConfig struct {
 	// DiffReviewerAgents is the per-phase override for the diff phase in
 	// auto-phase grouped diff (round-robin). Empty slice means fall back to
 	// ReviewerAgents.
-	DiffReviewerAgents []string
-	SummarizerAgent    string
-	ReviewerModel      string
-	SummarizerModel    string
-	SummarizerTimeout  time.Duration
-	FPFilterTimeout    time.Duration
-	CrossCheckTimeout  time.Duration
-	Guidance           string
-	GuidanceFile       string
-	FPFilterEnabled    bool
-	FPThreshold        int
-	PRFeedbackEnabled  bool
-	PRFeedbackAgent    string
-	CrossCheckEnabled  bool
-	CrossCheckAgent    string // empty means use summarizer agent
-	CrossCheckModel    string // empty means use summarizer model
-	AutoPhase          bool
-	Strict             bool // when true, advisory verdict exits 1 (default false)
+	DiffReviewerAgents     []string
+	SummarizerAgent        string
+	ReviewerModel          string
+	SummarizerModel        string
+	SummarizerTimeout      time.Duration
+	FPFilterTimeout        time.Duration
+	CrossCheckTimeout      time.Duration
+	Guidance               string
+	GuidanceFile           string
+	FPFilterEnabled        bool
+	FPThreshold            int
+	PRFeedbackEnabled      bool
+	PRFeedbackAgent        string
+	CrossCheckEnabled      bool
+	CrossCheckAgent        string // empty means use summarizer agent
+	CrossCheckModel        string // empty means use summarizer model
+	AutoPhase              bool
+	Strict                 bool // when true, advisory verdict exits 1 (default false)
+	MinLargeDiffReviewers  int
+	MinMediumDiffReviewers int
 	// ReviewerModelFromCLI is true when --reviewer-model or ACR_REVIEWER_MODEL
 	// set the ReviewerModel field, making it a CLI/env override that should win
 	// over models.agents/sizes/defaults config.
@@ -1284,6 +1296,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		}
 		if cfg.AutoPhase != nil {
 			result.AutoPhase = *cfg.AutoPhase
+		}
+		if cfg.MinLargeDiffReviewers != nil {
+			result.MinLargeDiffReviewers = *cfg.MinLargeDiffReviewers
+		}
+		if cfg.MinMediumDiffReviewers != nil {
+			result.MinMediumDiffReviewers = *cfg.MinMediumDiffReviewers
 		}
 		// Models configuration is a struct (not a pointer); copy as-is.
 		result.Models = cfg.Models

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2828,6 +2828,70 @@ func TestValidate_RejectsZeroSmallDiffReviewers(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// min_large_diff_reviewers / min_medium_diff_reviewers (yaml-only floor keys)
+// ---------------------------------------------------------------------------
+
+func TestResolve_MinLargeDiffReviewers_DefaultsTo2(t *testing.T) {
+	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.MinLargeDiffReviewers != 2 {
+		t.Errorf("expected default min_large_diff_reviewers=2, got %d", result.MinLargeDiffReviewers)
+	}
+	if Defaults.MinLargeDiffReviewers != 2 {
+		t.Errorf("expected Defaults.MinLargeDiffReviewers=2, got %d", Defaults.MinLargeDiffReviewers)
+	}
+}
+
+func TestResolve_MinLargeDiffReviewers_FromYAML(t *testing.T) {
+	cfg := &Config{MinLargeDiffReviewers: ptr(3)}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.MinLargeDiffReviewers != 3 {
+		t.Errorf("expected min_large_diff_reviewers=3 from yaml, got %d", result.MinLargeDiffReviewers)
+	}
+}
+
+func TestResolve_MinMediumDiffReviewers_DefaultsTo2(t *testing.T) {
+	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.MinMediumDiffReviewers != 2 {
+		t.Errorf("expected default min_medium_diff_reviewers=2, got %d", result.MinMediumDiffReviewers)
+	}
+	if Defaults.MinMediumDiffReviewers != 2 {
+		t.Errorf("expected Defaults.MinMediumDiffReviewers=2, got %d", Defaults.MinMediumDiffReviewers)
+	}
+}
+
+func TestResolve_MinMediumDiffReviewers_FromYAML(t *testing.T) {
+	cfg := &Config{MinMediumDiffReviewers: ptr(4)}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.MinMediumDiffReviewers != 4 {
+		t.Errorf("expected min_medium_diff_reviewers=4 from yaml, got %d", result.MinMediumDiffReviewers)
+	}
+}
+
+func TestValidate_RejectsMinLargeDiffReviewersBelow2(t *testing.T) {
+	cfg := Defaults
+	cfg.MinLargeDiffReviewers = 1
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for min_large_diff_reviewers=1, got nil")
+	}
+	if !strings.Contains(err.Error(), "min_large_diff_reviewers must be >= 2") {
+		t.Errorf("expected 'min_large_diff_reviewers must be >= 2' in error, got: %v", err)
+	}
+}
+
+func TestValidate_RejectsMinMediumDiffReviewersBelow2(t *testing.T) {
+	cfg := Defaults
+	cfg.MinMediumDiffReviewers = 1
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for min_medium_diff_reviewers=1, got nil")
+	}
+	if !strings.Contains(err.Error(), "min_medium_diff_reviewers must be >= 2") {
+		t.Errorf("expected 'min_medium_diff_reviewers must be >= 2' in error, got: %v", err)
+	}
+}
+
 func TestLoadEnvState_SmallDiffReviewers(t *testing.T) {
 	clearACREnv(t)
 	t.Setenv("ACR_SMALL_DIFF_REVIEWERS", "4")

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -257,7 +257,7 @@ type DiffSize int
 const (
 	DiffSizeSmall  DiffSize = iota // ≤3 files AND ≤100 changed lines
 	DiffSizeMedium                 // 4-10 files OR 101-500 changed lines
-	DiffSizeLarge                  // >10 files OR >500 changed lines
+	DiffSizeLarge                  // (>10 files OR >500 changed lines) AND ≥2 files
 )
 
 // String returns a human-readable label.
@@ -330,7 +330,7 @@ func parseDiffStat(output string) (fileCount, lineCount int) {
 
 // classifySize applies size thresholds to file and line counts.
 func classifySize(fileCount, lineCount int) DiffSize {
-	if fileCount > 10 || lineCount > 500 {
+	if (fileCount > 10 || lineCount > 500) && fileCount >= 2 {
 		return DiffSizeLarge
 	}
 	if fileCount > 3 || lineCount > 100 {

--- a/internal/git/diff_size_test.go
+++ b/internal/git/diff_size_test.go
@@ -72,8 +72,11 @@ func TestClassifySize(t *testing.T) {
 		{"medium - files threshold", 4, 50, DiffSizeMedium},
 		{"medium - lines threshold", 2, 101, DiffSizeMedium},
 		{"medium - both medium", 5, 200, DiffSizeMedium},
+		{"medium - single file many lines", 1, 501, DiffSizeMedium},
+		{"medium - single file huge", 1, 2000, DiffSizeMedium},
 		{"large - many files", 11, 50, DiffSizeLarge},
 		{"large - many lines", 2, 501, DiffSizeLarge},
+		{"large - boundary 2 files many lines", 2, 501, DiffSizeLarge},
 		{"large - both large", 15, 1000, DiffSizeLarge},
 		{"zero values", 0, 0, DiffSizeSmall},
 	}

--- a/internal/git/diff_size_test.go
+++ b/internal/git/diff_size_test.go
@@ -76,7 +76,7 @@ func TestClassifySize(t *testing.T) {
 		{"medium - single file huge", 1, 2000, DiffSizeMedium},
 		{"large - many files", 11, 50, DiffSizeLarge},
 		{"large - many lines", 2, 501, DiffSizeLarge},
-		{"large - boundary 2 files many lines", 2, 501, DiffSizeLarge},
+		{"medium - boundary 2 files 500 lines", 2, 500, DiffSizeMedium},
 		{"large - both large", 15, 1000, DiffSizeLarge},
 		{"zero values", 0, 0, DiffSizeSmall},
 	}


### PR DESCRIPTION
## Summary

- `--phase large` トークンを追加。auto-phase を経由せず grouped specs を直接構築し、arch + N diff groups + cross-check の large パスを明示的に実行可能に
- `classifySize` に `fileCount >= 2` 制約を追加。1ファイル diff の誤った large 判定を排除
- `min_large_diff_reviewers` / `min_medium_diff_reviewers` を yaml-only 設定キーとして新設 (デフォルト 2)。grouped review の構造的最低条件をフロアとして保証
- `resolveAutoPhase` の large/medium 両パスにフロア適用
- ファイル数不足 (<2 groups) 時は medium にフォールバック + cross-check スキップの warning ログ

## ADR

| # | Decision | 根拠 |
|---|----------|------|
| 0 | `classifySize` に `fileCount >= 2` 必須条件 | grouped review は 2 グループ以上への分割が構造的前提 |
| 1 | `min_*_diff_reviewers` は yaml-only | プロジェクト品質方針であり CLI で緩和すべきでない |
| 2 | トークン名 `large` | 既存 small/medium との一貫性 |
| 3 | 防御的 medium フォールバック | `--phase large` の意図は「少なくとも多相レビュー」 |
| 4 | `sizeStr` 上書き | sizes.large モデルカスケードと cross-check 条件を自然に満たす |

## Test plan

- [x] `TestClassifySize` — 1ファイル×501行 → medium、2ファイル×501行 → large
- [x] `TestResolve_MinLargeDiffReviewers_*` / `TestResolve_MinMediumDiffReviewers_*` — デフォルト値、yaml 読み込み
- [x] `TestValidate_RejectsMinLargeDiffReviewersBelow2` / `TestValidate_RejectsMinMediumDiffReviewersBelow2`
- [x] `TestResolveAutoPhase_*Floor*` — large/medium フロア clamp
- [x] `TestResolvePhaseLarge_SufficientFiles_GroupedSpecs` — 6ファイル → grouped 成立
- [x] `TestResolvePhaseLarge_InsufficientFiles_FallbackToMedium` — 1ファイル → medium フォールバック
- [x] `TestResolvePhaseLarge_FloorApplied` — フロア clamp → grouped 成立
- [x] 全 14 パッケージ PASS、ビルド成功、`--help` に "large" 表示確認
- [x] ACR セルフレビュー: blocking findings 対応済み → LGTM

## Related

- Closes #11
- Issue #23: `--phase` 指定時の cross-check runtime validation スキップ (pre-existing, 別対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)