### PR TITLE
feat: --role-prompts デフォルト ON 化

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -822,7 +822,7 @@ var Defaults = ResolvedConfig{
 	Strict:                 false,
 	MinLargeDiffReviewers:  2,
 	MinMediumDiffReviewers: 2,
-	RolePrompts:            false,
+	RolePrompts:            true,
 }
 
 type ResolvedConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3219,10 +3219,10 @@ func TestValidateRuntime_CrossCheckModelsTreeFallback(t *testing.T) {
 
 // --- RolePrompts config resolution tests ---
 
-func TestResolve_RolePromptsDefaultsFalse(t *testing.T) {
+func TestResolve_RolePromptsDefaultsTrue(t *testing.T) {
 	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
-	if result.RolePrompts {
-		t.Errorf("expected RolePrompts=false as default, got true")
+	if !result.RolePrompts {
+		t.Errorf("expected RolePrompts=true as default, got false")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `role_prompts` のデフォルト値を `false` → `true` に変更
- ベンチマーク結果 (CONDITIONAL GO) + 阻害バグ 3 件修正済み (PR #28) を受けての有効化
- テストのデフォルト期待値を更新

## 背景

PR #28 で導入した `--role-prompts` フラグは auto-phase 時に diff/arch ロール別プロンプトを使用する機能。12 trials のベンチマークで findings 数 ±0%、ノイズ 40% 減、分散半減を確認済み。

## Test plan

- [x] `go test ./internal/config/...` PASS
- [x] `go test ./internal/agent/...` PASS
- [x] `go test ./internal/runner/...` PASS
- [x] `go test ./cmd/acr/...` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)