### PR TITLE
refactor: Issue #18/#20/#22 + ドキュメント整合性修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,45 +34,100 @@ go install ./cmd/acr  # Install locally
 ## Architecture
 
 ```
-cmd/acr/main.go          # CLI entry point, flag parsing, orchestration
+cmd/acr/                   # CLI entry point and subcommands
+  main.go                  # CLI entry point, flag parsing, cobra root command
+  review.go                # Core review orchestration (executeReview)
+  review_opts.go           # ReviewOpts struct bundling resolved config + CLI flags
+  pr_submit.go             # PR submission flow (post comments, approve)
+  config_cmd.go            # `acr config` subcommand (init/show .acr.yaml)
+  help.go                  # Custom help formatting (flag groups)
+  helpers.go               # CLI helper functions (finding filtering, etc.)
+  version.go               # Version info (injected via ldflags)
+  signals_unix.go          # Unix signal handling (build-tagged)
+  signals_windows.go       # Windows signal handling (build-tagged)
+  *_test.go                # Tests for review, helpers, config_cmd, pr_submit, help
+
 internal/
-  agent/                 # LLM agent abstraction layer
-    agent.go             # Agent interface (ExecuteReview, ExecuteSummary)
-    codex.go             # Codex CLI agent implementation
-    claude.go            # Claude CLI agent implementation
-    gemini.go            # Gemini CLI agent implementation
-    factory.go           # Agent and parser factory functions
-    parser.go            # ReviewParser and SummaryParser interfaces
-    *_review_parser.go   # Agent-specific review output parsers
-    *_summary_parser.go  # Agent-specific summary output parsers
-    prompts.go           # Default review prompts per agent
-  config/                # Configuration file support
-    config.go            # Load/parse .acr.yaml, resolve precedence (flags > env > config > defaults)
-  domain/                # Core types: Finding, AggregatedFinding, GroupedFindings
-    finding.go           # Finding types and aggregation logic
-    result.go            # ReviewerResult and ReviewStats
-    exitcode.go          # Exit code constants
-  filter/                # Finding filtering
-    filter.go            # Exclude findings by regex pattern matching
-  fpfilter/              # False positive filtering
-    fpfilter.go          # LLM-based false positive detection and removal
-  feedback/              # PR feedback summarization
-    fetch.go             # Fetch PR description and comments via gh CLI
-    summarizer.go        # LLM-based summarization of prior PR discussion
-  runner/                # Review execution engine
-    runner.go            # Parallel reviewer orchestration
-    report.go            # Report rendering (terminal + markdown)
-  summarizer/            # LLM-based finding summarization
-    summarizer.go        # Orchestrates agent execution and output parsing
-  github/                # GitHub PR operations via gh CLI
-    pr.go                # Post comments, approve PRs, check CI status
-  git/                   # Git operations
-    worktree.go          # Temporary worktree management
-  terminal/              # Terminal UI
-    spinner.go           # Progress spinner
-    logger.go            # Styled logging
-    colors.go            # ANSI color codes
-    format.go            # Text formatting utilities
+  agent/                   # LLM agent abstraction layer
+    doc.go                 # Package documentation
+    agent.go               # Agent interface (ExecuteReview, ExecuteSummary)
+    codex.go               # Codex CLI agent implementation
+    claude.go              # Claude CLI agent implementation
+    gemini.go              # Gemini CLI agent implementation
+    factory.go             # Agent and parser factory functions (registry)
+    cohort.go              # Multi-agent name parsing, availability checks, distribution
+    config.go              # ReviewConfig and SummaryConfig structs
+    executor.go            # Subprocess execution with stderr capture
+    cmd_reader.go          # io.Reader wrapper with process lifecycle management
+    result.go              # ExecutionResult (io.ReadCloser + exit code + stderr)
+    auth.go                # Authentication failure detection (exit codes, stderr patterns)
+    diff.go                # Git diff/fetch delegations (backward-compat aliases)
+    diff_review.go         # Diff-based review execution (shared by Claude/Gemini)
+    parser.go              # ReviewParser and SummaryParser interfaces
+    claude_review_parser.go    # Claude review output parser
+    codex_review_parser.go     # Codex review output parser (JSONL)
+    gemini_review_parser.go    # Gemini review output parser
+    claude_summary_parser.go   # Claude summary output parser
+    codex_summary_parser.go    # Codex summary output parser
+    gemini_summary_parser.go   # Gemini summary output parser
+    prompts.go             # Default review/summary prompts per agent
+    nonfinding.go          # "No issues found" response detection
+    reffile.go             # Temp file management for large diffs
+    severity.go            # Severity extraction from finding text
+    process_unix.go        # Unix process group handling (build-tagged)
+    process_windows.go     # Windows process group handling (build-tagged)
+    *_test.go              # Extensive test suite
+
+  config/                  # Configuration file support
+    config.go              # Load/parse .acr.yaml, LoadEnvState(), Resolve() precedence
+
+  domain/                  # Core types: Finding, AggregatedFinding, GroupedFindings
+    finding.go             # Finding types, aggregation logic, disposition tracking
+    result.go              # ReviewerResult and ReviewStats
+    exitcode.go            # Exit code constants (0=clean, 1=findings, 2=error, 130=interrupted)
+    phase.go               # Phase constants (PhaseArch, PhaseDiff)
+
+  filter/                  # Finding filtering
+    filter.go              # Exclude findings by regex pattern matching
+
+  fpfilter/                # False positive filtering
+    filter.go              # LLM-based false positive detection and removal
+    prompt.go              # FP filter prompt templates (including prior feedback)
+
+  feedback/                # PR feedback summarization
+    fetch.go               # Fetch PR description and comments via gh CLI
+    summarizer.go          # LLM-based summarization of prior PR discussion
+    prompt.go              # Feedback summarization prompt template
+
+  runner/                  # Review execution engine
+    runner.go              # Parallel reviewer orchestration
+    report.go              # Report rendering (terminal + markdown)
+    phase.go               # PhaseConfig and multi-phase review planning
+    spec.go                # ReviewerSpec and distribution formatting
+
+  summarizer/              # LLM-based finding summarization
+    summarizer.go          # Orchestrates agent execution and output parsing
+    crosscheck.go          # Cross-check validation of summarizer output
+
+  github/                  # GitHub PR operations via gh CLI
+    pr.go                  # Post comments, approve PRs, check CI status
+    fork.go                # Fork reference resolution
+
+  git/                     # Git operations
+    worktree.go            # Temporary worktree management
+    diff.go                # Diff generation, branch update, diff size classification
+    diffsplit.go           # Split unified diffs into per-file sections
+    remote.go              # Remote management (add, fetch, URL operations)
+
+  terminal/                # Terminal UI
+    spinner.go             # Progress spinner
+    logger.go              # Styled logging
+    colors.go              # ANSI color codes
+    format.go              # Text formatting utilities
+    selector.go            # Interactive TUI selector (bubbletea-based)
+
+  modelconfig/             # Model configuration resolution
+    resolver.go            # Resolve model + effort for (size, role, agent) tuples
 ```
 
 ## Key Design Decisions
@@ -106,7 +161,7 @@ internal/
 When adding features:
 
 1. **Domain types go in `internal/domain/`** - Keep them simple, no external dependencies.
-2. **New CLI flags** - Add to `cmd/acr/main.go`, follow existing pattern with env var defaults.
+2. **New CLI flags** - Add to `cmd/acr/main.go`, env var parsing in `internal/config/config.go`.
 3. **Tests required** - Add `_test.go` files alongside implementation.
 4. **Lint clean** - Run `make lint` before committing.
 
@@ -118,8 +173,15 @@ When adding features:
 // In cmd/acr/main.go, add to var block:
 var myFlag string
 
-// In run(), add flag definition:
-rootCmd.Flags().StringVarP(&myFlag, "my-flag", "m", getEnvStr("ACR_MY_FLAG", "default"), "Description")
+// In run(), add flag definition with a hardcoded default:
+rootCmd.Flags().StringVarP(&myFlag, "my-flag", "m", "default", "Description")
+
+// In internal/config/config.go, add env var parsing in LoadEnvState():
+if v := os.Getenv("ACR_MY_FLAG"); v != "" {
+    state.MyFlag = v
+}
+
+// Precedence is resolved automatically in Resolve(): flags > env > .acr.yaml > defaults
 ```
 
 ### Adding a new finding field

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,19 +169,37 @@ When adding features:
 
 ### Adding a new CLI flag
 
-```go
-// In cmd/acr/main.go, add to var block:
-var myFlag string
+A new flag touches 4 locations across 2 files:
 
-// In run(), add flag definition with a hardcoded default:
+```go
+// 1. cmd/acr/main.go — declare var and register cobra flag
+var myFlag string
 rootCmd.Flags().StringVarP(&myFlag, "my-flag", "m", "default", "Description")
 
-// In internal/config/config.go, add env var parsing in LoadEnvState():
-if v := os.Getenv("ACR_MY_FLAG"); v != "" {
-    state.MyFlag = v
+// 2. cmd/acr/main.go — wire into FlagState + flagValues (in run())
+flagState := config.FlagState{
+    // ...
+    MyFlagSet: cmd.Flags().Changed("my-flag"),
+}
+flagValues := config.ResolvedConfig{
+    // ...
+    MyFlag: myFlag,
 }
 
-// Precedence is resolved automatically in Resolve(): flags > env > .acr.yaml > defaults
+// 3. internal/config/config.go — add to ResolvedConfig, FlagState, EnvState structs
+//    and add env var parsing in LoadEnvState():
+if v := os.Getenv("ACR_MY_FLAG"); v != "" {
+    state.MyFlag = v
+    state.MyFlagSet = true
+}
+
+// 4. internal/config/config.go — add precedence logic in Resolve():
+if flagState.MyFlagSet {
+    result.MyFlag = flagValues.MyFlag
+} else if envState.MyFlagSet {
+    result.MyFlag = envState.MyFlag
+}
+// config file and Defaults provide the base value
 ```
 
 ### Adding a new finding field

