### PR TITLE
fix: --phase large 指定時に ValidateRuntime を startup で実行 (#23)

### DIFF
--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -514,12 +514,13 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 	// somewhere). Done as a separate pass so YAML-only Validate() does not
 	// false-positive on configs that defer the model to env/CLI.
 	//
-	// Cross-check runs exclusively on the auto-phase grouped (large) path.
-	// When auto-phase is disabled or an explicit --phase overrides it,
-	// cross-check can never execute, so skip validation to avoid rejecting
-	// valid flat/arch,diff workflows that omit cross_check.model.
+	// Cross-check runs on the auto-phase grouped (large) path AND the explicit
+	// --phase large path. Skip validation only for paths where
+	// cross-check can never execute (--phase small/medium, --no-auto-phase
+	// without --phase large) to avoid rejecting valid workflows that omit
+	// cross_check.model.
 	phaseFlag, _ := cmd.Flags().GetString("phase")
-	if resolved.AutoPhase && phaseFlag == "" {
+	if shouldRunRuntimeValidation(resolved.AutoPhase, phaseFlag) {
 		if runtimeErrs := resolved.ValidateRuntime(); len(runtimeErrs) > 0 {
 			for _, e := range runtimeErrs {
 				logger.Logf(terminal.StyleError, "%s", e)

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -162,16 +162,18 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 	// Cross-check agent resolution and CLI availability checks are BOTH deferred
 	// to the grouped path below (see `if useGroupedSpecs && opts.CrossCheckEnabled`).
-	// Round-14 F#1: cross-check is invoked only when useGroupedSpecs=true, which
-	// resolveAutoPhase only returns under DiffSizeLarge. Eager resolution here
-	// would force users on small/medium diffs (or `--phase`/`--no-auto-phase`/
-	// medium fallback paths) to satisfy cross_check.model purely to start the
-	// run — even though cross-check would never execute. Deferring resolve until
-	// the gate also implicitly tightens validate↔runtime symmetry: at the gate,
-	// sizeStr is guaranteed to be "large", matching `canResolveCrossCheckModelForAgent`'s
-	// sizes["large"] cascade in internal/config. Contract integrity (agent name
-	// validity, model 1:1 pairing) is still enforced at validate time by
-	// ResolvedConfig.ValidateRuntime.
+	// Cross-check fires only when useGroupedSpecs=true && sizeStr=="large", which
+	// is reachable via auto-phase (DiffSizeLarge) or explicit --phase large.
+	// Eager resolution here would force users on small/medium diffs (or
+	// --phase small/medium / --no-auto-phase without --phase large / medium
+	// fallback paths) to satisfy cross_check.model purely to start the run —
+	// even though cross-check would never execute on those paths. Deferring
+	// resolve until the gate tightens validate↔runtime symmetry: at the gate,
+	// sizeStr is guaranteed to be "large", matching
+	// `canResolveCrossCheckModelForAgent`'s sizes["large"] cascade in
+	// internal/config. Cross-check model resolution and agent/model count
+	// pairing are enforced at startup by shouldRunRuntimeValidation →
+	// ResolvedConfig.ValidateRuntime for both auto-phase and --phase large.
 
 	// Verbose: log the effective model/effort matrix for all roles once, up-front.
 	// fp_filter and pr_feedback specs are resolved later in the flow, so we
@@ -758,6 +760,15 @@ func shouldUseAutoPhase(opts ReviewOpts) bool {
 	return opts.AutoPhase && opts.Phase == ""
 }
 
+// shouldRunRuntimeValidation returns true when ValidateRuntime() should be
+// called at startup. Cross-check can fire on two paths: (1) auto-phase when
+// the diff is classified as large, and (2) explicit --phase large. All other
+// paths (--phase small/medium, --no-auto-phase without --phase large) cannot
+// trigger cross-check, so validation is safely skipped.
+func shouldRunRuntimeValidation(autoPhase bool, phaseFlag string) bool {
+	return (autoPhase && phaseFlag == "") || phaseFlag == "large"
+}
+
 // collectAllCLINames returns CLI names that may be invoked during an auto-phase
 // review run. The returned slice may contain duplicates; deduplication is handled
 // by CheckCLIAvailability. Fallback defaults for optional fields are resolved here
@@ -845,13 +856,13 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 //
 // Round-14 F#1 contract: this function is invoked exclusively from the
 // grouped-path gate in executeReview, where sizeStr is guaranteed to be
-// "large" (useGroupedSpecs=true is exclusive to DiffSizeLarge in
-// resolveAutoPhase). The defense-in-depth log helper logCrossCheckModelMatrix
-// also calls this with the same sizeStr just before the gate, so the size
-// argument is consistent across both call sites. Non-grouped review paths
-// (small / medium / `--phase` / `--no-auto-phase` / medium fallback) skip
-// cross-check entirely and never invoke this function — that is the entire
-// point of Round-14 F#1's resolve deferral.
+// "large" (useGroupedSpecs=true is reachable via auto-phase DiffSizeLarge
+// or explicit --phase large). The defense-in-depth log helper
+// logCrossCheckModelMatrix also calls this with the same sizeStr just
+// before the gate, so the size argument is consistent across both call
+// sites. Non-grouped review paths (small / medium / --phase small|medium /
+// --no-auto-phase without --phase large / medium fallback) skip cross-check
+// entirely and never invoke this function.
 //
 // Returns (nil, nil, nil) when cross-check is disabled.
 //

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -836,6 +836,44 @@ func TestExecuteReview_NoAutoPhase_UsesFlatPath(t *testing.T) {
 	}
 }
 
+// --- shouldRunRuntimeValidation tests ---
+
+func TestShouldRunRuntimeValidation_AutoPhase_NoExplicitPhase(t *testing.T) {
+	if !shouldRunRuntimeValidation(true, "") {
+		t.Error("expected true: auto-phase active, no explicit --phase → cross-check may fire on large diff")
+	}
+}
+
+func TestShouldRunRuntimeValidation_AutoPhase_PhaseLarge(t *testing.T) {
+	if !shouldRunRuntimeValidation(true, "large") {
+		t.Error("expected true: --phase large can trigger cross-check via grouped review")
+	}
+}
+
+func TestShouldRunRuntimeValidation_NoAutoPhase_PhaseLarge(t *testing.T) {
+	if !shouldRunRuntimeValidation(false, "large") {
+		t.Error("expected true: --no-auto-phase --phase large still triggers cross-check")
+	}
+}
+
+func TestShouldRunRuntimeValidation_AutoPhase_PhaseSmall(t *testing.T) {
+	if shouldRunRuntimeValidation(true, "small") {
+		t.Error("expected false: --phase small cannot trigger cross-check")
+	}
+}
+
+func TestShouldRunRuntimeValidation_AutoPhase_PhaseMedium(t *testing.T) {
+	if shouldRunRuntimeValidation(true, "medium") {
+		t.Error("expected false: --phase medium cannot trigger cross-check")
+	}
+}
+
+func TestShouldRunRuntimeValidation_NoAutoPhase_NoPhase(t *testing.T) {
+	if shouldRunRuntimeValidation(false, "") {
+		t.Error("expected false: --no-auto-phase with no explicit phase → flat path, no cross-check")
+	}
+}
+
 // --- applyVerdictExitPolicy tests (Part C exit-code policy) ---
 
 func TestReview_ExitCode_VerdictOk_ExitsZero(t *testing.T) {


### PR DESCRIPTION
## Summary

- `--phase large` 指定時に `ValidateRuntime()` が startup でスキップされ、不正な `cross_check.model` 設定がレビュー完了後に初めて検出される問題を修正 (Issue #23)
- `shouldRunRuntimeValidation` ヘルパーを導入し、auto-phase と `--phase large` の両パスで startup 検証を実行
- `review.go` / `main.go` の陳腐化したコメントを `--phase large` 対応後の実態に合わせて修正

## 変更内容

| ファイル | 変更 |
|---|---|
| `cmd/acr/review.go` | `shouldRunRuntimeValidation()` ヘルパー追加 + コメント修正 (deferred resolution / resolveCrossCheckAgents docstring) |
| `cmd/acr/main.go` | 条件式をヘルパー呼び出しに差し替え + コメント修正 |
| `cmd/acr/review_test.go` | 6 テストケース追加 (auto-phase, --phase large, --no-auto-phase --phase large, --phase small, --phase medium, --no-auto-phase) |

## Test plan

- [x] `go test ./cmd/acr/...` 全 PASS
- [x] `go test ./internal/config/...` 全 PASS
- [x] `go build -o .\acr.exe .\cmd\acr` 成功
- [x] `gofmt` クリーン
- [x] ACR セルフレビュー: advisory 1件 → FALSE POSITIVE (WAI: 設定不備の早期検出は意図通り)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)