--- a/README.md
+++ b/README.md
@@ -170,9 +170,25 @@ The verdict field (`ok` / `advisory` / `blocking`) and exit-code policy apply on
 | `--exclude-pattern` |       |         | Exclude findings matching regex (repeat)  |
 | `--no-config`       |       | false   | Skip loading .acr.yaml config file        |
 | `--reviewer-agent`  | `-a`  | codex   | Agent(s) for reviews, comma-separated (codex, claude, gemini) |
+| `--arch-reviewer-agent`|    |         | Single agent for arch phase in auto-phase grouped diff (default: first --reviewer-agent) |
+| `--diff-reviewer-agents`|   |         | Agent(s) for diff phase in auto-phase grouped diff, comma-separated (default: same as --reviewer-agent) |
 | `--summarizer-agent`| `-s`  | codex   | Agent for summarization (codex, claude, gemini) |
 | `--reviewer-model`  |       |         | LLM model for review agents (env: ACR_REVIEWER_MODEL) |
 | `--summarizer-model`|       |         | LLM model for summarizer/FP filter agents (env: ACR_SUMMARIZER_MODEL) |
+| `--auto-phase`/`--no-auto-phase`| | true | Auto-select review phases based on diff size (env: ACR_AUTO_PHASE) |
+| `--phase`           |       |         | Override auto-phase: small, medium, large  |
+| `--large-diff-reviewers`|   | 4       | Number of diff reviewers in auto-phase grouped path (large diff) |
+| `--medium-diff-reviewers`|  | 2       | Number of diff reviewers for auto-phase medium and --phase medium |
+| `--small-diff-reviewers`|   | 1       | Number of reviewers for auto-phase small and --phase small |
+| `--role-prompts`/`--no-role-prompts`| | true | Use role-specific prompts for auto-phase diff/arch reviewers |
+| `--summarizer-timeout`|     | 5m      | Timeout for summarizer phase              |
+| `--fp-filter-timeout`|      | 5m      | Timeout for false positive filter phase   |
+| `--no-cross-check`  |       | false   | Disable cross-group consistency verification |
+| `--cross-check-agent`|      |         | Agent(s) for cross-check verification, comma-separated (default: same as --summarizer-agent) |
+| `--cross-check-model`|      |         | LLM model(s) for cross-check, comma-separated (REQUIRED when cross-check enabled) |
+| `--cross-check-timeout`|    | 5m      | Timeout for cross-check phase             |
+| `--strict`          |       | false   | Exit 1 on any advisory verdict            |
+| `--format`          |       | text    | Output format: text or json               |
 
 ### Concurrency Control
 
@@ -292,9 +308,21 @@ PR feedback summarization runs in parallel with the reviewers and is enabled by 
 | `ACR_PR_FEEDBACK`         | Enable PR feedback summarization (true/false) |
 | `ACR_PR_FEEDBACK_AGENT`   | Agent for PR feedback summarization |
 | `ACR_REVIEWER_AGENT`      | Default reviewer agent(s), comma-separated |
+| `ACR_ARCH_REVIEWER_AGENT` | Single agent for arch phase in auto-phase grouped diff |
+| `ACR_DIFF_REVIEWER_AGENTS`| Agent(s) for diff phase in auto-phase grouped diff |
 | `ACR_SUMMARIZER_AGENT`    | Default summarizer agent  |
 | `ACR_SUMMARIZER_TIMEOUT`  | Timeout for summarizer phase (e.g., "5m" or "300") |
 | `ACR_FP_FILTER_TIMEOUT`   | Timeout for false positive filter phase (e.g., "5m" or "300") |
+| `ACR_AUTO_PHASE`          | Enable auto-phase selection (true/false)   |
+| `ACR_LARGE_DIFF_REVIEWERS`| Number of diff reviewers for auto-phase large path |
+| `ACR_MEDIUM_DIFF_REVIEWERS`| Number of diff reviewers for auto-phase medium path |
+| `ACR_SMALL_DIFF_REVIEWERS`| Number of reviewers for auto-phase small path |
+| `ACR_ROLE_PROMPTS`        | Enable role-specific prompts (true/false)  |
+| `ACR_CROSS_CHECK`         | Enable cross-group consistency verification (true/false) |
+| `ACR_CROSS_CHECK_AGENT`   | Agent(s) for cross-check verification      |
+| `ACR_CROSS_CHECK_MODEL`   | LLM model(s) for cross-check               |
+| `ACR_CROSS_CHECK_TIMEOUT` | Timeout for cross-check phase (e.g., "5m" or "300") |
+| `ACR_STRICT`              | Exit 1 on any advisory verdict (true/false) |
 | `ACR_GUIDANCE`            | Steering context appended to review prompt |
 | `ACR_GUIDANCE_FILE`       | Path to file containing review guidance    |
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The verdict field (`ok` / `advisory` / `blocking`) and exit-code policy apply on
 | `--large-diff-reviewers`|   | 4       | Number of diff reviewers in auto-phase grouped path (large diff) |
 | `--medium-diff-reviewers`|  | 2       | Number of diff reviewers for auto-phase medium and --phase medium |
 | `--small-diff-reviewers`|   | 1       | Number of reviewers for auto-phase small and --phase small |
-| `--role-prompts`/`--no-role-prompts`| | true | Use role-specific prompts for auto-phase diff/arch reviewers |
+| `--role-prompts`/`--no-role-prompts`| | true | Use role-specific prompts for auto-phase diff/arch reviewers (note: `--help` shows `false` as the cobra default, but the effective default is `true` via config resolution) |
 | `--summarizer-timeout`|     | 5m      | Timeout for summarizer phase              |
 | `--fp-filter-timeout`|      | 5m      | Timeout for false positive filter phase   |
 | `--no-cross-check`  |       | false   | Disable cross-group consistency verification |

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -196,8 +196,8 @@ Exit codes:
 		"Disable auto-phase selection and use flat diff review (env: ACR_AUTO_PHASE=false)")
 	rootCmd.Flags().BoolVar(&strict, "strict", false,
 		"Exit 1 on any advisory verdict (default: false, env: ACR_STRICT)")
-	rootCmd.Flags().BoolVar(&rolePrompts, "role-prompts", false,
-		"Use role-specific prompts for auto-phase diff/arch reviewers (default: false, env: ACR_ROLE_PROMPTS)")
+	rootCmd.Flags().BoolVar(&rolePrompts, "role-prompts", true,
+		"Use role-specific prompts for auto-phase diff/arch reviewers (default: true, env: ACR_ROLE_PROMPTS)")
 	rootCmd.Flags().BoolVar(&noRolePrompts, "no-role-prompts", false,
 		"Disable role-specific prompts (env: ACR_ROLE_PROMPTS=false)")
 

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -767,7 +767,7 @@ func shouldUseAutoPhase(opts ReviewOpts) bool {
 // specsHaveArch returns true if any spec in the slice has Phase "arch".
 func specsHaveArch(specs []runner.ReviewerSpec) bool {
 	for _, s := range specs {
-		if s.Phase == "arch" {
+		if s.Phase == domain.PhaseArch {
 			return true
 		}
 	}
@@ -837,15 +837,15 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 	switch phaseStr {
 	case "small":
 		return []runner.PhaseConfig{
-			{Phase: "diff", ReviewerCount: totalReviewers},
+			{Phase: domain.PhaseDiff, ReviewerCount: totalReviewers},
 		}, nil
 	case "medium":
 		if totalReviewers < 2 {
 			return nil, fmt.Errorf("phase %q requires >= 2 reviewers (1 arch + >= 1 diff), got %d", phaseStr, totalReviewers)
 		}
 		return []runner.PhaseConfig{
-			{Phase: "arch", ReviewerCount: 1},
-			{Phase: "diff", ReviewerCount: totalReviewers - 1},
+			{Phase: domain.PhaseArch, ReviewerCount: 1},
+			{Phase: domain.PhaseDiff, ReviewerCount: totalReviewers - 1},
 		}, nil
 	default:
 		return nil, fmt.Errorf("unknown phase %q (valid: small, medium)", phaseStr)
@@ -957,7 +957,7 @@ func buildCrossCheckContext(findings []domain.AggregatedFinding, specs []runner.
 			GroupKey:    s.GroupKey,
 			Phase:       s.Phase,
 			TargetFiles: s.TargetFiles,
-			FullDiff:    s.Phase == "arch",
+			FullDiff:    s.Phase == domain.PhaseArch,
 		})
 	}
 
@@ -1209,7 +1209,7 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 	}
 	cliRevModel, legacyRevModel := cliOrLegacy(opts.ReviewerModel, opts.ReviewerModelFromCLI)
 	archSpec := modelconfig.ResolveReviewer(
-		opts.Models, sizeStr, "arch", archAgentName,
+		opts.Models, sizeStr, domain.PhaseArch, archAgentName,
 		cliRevModel, "",
 		legacyRevModel, "",
 	)
@@ -1232,7 +1232,7 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 	diffAgents := make([]agent.Agent, 0, len(diffAgentNames))
 	for _, name := range diffAgentNames {
 		spec := modelconfig.ResolveReviewer(
-			opts.Models, sizeStr, "diff", name,
+			opts.Models, sizeStr, domain.PhaseDiff, name,
 			cliRevModel, "",
 			legacyRevModel, "",
 		)
@@ -1272,7 +1272,7 @@ func logPerPhaseModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr st
 		archName = opts.ReviewerAgents[0]
 	}
 	archSpec := modelconfig.ResolveReviewer(
-		opts.Models, sizeStr, "arch", archName,
+		opts.Models, sizeStr, domain.PhaseArch, archName,
 		cliRevModelLog, "",
 		legacyRevModelLog, "",
 	)
@@ -1286,7 +1286,7 @@ func logPerPhaseModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr st
 	}
 	for _, name := range diffNames {
 		diffSpec := modelconfig.ResolveReviewer(
-			opts.Models, sizeStr, "diff", name,
+			opts.Models, sizeStr, domain.PhaseDiff, name,
 			cliRevModelLog, "",
 			legacyRevModelLog, "",
 		)
@@ -1363,8 +1363,8 @@ func buildGroupedDiffSpecs(
 	specs = append(specs, runner.ReviewerSpec{
 		ReviewerID:      1,
 		Agent:           archAgent,
-		Phase:           "arch",
-		GroupKey:        "arch",
+		Phase:           domain.PhaseArch,
+		GroupKey:        domain.PhaseArch,
 		Guidance:        guidance,
 		Diff:            fullDiff,
 		DiffPrecomputed: diffPrecomputed,
@@ -1393,7 +1393,7 @@ func buildGroupedDiffSpecs(
 		specs = append(specs, runner.ReviewerSpec{
 			ReviewerID:      reviewerID,
 			Agent:           diffAgent,
-			Phase:           "diff",
+			Phase:           domain.PhaseDiff,
 			GroupKey:        group.Key,
 			Guidance:        guidance,
 			Diff:            groupDiff,
@@ -1431,8 +1431,8 @@ func buildMediumDiffSpecs(
 	specs = append(specs, runner.ReviewerSpec{
 		ReviewerID:      1,
 		Agent:           archAgent,
-		Phase:           "arch",
-		GroupKey:        "arch",
+		Phase:           domain.PhaseArch,
+		GroupKey:        domain.PhaseArch,
 		Guidance:        guidance,
 		Diff:            fullDiff,
 		DiffPrecomputed: diffPrecomputed,
@@ -1454,7 +1454,7 @@ func buildMediumDiffSpecs(
 		specs = append(specs, runner.ReviewerSpec{
 			ReviewerID:      reviewerID,
 			Agent:           diffAgent,
-			Phase:           "diff",
+			Phase:           domain.PhaseDiff,
 			GroupKey:        group.Key,
 			Guidance:        guidance,
 			Diff:            groupDiff,

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -764,7 +764,7 @@ func shouldUseAutoPhase(opts ReviewOpts) bool {
 	return opts.AutoPhase && opts.Phase == ""
 }
 
-// specsHaveArch returns true if any spec in the slice has Phase "arch".
+// specsHaveArch returns true if any spec in the slice has Phase domain.PhaseArch.
 func specsHaveArch(specs []runner.ReviewerSpec) bool {
 	for _, s := range specs {
 		if s.Phase == domain.PhaseArch {

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -1337,29 +1337,20 @@ func logCrossCheckModelMatrix(logger *terminal.Logger, opts ReviewOpts, sizeStr 
 // dedicated `large_diff_reviewers` knob, capped at the actual file count so that
 // every group has at least 1 file.
 //
-// archAgent and diffAgents are independent so per-phase reviewer overrides
-// (arch_reviewer_agent / diff_reviewer_agents) can route phases to different
-// agent backends.
-func buildGroupedDiffSpecs(
+// buildDiffSpecsCore builds ReviewerSpecs from pre-grouped diff sections.
+// It creates one arch spec (full diff) followed by one diff spec per group.
+// When skipEmptyGroups is true, groups whose joined diff is empty are silently
+// skipped; otherwise an error is returned.
+func buildDiffSpecsCore(
+	groups []git.DiffGroup,
 	fullDiff, guidance string,
 	diffPrecomputed bool,
 	archAgent agent.Agent,
 	diffAgents []agent.Agent,
-	maxDiffGroups int,
+	skipEmptyGroups bool,
 ) ([]runner.ReviewerSpec, error) {
-	sections := git.ParseDiffSections(fullDiff)
-	if len(sections) == 0 {
-		return nil, fmt.Errorf("no diff sections found in precomputed diff")
-	}
-
-	groups := git.GroupDiffSections(sections, 0, 0, maxDiffGroups)
-	if len(groups) == 0 {
-		return nil, fmt.Errorf("grouping produced no groups")
-	}
-
 	specs := make([]runner.ReviewerSpec, 0, 1+len(groups))
 
-	// 1. Arch reviewer: full diff (ReviewerID=1)
 	specs = append(specs, runner.ReviewerSpec{
 		ReviewerID:      1,
 		Agent:           archAgent,
@@ -1370,18 +1361,14 @@ func buildGroupedDiffSpecs(
 		DiffPrecomputed: diffPrecomputed,
 	})
 
-	// 2. Per-group diff reviewers (ReviewerID=2, 3, ...)
-	// Compute ReviewerID once per non-skipped group so spec ordering and the
-	// diff-phase agent round-robin stay in lockstep (empty groups skip both
-	// counters together). diffReviewerIdx is 1-based per AgentForReviewer's
-	// contract; the 1st surviving diff group always uses diffAgents[0].
 	diffReviewerIdx := 0
 	for _, group := range groups {
 		groupDiff := git.JoinDiffSections(group.Sections)
 		if groupDiff == "" {
-			// Empty group diff after splitting precomputed diff is unexpected.
-			// Skip (budget adjusts accordingly).
-			continue
+			if skipEmptyGroups {
+				continue
+			}
+			return nil, fmt.Errorf("diff split: group %q produced empty diff from %d section(s)", group.Key, len(group.Sections))
 		}
 		var targetFiles []string
 		for _, s := range group.Sections {
@@ -1405,6 +1392,27 @@ func buildGroupedDiffSpecs(
 	return specs, nil
 }
 
+// archAgent and diffAgents are independent so per-phase reviewer overrides
+// (arch_reviewer_agent / diff_reviewer_agents) can route phases to different
+// agent backends.
+func buildGroupedDiffSpecs(
+	fullDiff, guidance string,
+	diffPrecomputed bool,
+	archAgent agent.Agent,
+	diffAgents []agent.Agent,
+	maxDiffGroups int,
+) ([]runner.ReviewerSpec, error) {
+	sections := git.ParseDiffSections(fullDiff)
+	if len(sections) == 0 {
+		return nil, fmt.Errorf("no diff sections found in precomputed diff")
+	}
+	groups := git.GroupDiffSections(sections, 0, 0, maxDiffGroups)
+	if len(groups) == 0 {
+		return nil, fmt.Errorf("grouping produced no groups")
+	}
+	return buildDiffSpecsCore(groups, fullDiff, guidance, diffPrecomputed, archAgent, diffAgents, true)
+}
+
 func buildMediumDiffSpecs(
 	fullDiff, guidance string,
 	diffPrecomputed bool,
@@ -1419,51 +1427,12 @@ func buildMediumDiffSpecs(
 	if len(sections) < 2 {
 		return nil, nil
 	}
-
 	maxFilesPerGroup := (len(sections) + mediumDiffReviewers - 1) / mediumDiffReviewers
 	groups := git.GroupDiffSections(sections, maxFilesPerGroup, 0, mediumDiffReviewers)
 	if len(groups) < 2 {
 		return nil, nil
 	}
-
-	specs := make([]runner.ReviewerSpec, 0, 1+len(groups))
-
-	specs = append(specs, runner.ReviewerSpec{
-		ReviewerID:      1,
-		Agent:           archAgent,
-		Phase:           domain.PhaseArch,
-		GroupKey:        domain.PhaseArch,
-		Guidance:        guidance,
-		Diff:            fullDiff,
-		DiffPrecomputed: diffPrecomputed,
-	})
-
-	diffReviewerIdx := 0
-	for _, group := range groups {
-		groupDiff := git.JoinDiffSections(group.Sections)
-		if groupDiff == "" {
-			return nil, fmt.Errorf("medium diff split: group %q produced empty diff from %d section(s)", group.Key, len(group.Sections))
-		}
-		var targetFiles []string
-		for _, s := range group.Sections {
-			targetFiles = append(targetFiles, s.FilePath)
-		}
-		reviewerID := len(specs) + 1
-		diffReviewerIdx++
-		diffAgent := agent.AgentForReviewer(diffAgents, diffReviewerIdx)
-		specs = append(specs, runner.ReviewerSpec{
-			ReviewerID:      reviewerID,
-			Agent:           diffAgent,
-			Phase:           domain.PhaseDiff,
-			GroupKey:        group.Key,
-			Guidance:        guidance,
-			Diff:            groupDiff,
-			DiffPrecomputed: true,
-			TargetFiles:     targetFiles,
-		})
-	}
-
-	return specs, nil
+	return buildDiffSpecsCore(groups, fullDiff, guidance, diffPrecomputed, archAgent, diffAgents, false)
 }
 
 // diffFindingGroups returns groups present in before but not in after.

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -27,21 +27,21 @@ func TestParsePhases(t *testing.T) {
 			name:      "small with 1 reviewer",
 			phaseStr:  "small",
 			reviewers: 1,
-			want:      []runner.PhaseConfig{{Phase: "diff", ReviewerCount: 1}},
+			want:      []runner.PhaseConfig{{Phase: domain.PhaseDiff, ReviewerCount: 1}},
 		},
 		{
 			name:      "small with 3 reviewers",
 			phaseStr:  "small",
 			reviewers: 3,
-			want:      []runner.PhaseConfig{{Phase: "diff", ReviewerCount: 3}},
+			want:      []runner.PhaseConfig{{Phase: domain.PhaseDiff, ReviewerCount: 3}},
 		},
 		{
 			name:      "medium with 3 reviewers",
 			phaseStr:  "medium",
 			reviewers: 3,
 			want: []runner.PhaseConfig{
-				{Phase: "arch", ReviewerCount: 1},
-				{Phase: "diff", ReviewerCount: 2},
+				{Phase: domain.PhaseArch, ReviewerCount: 1},
+				{Phase: domain.PhaseDiff, ReviewerCount: 2},
 			},
 		},
 		{
@@ -49,8 +49,8 @@ func TestParsePhases(t *testing.T) {
 			phaseStr:  "medium",
 			reviewers: 2,
 			want: []runner.PhaseConfig{
-				{Phase: "arch", ReviewerCount: 1},
-				{Phase: "diff", ReviewerCount: 1},
+				{Phase: domain.PhaseArch, ReviewerCount: 1},
+				{Phase: domain.PhaseDiff, ReviewerCount: 1},
 			},
 		},
 		{
@@ -151,10 +151,10 @@ func TestBuildGroupedDiffSpecs_BasicGroups(t *testing.T) {
 	}
 
 	// First spec is arch
-	if specs[0].Phase != "arch" {
+	if specs[0].Phase != domain.PhaseArch {
 		t.Errorf("specs[0].Phase = %q, want %q", specs[0].Phase, "arch")
 	}
-	if specs[0].GroupKey != "arch" {
+	if specs[0].GroupKey != domain.PhaseArch {
 		t.Errorf("specs[0].GroupKey = %q, want %q", specs[0].GroupKey, "arch")
 	}
 }
@@ -169,11 +169,11 @@ func TestBuildGroupedDiffSpecs_GroupKeysAssigned(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if specs[0].GroupKey != "arch" {
+	if specs[0].GroupKey != domain.PhaseArch {
 		t.Errorf("specs[0].GroupKey = %q, want %q", specs[0].GroupKey, "arch")
 	}
 	for i := 1; i < len(specs); i++ {
-		if specs[i].Phase != "diff" {
+		if specs[i].Phase != domain.PhaseDiff {
 			t.Errorf("specs[%d].Phase = %q, want %q", i, specs[i].Phase, "diff")
 		}
 		if specs[i].GroupKey == "" {
@@ -312,9 +312,9 @@ func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 
 func TestBuildCrossCheckContext_GroupTopology(t *testing.T) {
 	specs := []runner.ReviewerSpec{
-		{ReviewerID: 1, Phase: "arch", GroupKey: "arch"},
-		{ReviewerID: 2, Phase: "diff", GroupKey: "g01", TargetFiles: []string{"a.go"}},
-		{ReviewerID: 3, Phase: "diff", GroupKey: "g02", TargetFiles: []string{"b.go"}},
+		{ReviewerID: 1, Phase: domain.PhaseArch, GroupKey: domain.PhaseArch},
+		{ReviewerID: 2, Phase: domain.PhaseDiff, GroupKey: "g01", TargetFiles: []string{"a.go"}},
+		{ReviewerID: 3, Phase: domain.PhaseDiff, GroupKey: "g02", TargetFiles: []string{"b.go"}},
 	}
 	rawFindings := []domain.Finding{
 		{Text: "issue", ReviewerID: 2, GroupKey: "g01"},
@@ -331,7 +331,7 @@ func TestBuildCrossCheckContext_GroupTopology(t *testing.T) {
 	if len(ccCtx.Groups) != 3 {
 		t.Fatalf("expected 3 groups, got %d", len(ccCtx.Groups))
 	}
-	if ccCtx.Groups[0].GroupKey != "arch" || !ccCtx.Groups[0].FullDiff {
+	if ccCtx.Groups[0].GroupKey != domain.PhaseArch || !ccCtx.Groups[0].FullDiff {
 		t.Errorf("expected arch group with FullDiff=true, got %+v", ccCtx.Groups[0])
 	}
 	if ccCtx.Groups[1].GroupKey != "g01" || ccCtx.Groups[1].FullDiff {
@@ -352,8 +352,8 @@ func TestBuildCrossCheckContext_GroupTopology(t *testing.T) {
 
 func TestBuildCrossCheckContext_DedupGroupKey(t *testing.T) {
 	specs := []runner.ReviewerSpec{
-		{Phase: "arch", GroupKey: "arch"},
-		{Phase: "arch", GroupKey: "arch"}, // duplicate key
+		{Phase: domain.PhaseArch, GroupKey: domain.PhaseArch},
+		{Phase: domain.PhaseArch, GroupKey: domain.PhaseArch}, // duplicate key
 	}
 	results := []domain.ReviewerResult{
 		{ReviewerID: 1, ExitCode: 0},
@@ -382,9 +382,9 @@ func TestReviewPipeline_CrossCheckUsesAggregatedIDs(t *testing.T) {
 	}
 
 	specs := []runner.ReviewerSpec{
-		{Phase: "arch", GroupKey: "arch"},
-		{Phase: "diff", GroupKey: "g01", TargetFiles: []string{"a.go"}},
-		{Phase: "diff", GroupKey: "g02", TargetFiles: []string{"b.go"}},
+		{Phase: domain.PhaseArch, GroupKey: domain.PhaseArch},
+		{Phase: domain.PhaseDiff, GroupKey: "g01", TargetFiles: []string{"a.go"}},
+		{Phase: domain.PhaseDiff, GroupKey: "g02", TargetFiles: []string{"b.go"}},
 	}
 	results := []domain.ReviewerResult{
 		{ReviewerID: 1, ExitCode: 0, Findings: []domain.Finding{raw[0]}},
@@ -668,7 +668,7 @@ func TestLargeReview_GroupedSpecsProduceCrossCheckableTopology(t *testing.T) {
 	if !apr.UseGrouped {
 		t.Fatal("expected UseGrouped=true for large diff with large_diff_reviewers=3")
 	}
-	if apr.GroupedSpecs[0].GroupKey != "arch" {
+	if apr.GroupedSpecs[0].GroupKey != domain.PhaseArch {
 		t.Errorf("expected first spec GroupKey=arch, got %q", apr.GroupedSpecs[0].GroupKey)
 	}
 	seen := map[string]bool{}
@@ -691,12 +691,12 @@ func TestBuildCrossCheckContext_UsesSpecReviewerID(t *testing.T) {
 	// Specs in shuffled order with non-sequential explicit ReviewerIDs.
 	// ID 7 → "g02", ID 3 → "arch", ID 5 → "g01"
 	specs := []runner.ReviewerSpec{
-		{ReviewerID: 7, Phase: "diff", GroupKey: "g02", TargetFiles: []string{"b.go"}},
-		{ReviewerID: 3, Phase: "arch", GroupKey: "arch"},
-		{ReviewerID: 5, Phase: "diff", GroupKey: "g01", TargetFiles: []string{"a.go"}},
+		{ReviewerID: 7, Phase: domain.PhaseDiff, GroupKey: "g02", TargetFiles: []string{"b.go"}},
+		{ReviewerID: 3, Phase: domain.PhaseArch, GroupKey: domain.PhaseArch},
+		{ReviewerID: 5, Phase: domain.PhaseDiff, GroupKey: "g01", TargetFiles: []string{"a.go"}},
 	}
 	rawFindings := []domain.Finding{
-		{Text: "arch issue", ReviewerID: 3, GroupKey: "arch"},
+		{Text: "arch issue", ReviewerID: 3, GroupKey: domain.PhaseArch},
 		{Text: "g01 issue", ReviewerID: 5, GroupKey: "g01"},
 	}
 	aggregated := domain.AggregateFindings(rawFindings)
@@ -722,7 +722,7 @@ func TestBuildCrossCheckContext_UsesSpecReviewerID(t *testing.T) {
 		outcomeByKey[g.GroupKey] = i
 	}
 
-	archIdx, ok := outcomeByKey["arch"]
+	archIdx, ok := outcomeByKey[domain.PhaseArch]
 	if !ok {
 		t.Fatal("arch group missing from cross-check context")
 	}
@@ -1770,7 +1770,7 @@ func TestBuildMediumDiffSpecs_BasicSplit(t *testing.T) {
 		t.Fatalf("expected 3 specs (1 arch + 2 diff), got %d", len(specs))
 	}
 
-	if specs[0].Phase != "arch" {
+	if specs[0].Phase != domain.PhaseArch {
 		t.Errorf("specs[0].Phase = %q, want %q", specs[0].Phase, "arch")
 	}
 	if specs[0].Diff != fullDiff {
@@ -1779,17 +1779,17 @@ func TestBuildMediumDiffSpecs_BasicSplit(t *testing.T) {
 	if specs[0].DiffPrecomputed != true {
 		t.Errorf("specs[0].DiffPrecomputed = %v, want true", specs[0].DiffPrecomputed)
 	}
-	if specs[0].GroupKey != "arch" {
+	if specs[0].GroupKey != domain.PhaseArch {
 		t.Errorf("specs[0].GroupKey = %q, want %q", specs[0].GroupKey, "arch")
 	}
 	if specs[0].Guidance != "test guidance" {
 		t.Errorf("specs[0].Guidance = %q, want %q", specs[0].Guidance, "test guidance")
 	}
 
-	if specs[1].Phase != "diff" {
+	if specs[1].Phase != domain.PhaseDiff {
 		t.Errorf("specs[1].Phase = %q, want %q", specs[1].Phase, "diff")
 	}
-	if specs[2].Phase != "diff" {
+	if specs[2].Phase != domain.PhaseDiff {
 		t.Errorf("specs[2].Phase = %q, want %q", specs[2].Phase, "diff")
 	}
 	if specs[1].Diff == specs[2].Diff {

--- a/internal/agent/diff_review.go
+++ b/internal/agent/diff_review.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/git"
 )
 
@@ -30,14 +31,14 @@ type diffReviewConfig struct {
 func resolvePrompts(config *ReviewConfig, dc *diffReviewConfig) {
 	if config.Phase != "" && config.RolePrompts && config.HasArchReviewer {
 		switch config.Phase {
-		case "arch":
+		case domain.PhaseArch:
 			dc.DefaultPrompt = AutoPhaseArchPrompt
 			dc.RefFilePrompt = AutoPhaseArchRefFilePrompt
 		default:
 			dc.DefaultPrompt = AutoPhaseDiffPrompt
 			dc.RefFilePrompt = AutoPhaseDiffRefFilePrompt
 		}
-	} else if config.Phase == "arch" {
+	} else if config.Phase == domain.PhaseArch {
 		dc.DefaultPrompt = DefaultArchPrompt
 	}
 }

--- a/internal/agent/diff_review_test.go
+++ b/internal/agent/diff_review_test.go
@@ -1,9 +1,13 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
 
 func TestResolvePrompts_RolePromptsEnabled_ArchPhase(t *testing.T) {
-	config := &ReviewConfig{Phase: "arch", RolePrompts: true, HasArchReviewer: true}
+	config := &ReviewConfig{Phase: domain.PhaseArch, RolePrompts: true, HasArchReviewer: true}
 	dc := diffReviewConfig{
 		DefaultPrompt: DefaultClaudePrompt,
 		RefFilePrompt: DefaultClaudeRefFilePrompt,
@@ -19,7 +23,7 @@ func TestResolvePrompts_RolePromptsEnabled_ArchPhase(t *testing.T) {
 
 func TestResolvePrompts_RolePromptsEnabled_DiffPhase(t *testing.T) {
 	// arch reviewer が存在する場合のみ AutoPhaseDiffPrompt に切替
-	config := &ReviewConfig{Phase: "diff", RolePrompts: true, HasArchReviewer: true}
+	config := &ReviewConfig{Phase: domain.PhaseDiff, RolePrompts: true, HasArchReviewer: true}
 	dc := diffReviewConfig{
 		DefaultPrompt: DefaultClaudePrompt,
 		RefFilePrompt: DefaultClaudeRefFilePrompt,
@@ -35,7 +39,7 @@ func TestResolvePrompts_RolePromptsEnabled_DiffPhase(t *testing.T) {
 
 func TestResolvePrompts_RolePromptsEnabled_DiffPhase_NoArch(t *testing.T) {
 	// arch reviewer なし → RolePrompts を適用しない (レガシーのまま)
-	config := &ReviewConfig{Phase: "diff", RolePrompts: true, HasArchReviewer: false}
+	config := &ReviewConfig{Phase: domain.PhaseDiff, RolePrompts: true, HasArchReviewer: false}
 	dc := diffReviewConfig{
 		DefaultPrompt: DefaultClaudePrompt,
 		RefFilePrompt: DefaultClaudeRefFilePrompt,
@@ -65,7 +69,7 @@ func TestResolvePrompts_RolePromptsEnabled_NoPhase(t *testing.T) {
 }
 
 func TestResolvePrompts_RolePromptsDisabled_ArchPhase(t *testing.T) {
-	config := &ReviewConfig{Phase: "arch", RolePrompts: false}
+	config := &ReviewConfig{Phase: domain.PhaseArch, RolePrompts: false}
 	dc := diffReviewConfig{
 		DefaultPrompt: DefaultClaudePrompt,
 		RefFilePrompt: DefaultClaudeRefFilePrompt,
@@ -81,7 +85,7 @@ func TestResolvePrompts_RolePromptsDisabled_ArchPhase(t *testing.T) {
 }
 
 func TestResolvePrompts_RolePromptsDisabled_DiffPhase(t *testing.T) {
-	config := &ReviewConfig{Phase: "diff", RolePrompts: false}
+	config := &ReviewConfig{Phase: domain.PhaseDiff, RolePrompts: false}
 	dc := diffReviewConfig{
 		DefaultPrompt: DefaultClaudePrompt,
 		RefFilePrompt: DefaultClaudeRefFilePrompt,

--- a/internal/domain/finding.go
+++ b/internal/domain/finding.go
@@ -18,10 +18,12 @@ type Finding struct {
 
 // AggregatedFinding represents a finding with the list of reviewers who found it.
 type AggregatedFinding struct {
-	Text      string
-	Reviewers []int
-	Severity  string // first-seen severity from grouped findings
-	GroupKey  string // group key(s), comma-separated if from multiple groups
+	Text          string
+	Reviewers     []int
+	ArchReviewers []int  `json:"arch_reviewers,omitempty"`
+	DiffReviewers []int  `json:"diff_reviewers,omitempty"`
+	Severity      string // first-seen severity from grouped findings
+	GroupKey      string // group key(s), comma-separated if from multiple groups
 }
 
 // FindingGroup represents a grouped/clustered finding from the summarizer.
@@ -226,6 +228,8 @@ func AggregateFindings(findings []Finding) []AggregatedFinding {
 	seen := make(map[string][]int)
 	severities := make(map[string]string)
 	groupKeyTokens := make(map[string]map[string]struct{})
+	archRevs := make(map[string][]int)
+	diffRevs := make(map[string][]int)
 	order := make([]string, 0)
 
 	for _, f := range findings {
@@ -257,6 +261,14 @@ func AggregateFindings(findings []Finding) []AggregatedFinding {
 		}
 		if !found {
 			seen[normalized] = append(reviewers, f.ReviewerID)
+			switch f.Phase {
+			case PhaseArch:
+				archRevs[normalized] = append(archRevs[normalized], f.ReviewerID)
+			case PhaseDiff:
+				diffRevs[normalized] = append(diffRevs[normalized], f.ReviewerID)
+			default:
+				diffRevs[normalized] = append(diffRevs[normalized], f.ReviewerID)
+			}
 		}
 	}
 
@@ -270,11 +282,17 @@ func AggregateFindings(findings []Finding) []AggregatedFinding {
 			tokens = append(tokens, tok)
 		}
 		slices.Sort(tokens)
+		sortedArch := slices.Clone(archRevs[text])
+		slices.Sort(sortedArch)
+		sortedDiff := slices.Clone(diffRevs[text])
+		slices.Sort(sortedDiff)
 		result = append(result, AggregatedFinding{
-			Text:      text,
-			Reviewers: sortedReviewers,
-			Severity:  severities[text],
-			GroupKey:  strings.Join(tokens, ","),
+			Text:          text,
+			Reviewers:     sortedReviewers,
+			ArchReviewers: sortedArch,
+			DiffReviewers: sortedDiff,
+			Severity:      severities[text],
+			GroupKey:       strings.Join(tokens, ","),
 		})
 	}
 

--- a/internal/domain/finding.go
+++ b/internal/domain/finding.go
@@ -292,7 +292,7 @@ func AggregateFindings(findings []Finding) []AggregatedFinding {
 			ArchReviewers: sortedArch,
 			DiffReviewers: sortedDiff,
 			Severity:      severities[text],
-			GroupKey:       strings.Join(tokens, ","),
+			GroupKey:      strings.Join(tokens, ","),
 		})
 	}
 

--- a/internal/domain/finding.go
+++ b/internal/domain/finding.go
@@ -196,9 +196,9 @@ func BackfillPhaseReviewerCounts(
 				}
 				for _, rid := range aggregated[srcIdx].Reviewers {
 					switch reviewerPhases[rid] {
-					case "arch":
+					case PhaseArch:
 						archSet[rid] = struct{}{}
-					case "diff":
+					case PhaseDiff:
 						diffSet[rid] = struct{}{}
 					}
 				}

--- a/internal/domain/finding_test.go
+++ b/internal/domain/finding_test.go
@@ -386,7 +386,7 @@ func TestBackfillPhaseReviewerCounts_ArchOnly(t *testing.T) {
 			{Sources: []int{0}},
 		},
 	}
-	reviewerPhases := map[int]string{1: "arch"}
+	reviewerPhases := map[int]string{1: PhaseArch}
 
 	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
 
@@ -408,7 +408,7 @@ func TestBackfillPhaseReviewerCounts_DiffOnly(t *testing.T) {
 			{Sources: []int{0}},
 		},
 	}
-	reviewerPhases := map[int]string{2: "diff"}
+	reviewerPhases := map[int]string{2: PhaseDiff}
 
 	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
 
@@ -431,7 +431,7 @@ func TestBackfillPhaseReviewerCounts_Mixed(t *testing.T) {
 			{Sources: []int{0, 1}},
 		},
 	}
-	reviewerPhases := map[int]string{1: "arch", 2: "diff", 3: "diff"}
+	reviewerPhases := map[int]string{1: PhaseArch, 2: PhaseDiff, 3: PhaseDiff}
 
 	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
 
@@ -456,7 +456,7 @@ func TestBackfillPhaseReviewerCounts_DeduplicatesReviewerIDs(t *testing.T) {
 			{Sources: []int{0, 1}},
 		},
 	}
-	reviewerPhases := map[int]string{1: "arch"}
+	reviewerPhases := map[int]string{1: PhaseArch}
 
 	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
 
@@ -478,7 +478,7 @@ func TestBackfillPhaseReviewerCounts_EmptySources(t *testing.T) {
 			{Sources: []int{}},
 		},
 	}
-	reviewerPhases := map[int]string{1: "arch"}
+	reviewerPhases := map[int]string{1: PhaseArch}
 
 	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
 
@@ -500,7 +500,7 @@ func TestBackfillPhaseReviewerCounts_OutOfRangeIndex(t *testing.T) {
 			{Sources: []int{-1, 5, 100}},
 		},
 	}
-	reviewerPhases := map[int]string{1: "arch"}
+	reviewerPhases := map[int]string{1: PhaseArch}
 
 	// Must not panic
 	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
@@ -548,7 +548,7 @@ func TestBackfillPhaseReviewerCounts_InfoGroups(t *testing.T) {
 			{Sources: []int{1}},
 		},
 	}
-	reviewerPhases := map[int]string{1: "arch", 2: "diff"}
+	reviewerPhases := map[int]string{1: PhaseArch, 2: PhaseDiff}
 
 	BackfillPhaseReviewerCounts(grouped, aggregated, reviewerPhases)
 

--- a/internal/domain/finding_test.go
+++ b/internal/domain/finding_test.go
@@ -633,3 +633,12 @@ func TestAggregateFindings_PerPhaseReviewers_FlatReview(t *testing.T) {
 		t.Errorf("DiffReviewers = %v, want [1, 2]", agg[0].DiffReviewers)
 	}
 }
+
+func TestPhaseConstants_WireContract(t *testing.T) {
+	if PhaseArch != "arch" {
+		t.Errorf("PhaseArch = %q, wire contract requires %q", PhaseArch, "arch")
+	}
+	if PhaseDiff != "diff" {
+		t.Errorf("PhaseDiff = %q, wire contract requires %q", PhaseDiff, "diff")
+	}
+}

--- a/internal/domain/finding_test.go
+++ b/internal/domain/finding_test.go
@@ -598,3 +598,38 @@ func TestFindingGroup_JSON_IncludesNonZeroPhaseReviewerCounts(t *testing.T) {
 		t.Errorf("expected diff_reviewer_count:2 in JSON; got %s", s)
 	}
 }
+
+func TestAggregateFindings_PerPhaseReviewers(t *testing.T) {
+	findings := []Finding{
+		{Text: "bug", ReviewerID: 1, Phase: PhaseArch},
+		{Text: "bug", ReviewerID: 2, Phase: PhaseDiff},
+		{Text: "bug", ReviewerID: 3, Phase: PhaseDiff},
+	}
+	agg := AggregateFindings(findings)
+	if len(agg) != 1 {
+		t.Fatalf("got %d findings, want 1", len(agg))
+	}
+	if len(agg[0].ArchReviewers) != 1 || agg[0].ArchReviewers[0] != 1 {
+		t.Errorf("ArchReviewers = %v, want [1]", agg[0].ArchReviewers)
+	}
+	if len(agg[0].DiffReviewers) != 2 {
+		t.Errorf("DiffReviewers = %v, want [2, 3]", agg[0].DiffReviewers)
+	}
+}
+
+func TestAggregateFindings_PerPhaseReviewers_FlatReview(t *testing.T) {
+	findings := []Finding{
+		{Text: "bug", ReviewerID: 1, Phase: ""},
+		{Text: "bug", ReviewerID: 2, Phase: ""},
+	}
+	agg := AggregateFindings(findings)
+	if len(agg) != 1 {
+		t.Fatalf("got %d findings, want 1", len(agg))
+	}
+	if len(agg[0].ArchReviewers) != 0 {
+		t.Errorf("ArchReviewers = %v, want empty", agg[0].ArchReviewers)
+	}
+	if len(agg[0].DiffReviewers) != 2 {
+		t.Errorf("DiffReviewers = %v, want [1, 2]", agg[0].DiffReviewers)
+	}
+}

--- a/internal/domain/phase.go
+++ b/internal/domain/phase.go
@@ -1,5 +1,7 @@
 package domain
 
+// Phase constants are wire-contract values used in JSON output, group keys,
+// prompt routing, and model config resolution. Do not change these values.
 const (
 	PhaseArch = "arch"
 	PhaseDiff = "diff"

--- a/internal/domain/phase.go
+++ b/internal/domain/phase.go
@@ -1,0 +1,6 @@
+package domain
+
+const (
+	PhaseArch = "arch"
+	PhaseDiff = "diff"
+)

--- a/internal/modelconfig/resolver.go
+++ b/internal/modelconfig/resolver.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 // Role constants for the supported agent roles.
@@ -95,9 +96,9 @@ func ResolveReviewer(
 ) Spec {
 	var primaryRole string
 	switch strings.ToLower(phase) {
-	case "arch":
+	case domain.PhaseArch:
 		primaryRole = RoleArchReviewer
-	case "diff":
+	case domain.PhaseDiff:
 		primaryRole = RoleDiffReviewer
 	default:
 		primaryRole = ""

--- a/internal/modelconfig/resolver_test.go
+++ b/internal/modelconfig/resolver_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/config"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 func ms(model, effort string) *config.ModelSpec {
@@ -217,7 +218,7 @@ func TestResolveReviewer(t *testing.T) {
 						ArchReviewer: ms("arch-m", "high"),
 					},
 				},
-				phase:     "arch",
+				phase:     domain.PhaseArch,
 				agentName: "codex",
 			},
 			want: Spec{Model: "arch-m", Effort: "high"},
@@ -230,7 +231,7 @@ func TestResolveReviewer(t *testing.T) {
 						Reviewer: ms("gen", "med"),
 					},
 				},
-				phase:     "arch",
+				phase:     domain.PhaseArch,
 				agentName: "codex",
 			},
 			want: Spec{Model: "gen", Effort: "med"},
@@ -244,7 +245,7 @@ func TestResolveReviewer(t *testing.T) {
 						DiffReviewer: ms("diff-m", "low"),
 					},
 				},
-				phase:     "diff",
+				phase:     domain.PhaseDiff,
 				agentName: "codex",
 			},
 			want: Spec{Model: "diff-m", Effort: "low"},
@@ -258,7 +259,7 @@ func TestResolveReviewer(t *testing.T) {
 						ArchReviewer: ms("arch-m", ""),
 					},
 				},
-				phase:     "arch",
+				phase:     domain.PhaseArch,
 				agentName: "codex",
 			},
 			want: Spec{Model: "arch-m", Effort: "med"},
@@ -274,7 +275,7 @@ func TestResolveReviewer(t *testing.T) {
 						"codex": {Reviewer: ms("codex-gen", "med")},
 					},
 				},
-				phase:     "arch",
+				phase:     domain.PhaseArch,
 				agentName: "codex",
 			},
 			want: Spec{Model: "codex-gen", Effort: "med"},
@@ -290,7 +291,7 @@ func TestResolveReviewer(t *testing.T) {
 						},
 					},
 				},
-				phase:     "arch",
+				phase:     domain.PhaseArch,
 				agentName: "codex",
 			},
 			want: Spec{Model: "codex-arch", Effort: "high"},
@@ -307,7 +308,7 @@ func TestResolveReviewer(t *testing.T) {
 					},
 				},
 				size:      "large",
-				phase:     "diff",
+				phase:     domain.PhaseDiff,
 				agentName: "codex",
 			},
 			want: Spec{Model: "large-diff", Effort: "high"},
@@ -316,7 +317,7 @@ func TestResolveReviewer(t *testing.T) {
 			name: "legacy fields fall back for generic reviewer only (no phase match)",
 			args: args{
 				cfgModels:    config.ModelsConfig{},
-				phase:        "arch",
+				phase:        domain.PhaseArch,
 				agentName:    "codex",
 				legacyModel:  "legacy-m",
 				legacyEffort: "legacy-e",
@@ -331,7 +332,7 @@ func TestResolveReviewer(t *testing.T) {
 						ArchReviewer: ms("arch-m", "high"),
 					},
 				},
-				phase:     "arch",
+				phase:     domain.PhaseArch,
 				agentName: "codex",
 				cliModel:  "cli-m",
 				cliEffort: "cli-e",
@@ -352,7 +353,7 @@ func TestResolveReviewer(t *testing.T) {
 						},
 					},
 				},
-				phase:     "arch",
+				phase:     domain.PhaseArch,
 				agentName: "codex",
 			},
 			want: Spec{Model: "codex-arch", Effort: "codex-effort"},

--- a/internal/runner/phase.go
+++ b/internal/runner/phase.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 // PhaseConfig defines a review phase and its parameters.
@@ -101,7 +102,7 @@ func BuildReviewerSpecs(phases []PhaseConfig, defaultAgents []agent.Agent, globa
 // Returns empty string for unknown phases (caller should fall back to global guidance).
 func defaultPromptForPhase(phase string) string {
 	switch phase {
-	case "arch":
+	case domain.PhaseArch:
 		return agent.DefaultArchPrompt
 	default:
 		return ""

--- a/internal/runner/phase_test.go
+++ b/internal/runner/phase_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 // mockPhaseAgent implements agent.Agent for phase testing.
@@ -29,8 +30,8 @@ func (m *mockPhaseAgent) Options() agent.AgentOptions {
 func TestBuildReviewerSpecs_ArchAndDiff(t *testing.T) {
 	agents := []agent.Agent{&mockPhaseAgent{name: "codex"}}
 	phases := []PhaseConfig{
-		{Phase: "arch", ReviewerCount: 1},
-		{Phase: "diff", ReviewerCount: 2},
+		{Phase: domain.PhaseArch, ReviewerCount: 1},
+		{Phase: domain.PhaseDiff, ReviewerCount: 2},
 	}
 
 	specs, err := BuildReviewerSpecs(phases, agents, "global guidance", "diff content", true)
@@ -42,7 +43,7 @@ func TestBuildReviewerSpecs_ArchAndDiff(t *testing.T) {
 	}
 
 	// First spec should be arch phase
-	if specs[0].Phase != "arch" {
+	if specs[0].Phase != domain.PhaseArch {
 		t.Errorf("specs[0].Phase = %q, want %q", specs[0].Phase, "arch")
 	}
 	// Arch phase guidance should be globalGuidance (prompt selection happens in execution path)
@@ -51,10 +52,10 @@ func TestBuildReviewerSpecs_ArchAndDiff(t *testing.T) {
 	}
 
 	// Remaining specs should be diff phase
-	if specs[1].Phase != "diff" {
+	if specs[1].Phase != domain.PhaseDiff {
 		t.Errorf("specs[1].Phase = %q, want %q", specs[1].Phase, "diff")
 	}
-	if specs[2].Phase != "diff" {
+	if specs[2].Phase != domain.PhaseDiff {
 		t.Errorf("specs[2].Phase = %q, want %q", specs[2].Phase, "diff")
 	}
 
@@ -72,7 +73,7 @@ func TestBuildReviewerSpecs_ArchAndDiff(t *testing.T) {
 func TestBuildReviewerSpecs_DefaultPrompt(t *testing.T) {
 	agents := []agent.Agent{&mockPhaseAgent{name: "codex"}}
 	phases := []PhaseConfig{
-		{Phase: "arch", ReviewerCount: 1},
+		{Phase: domain.PhaseArch, ReviewerCount: 1},
 	}
 
 	specs, err := BuildReviewerSpecs(phases, agents, "fallback", "", false)
@@ -89,7 +90,7 @@ func TestBuildReviewerSpecs_DefaultPrompt(t *testing.T) {
 func TestBuildReviewerSpecs_CustomPrompt(t *testing.T) {
 	agents := []agent.Agent{&mockPhaseAgent{name: "codex"}}
 	phases := []PhaseConfig{
-		{Phase: "arch", ReviewerCount: 1, Prompt: "custom arch prompt"},
+		{Phase: domain.PhaseArch, ReviewerCount: 1, Prompt: "custom arch prompt"},
 	}
 
 	specs, err := BuildReviewerSpecs(phases, agents, "fallback", "", false)
@@ -105,7 +106,7 @@ func TestBuildReviewerSpecs_CustomPrompt(t *testing.T) {
 func TestBuildReviewerSpecs_DiffPhaseUsesGlobalGuidance(t *testing.T) {
 	agents := []agent.Agent{&mockPhaseAgent{name: "codex"}}
 	phases := []PhaseConfig{
-		{Phase: "diff", ReviewerCount: 1},
+		{Phase: domain.PhaseDiff, ReviewerCount: 1},
 	}
 
 	specs, err := BuildReviewerSpecs(phases, agents, "global guidance", "", false)
@@ -130,7 +131,7 @@ func TestBuildReviewerSpecs_EmptyPhasesError(t *testing.T) {
 func TestBuildReviewerSpecs_ZeroReviewerCount(t *testing.T) {
 	agents := []agent.Agent{&mockPhaseAgent{name: "codex"}}
 	phases := []PhaseConfig{
-		{Phase: "arch", ReviewerCount: 0},
+		{Phase: domain.PhaseArch, ReviewerCount: 0},
 	}
 	_, err := BuildReviewerSpecs(phases, agents, "", "", false)
 	if err == nil {
@@ -143,8 +144,8 @@ func TestDefaultPromptForPhase(t *testing.T) {
 		phase     string
 		wantEmpty bool
 	}{
-		{"arch", false},
-		{"diff", true},
+		{domain.PhaseArch, false},
+		{domain.PhaseDiff, true},
 		{"", true},
 		{"unknown", true},
 	}
@@ -171,7 +172,7 @@ func TestDefaultPromptForPhase(t *testing.T) {
 func TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseModel(t *testing.T) {
 	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: ""}
 	phases := []PhaseConfig{
-		{Phase: "diff", ReviewerCount: 1, Effort: "high"},
+		{Phase: domain.PhaseDiff, ReviewerCount: 1, Effort: "high"},
 	}
 
 	specs, err := BuildReviewerSpecs(phases, []agent.Agent{base}, "", "", false)

--- a/internal/runner/report.go
+++ b/internal/runner/report.go
@@ -578,15 +578,31 @@ func formatRawFindings(aggregated []domain.AggregatedFinding, indices []int, sta
 		return ""
 	}
 
+	multiPhase := stats.ArchReviewers > 0 && stats.DiffReviewers > 0
+
 	var lines []string
 	for idx, src := range indices {
 		if src < 0 || src >= len(aggregated) {
 			continue
 		}
 		entry := aggregated[src]
-		reviewerCount := len(entry.Reviewers)
 		lines = append(lines, "")
-		lines = append(lines, fmt.Sprintf("%d. (%d/%d reviewers)", idx+1, reviewerCount, stats.TotalReviewers))
+		if multiPhase {
+			var parts []string
+			if len(entry.ArchReviewers) > 0 {
+				parts = append(parts, fmt.Sprintf("arch: %d/%d", len(entry.ArchReviewers), stats.ArchReviewers))
+			}
+			if len(entry.DiffReviewers) > 0 {
+				parts = append(parts, fmt.Sprintf("diff: %d/%d", len(entry.DiffReviewers), stats.DiffReviewers))
+			}
+			if len(parts) > 0 {
+				lines = append(lines, fmt.Sprintf("%d. (%s reviewers)", idx+1, strings.Join(parts, ", ")))
+			} else {
+				lines = append(lines, fmt.Sprintf("%d. (%d/%d reviewers)", idx+1, len(entry.Reviewers), stats.TotalReviewers))
+			}
+		} else {
+			lines = append(lines, fmt.Sprintf("%d. (%d/%d reviewers)", idx+1, len(entry.Reviewers), stats.TotalReviewers))
+		}
 		lines = append(lines, "```")
 		lines = append(lines, strings.TrimRight(entry.Text, " \n"))
 		lines = append(lines, "```")

--- a/internal/runner/report_test.go
+++ b/internal/runner/report_test.go
@@ -114,6 +114,36 @@ func TestFormatRawFindings_TrimsTrailingWhitespace(t *testing.T) {
 	}
 }
 
+func TestFormatRawFindings_PerPhaseDisplay(t *testing.T) {
+	aggregated := []domain.AggregatedFinding{
+		{Text: "bug in auth", Reviewers: []int{1, 2}, ArchReviewers: []int{1}, DiffReviewers: []int{2}},
+	}
+	stats := domain.ReviewStats{TotalReviewers: 3, ArchReviewers: 1, DiffReviewers: 2}
+	result := formatRawFindings(aggregated, []int{0}, stats)
+
+	if !strings.Contains(result, "arch: 1/1") {
+		t.Errorf("expected per-phase arch count, got:\n%s", result)
+	}
+	if !strings.Contains(result, "diff: 1/2") {
+		t.Errorf("expected per-phase diff count, got:\n%s", result)
+	}
+}
+
+func TestFormatRawFindings_FlatDisplayForSinglePhase(t *testing.T) {
+	aggregated := []domain.AggregatedFinding{
+		{Text: "bug", Reviewers: []int{1, 2}},
+	}
+	stats := domain.ReviewStats{TotalReviewers: 3}
+	result := formatRawFindings(aggregated, []int{0}, stats)
+
+	if !strings.Contains(result, "2/3 reviewers") {
+		t.Errorf("expected flat reviewer count, got:\n%s", result)
+	}
+	if strings.Contains(result, "arch:") || strings.Contains(result, "diff:") {
+		t.Errorf("unexpected per-phase display in single-phase mode:\n%s", result)
+	}
+}
+
 func TestRenderLGTMMarkdown_BasicFormat(t *testing.T) {
 	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 5, SuccessfulReviewers: 5}, nil, "dev")
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -465,12 +465,12 @@ func BuildStats(results []domain.ReviewerResult, totalReviewers int, wallClock t
 		}
 
 		switch r.Phase {
-		case "arch":
+		case domain.PhaseArch:
 			stats.ArchReviewers++
 			if !r.TimedOut && !r.AuthFailed && r.ExitCode == 0 {
 				stats.SuccessfulArchReviewers++
 			}
-		case "diff":
+		case domain.PhaseDiff:
 			stats.DiffReviewers++
 			if !r.TimedOut && !r.AuthFailed && r.ExitCode == 0 {
 				stats.SuccessfulDiffReviewers++

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -509,11 +509,11 @@ func TestNewWithSpecs_DuplicateReviewerIDError(t *testing.T) {
 
 func TestBuildStats_PerPhaseCount(t *testing.T) {
 	results := []domain.ReviewerResult{
-		{ReviewerID: 1, Phase: "arch", ExitCode: 0},
-		{ReviewerID: 2, Phase: "diff", ExitCode: 0},
-		{ReviewerID: 3, Phase: "diff", ExitCode: 0},
-		{ReviewerID: 4, Phase: "diff", ExitCode: 0},
-		{ReviewerID: 5, Phase: "diff", ExitCode: 0},
+		{ReviewerID: 1, Phase: domain.PhaseArch, ExitCode: 0},
+		{ReviewerID: 2, Phase: domain.PhaseDiff, ExitCode: 0},
+		{ReviewerID: 3, Phase: domain.PhaseDiff, ExitCode: 0},
+		{ReviewerID: 4, Phase: domain.PhaseDiff, ExitCode: 0},
+		{ReviewerID: 5, Phase: domain.PhaseDiff, ExitCode: 0},
 	}
 	stats := BuildStats(results, 5, 0)
 
@@ -555,11 +555,11 @@ func TestBuildStats_PerPhaseCount_FlatReview(t *testing.T) {
 
 func TestBuildStats_PerPhaseCount_PartialFailure(t *testing.T) {
 	results := []domain.ReviewerResult{
-		{ReviewerID: 1, Phase: "arch", ExitCode: 0},
-		{ReviewerID: 2, Phase: "diff", ExitCode: 0},
-		{ReviewerID: 3, Phase: "diff", ExitCode: 0},
-		{ReviewerID: 4, Phase: "diff", ExitCode: -1, TimedOut: true},
-		{ReviewerID: 5, Phase: "diff", ExitCode: 1},
+		{ReviewerID: 1, Phase: domain.PhaseArch, ExitCode: 0},
+		{ReviewerID: 2, Phase: domain.PhaseDiff, ExitCode: 0},
+		{ReviewerID: 3, Phase: domain.PhaseDiff, ExitCode: 0},
+		{ReviewerID: 4, Phase: domain.PhaseDiff, ExitCode: -1, TimedOut: true},
+		{ReviewerID: 5, Phase: domain.PhaseDiff, ExitCode: 1},
 	}
 	stats := BuildStats(results, 5, 0)
 

--- a/internal/summarizer/crosscheck.go
+++ b/internal/summarizer/crosscheck.go
@@ -275,10 +275,10 @@ func buildCrossCheckPayload(ccCtx CrossCheckContext) crossCheckPayload {
 		text := truncateByRunes(f.Text, maxFindingTextLen)
 		// AggregatedFinding has no Phase field; derive it from GroupKey.
 		// "arch" group key → arch phase; anything else is a diff phase.
-		phase := "diff"
+		phase := domain.PhaseDiff
 		for _, tok := range strings.Split(f.GroupKey, ",") {
-			if strings.TrimSpace(tok) == "arch" {
-				phase = "arch"
+			if strings.TrimSpace(tok) == domain.PhaseArch {
+				phase = domain.PhaseArch
 				break
 			}
 		}

--- a/internal/summarizer/crosscheck_test.go
+++ b/internal/summarizer/crosscheck_test.go
@@ -54,8 +54,8 @@ func TestCrossCheckPayload_UsesAggregatedIDs(t *testing.T) {
 	ccCtx := CrossCheckContext{
 		Findings: aggregated,
 		Groups: []GroupInfo{
-			{GroupKey: "g01", Phase: "diff"},
-			{GroupKey: "g02", Phase: "diff"},
+			{GroupKey: "g01", Phase: domain.PhaseDiff},
+			{GroupKey: "g02", Phase: domain.PhaseDiff},
 		},
 		Outcomes: []GroupOutcome{
 			{GroupKey: "g01", Succeeded: true, FindingCount: 1},
@@ -83,7 +83,7 @@ func TestBuildCrossCheckPayload_TruncatesLongText(t *testing.T) {
 			{Text: longText, GroupKey: "g01", Severity: "blocking"},
 		},
 		Groups: []GroupInfo{
-			{GroupKey: "g01", Phase: "diff"},
+			{GroupKey: "g01", Phase: domain.PhaseDiff},
 		},
 		Outcomes: []GroupOutcome{
 			{GroupKey: "g01", Succeeded: true, FindingCount: 1},
@@ -105,11 +105,11 @@ func TestBuildCrossCheckPayload_TruncatesLongText(t *testing.T) {
 func TestBuildCrossCheckPayload_OutcomesMergedByKey(t *testing.T) {
 	ccCtx := CrossCheckContext{
 		Groups: []GroupInfo{
-			{GroupKey: "arch", Phase: "arch", FullDiff: true},
-			{GroupKey: "g01", Phase: "diff", TargetFiles: []string{"a.go"}},
+			{GroupKey: domain.PhaseArch, Phase: domain.PhaseArch, FullDiff: true},
+			{GroupKey: "g01", Phase: domain.PhaseDiff, TargetFiles: []string{"a.go"}},
 		},
 		Outcomes: []GroupOutcome{
-			{GroupKey: "arch", Succeeded: true, FindingCount: 3},
+			{GroupKey: domain.PhaseArch, Succeeded: true, FindingCount: 3},
 			{GroupKey: "g01", Succeeded: false, TimedOut: true},
 		},
 	}
@@ -130,7 +130,7 @@ func TestBuildCrossCheckPayload_OutcomesMergedByKey(t *testing.T) {
 
 func TestCrossCheck_SkippedForSingleGroup(t *testing.T) {
 	ccCtx := CrossCheckContext{
-		Groups: []GroupInfo{{GroupKey: "arch"}},
+		Groups: []GroupInfo{{GroupKey: domain.PhaseArch}},
 	}
 	result := CrossCheck(context.Background(), []CrossCheckAgentSpec{{Name: "codex"}}, ccCtx, false, terminal.NewLogger())
 	if !result.Skipped {
@@ -143,7 +143,7 @@ func TestCrossCheck_SkippedForSingleGroup(t *testing.T) {
 
 func TestCrossCheck_SkippedForNoAgents(t *testing.T) {
 	ccCtx := CrossCheckContext{
-		Groups: []GroupInfo{{GroupKey: "arch"}, {GroupKey: "g01"}},
+		Groups: []GroupInfo{{GroupKey: domain.PhaseArch}, {GroupKey: "g01"}},
 	}
 	result := CrossCheck(context.Background(), nil, ccCtx, false, terminal.NewLogger())
 	if !result.Skipped {
@@ -302,7 +302,7 @@ func TestBuildCrossCheckPayload_TruncatesByRunes_NotBytes(t *testing.T) {
 			{Text: longJapanese, GroupKey: "g01", Severity: "advisory"},
 		},
 		Groups: []GroupInfo{
-			{GroupKey: "g01", Phase: "diff"},
+			{GroupKey: "g01", Phase: domain.PhaseDiff},
 		},
 		Outcomes: []GroupOutcome{
 			{GroupKey: "g01", Succeeded: true, FindingCount: 1},


### PR DESCRIPTION
## Summary

- **Issue #18**: `domain.PhaseArch` / `domain.PhaseDiff` 定数を導入し、全パッケージで散在していた `"arch"` / `"diff"` 文字列リテラル（50+ 箇所）を定数参照に統一
- **Issue #22**: `buildGroupedDiffSpecs` と `buildMediumDiffSpecs` の 70% 共通コードを `buildDiffSpecsCore` に抽出（-48% 重複削減）
- **Issue #20**: `AggregatedFinding` に `ArchReviewers` / `DiffReviewers` フィールドを追加し、`formatRawFindings` を multi-phase 時に per-phase 表示 `(arch: N/M, diff: N/M reviewers)` に対応
- **ドキュメント**: CLAUDE.md Architecture セクション全面更新（30+ ファイル追加）、README.md に 16 フラグ・11 環境変数追加、CLI flag 追加手順コード例を修正
- **Codex (gpt-5.5) レビュー対応**: wire contract テスト追加、CLI flag 手順補完、--role-prompts default 注記

## Test plan

- [x] `go test ./...` 全パス（14 パッケージ）
- [x] `go vet ./...` 警告なし
- [x] `go build -o acr.exe ./cmd/acr` ビルド成功
- [x] Phase 定数の wire contract テスト (`TestPhaseConstants_WireContract`) 追加・PASS
- [x] `AggregateFindings` per-phase 集計テスト追加・PASS
- [x] `formatRawFindings` per-phase / flat 表示テスト追加・PASS
- [x] Codex (gpt-5.5) 敵対的レビュー実施・指摘 3 件対応済み

Closes #18, Closes #20, Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)