### PR TITLE
feat: FP filter に severity triage 機能を追加

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -68,6 +68,8 @@ summarizer_agent: claude
 fp_filter:
   enabled: true
   threshold: 75
+  triage: true           # severity triage (blocking/advisory/noise) を有効化
+  # show_noise: false    # noise 指摘を表示（既定: 非表示）
   agent: claude          # FP filter/triage 用エージェント (default: summarizer_agent)
   model: claude-opus-4-6 # FP filter/triage 用モデル (default: summarizer_model)
   effort: high           # FP filter/triage 用 effort (default: summarizer と同じ)

--- a/.acr.yaml
+++ b/.acr.yaml
@@ -64,10 +64,13 @@ summarizer_agent: claude
 #   exclude_patterns:
 #     - "pattern to exclude"
 
-# False positive filtering
-# fp_filter:
-#   enabled: true
-#   threshold: 75
+# False positive filtering/triage
+fp_filter:
+  enabled: true
+  threshold: 75
+  agent: claude          # FP filter/triage 用エージェント (default: summarizer_agent)
+  model: claude-opus-4-6 # FP filter/triage 用モデル (default: summarizer_model)
+  effort: high           # FP filter/triage 用 effort (default: summarizer と同じ)
 
 # Cross-check configuration (Round-9 contract: model is REQUIRED when enabled,
 # comma-separated count must match agent list, paired positionally).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,9 @@ internal/
   filter/                  # Finding filtering
     filter.go              # Exclude findings by regex pattern matching
 
-  fpfilter/                # False positive filtering
-    filter.go              # LLM-based false positive detection and removal
-    prompt.go              # FP filter prompt templates (including prior feedback)
+  fpfilter/                # False positive filtering and severity triage
+    filter.go              # LLM-based false positive detection and severity triage (blocking/advisory/noise)
+    prompt.go              # FP filter and triage prompt templates (including prior feedback)
 
   feedback/                # PR feedback summarization
     fetch.go               # Fetch PR description and comments via gh CLI
@@ -141,7 +141,7 @@ internal/
 4. **Finding Aggregation**: Three-phase process:
    - First: Exact-match deduplication in `domain.AggregateFindings()`
    - Then: Semantic clustering via LLM in `summarizer.Summarize()`
-   - Finally: LLM-based false positive filtering in `fpfilter.Filter()` (enabled by default, configurable threshold)
+   - Finally: LLM-based false positive filtering and severity triage in `fpfilter.Filter()` (enabled by default, configurable threshold). Triage classifies findings as blocking/advisory/noise; noise findings are hidden by default (`--show-noise` to display).
 
 5. **Exit Codes**: Semantic exit codes (0=clean, 1=findings, 2=error, 130=interrupted) for CI integration.
 

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -263,6 +263,8 @@ func newConfigInitCmd() *cobra.Command {
 # fp_filter:
 #   enabled: true
 #   threshold: 75
+#   triage: true  # Enable severity triage (blocking/advisory/noise classification)
+#   show_noise: false  # Show noise-level findings (hidden by default)
 #   agent: ""    # FP filter/triage agent (default: same as summarizer_agent)
 #   model: ""    # FP filter/triage model (default: same as summarizer_model)
 #   effort: ""   # FP filter/triage effort (default: same as summarizer)

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -125,7 +125,24 @@ func newConfigShowCmd() *cobra.Command {
 
 			// FP filter
 			fmt.Fprintf(out, "  %-32s %t\n", "fp_filter.enabled:", resolved.FPFilterEnabled)
+			fmt.Fprintf(out, "  %-32s %t\n", "fp_filter.triage:", resolved.TriageEnabled)
+			fmt.Fprintf(out, "  %-32s %t\n", "fp_filter.show_noise:", resolved.ShowNoise)
 			fmt.Fprintf(out, "  %-32s %d\n", "fp_filter.threshold:", resolved.FPThreshold)
+			if resolved.FPFilterAgent != "" {
+				fmt.Fprintf(out, "  %-32s %s\n", "fp_filter.agent:", resolved.FPFilterAgent)
+			} else {
+				fmt.Fprintf(out, "  %-32s %s\n", "fp_filter.agent:", "(same as summarizer_agent)")
+			}
+			if resolved.FPFilterModel != "" {
+				fmt.Fprintf(out, "  %-32s %s\n", "fp_filter.model:", resolved.FPFilterModel)
+			} else {
+				fmt.Fprintf(out, "  %-32s %s\n", "fp_filter.model:", "(same as summarizer_model)")
+			}
+			if resolved.FPFilterEffort != "" {
+				fmt.Fprintf(out, "  %-32s %s\n", "fp_filter.effort:", resolved.FPFilterEffort)
+			} else {
+				fmt.Fprintf(out, "  %-32s %s\n", "fp_filter.effort:", "(same as summarizer)")
+			}
 			fmt.Fprintln(out)
 
 			// PR feedback
@@ -246,6 +263,9 @@ func newConfigInitCmd() *cobra.Command {
 # fp_filter:
 #   enabled: true
 #   threshold: 75
+#   agent: ""    # FP filter/triage agent (default: same as summarizer_agent)
+#   model: ""    # FP filter/triage model (default: same as summarizer_model)
+#   effort: ""   # FP filter/triage effort (default: same as summarizer)
 
 # PR feedback summarization
 # pr_feedback:

--- a/cmd/acr/help.go
+++ b/cmd/acr/help.go
@@ -32,6 +32,7 @@ var flagGroups = []flagGroup{
 	{
 		title: "Filtering",
 		flags: []string{"exclude-pattern", "no-fp-filter", "fp-threshold",
+			"fp-filter-agent", "fp-filter-model", "fp-filter-effort",
 			"show-noise", "no-triage"},
 	},
 	{

--- a/cmd/acr/help.go
+++ b/cmd/acr/help.go
@@ -31,7 +31,8 @@ var flagGroups = []flagGroup{
 	},
 	{
 		title: "Filtering",
-		flags: []string{"exclude-pattern", "no-fp-filter", "fp-threshold"},
+		flags: []string{"exclude-pattern", "no-fp-filter", "fp-threshold",
+			"show-noise", "no-triage"},
 	},
 	{
 		title: "Guidance",

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -85,6 +85,8 @@ var (
 	strict              bool
 	rolePrompts         bool
 	noRolePrompts       bool
+	showNoise           bool
+	noTriage            bool
 )
 
 func main() {
@@ -200,6 +202,10 @@ Exit codes:
 		"Use role-specific prompts for auto-phase diff/arch reviewers (default: true, env: ACR_ROLE_PROMPTS)")
 	rootCmd.Flags().BoolVar(&noRolePrompts, "no-role-prompts", false,
 		"Disable role-specific prompts (env: ACR_ROLE_PROMPTS=false)")
+	rootCmd.Flags().BoolVar(&showNoise, "show-noise", false,
+		"Show noise-level findings that are normally hidden (env: ACR_SHOW_NOISE)")
+	rootCmd.Flags().BoolVar(&noTriage, "no-triage", false,
+		"Disable severity triage (FP-only mode, env: ACR_TRIAGE=false)")
 
 	rootCmd.AddCommand(newConfigCmd())
 
@@ -444,6 +450,8 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		AutoPhaseSet:           autoPhaseAnySet,
 		StrictSet:              cmd.Flags().Changed("strict"),
 		RolePromptsSet:         rolePromptsChanged || noRolePromptsChanged,
+		ShowNoiseSet:           cmd.Flags().Changed("show-noise"),
+		NoTriageSet:            cmd.Flags().Changed("no-triage"),
 	}
 
 	// Load env var state
@@ -509,6 +517,8 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		AutoPhase:           autoPhaseValue,
 		Strict:              strict,
 		RolePrompts:         rolePromptsValue,
+		ShowNoise:           showNoise,
+		TriageEnabled:       !noTriage,
 	}
 
 	// Resolve final configuration (precedence: flags > env vars > config file > defaults)

--- a/cmd/acr/main.go
+++ b/cmd/acr/main.go
@@ -72,6 +72,9 @@ var (
 	fpThreshold         int
 	summarizerTimeout   time.Duration
 	fpFilterTimeout     time.Duration
+	fpFilterAgentName   string
+	fpFilterModel       string
+	fpFilterEffort      string
 	noPRFeedback        bool
 	prFeedbackAgent     string
 	noCrossCheck        bool
@@ -176,6 +179,12 @@ Exit codes:
 		"Timeout for summarizer phase (default: 5m, env: ACR_SUMMARIZER_TIMEOUT)")
 	rootCmd.Flags().DurationVar(&fpFilterTimeout, "fp-filter-timeout", 0,
 		"Timeout for false positive filter phase (default: 5m, env: ACR_FP_FILTER_TIMEOUT)")
+	rootCmd.Flags().StringVar(&fpFilterAgentName, "fp-filter-agent", "",
+		"LLM agent for FP filter/triage (default: same as --summarizer-agent, env: ACR_FP_FILTER_AGENT)")
+	rootCmd.Flags().StringVar(&fpFilterModel, "fp-filter-model", "",
+		"LLM model for FP filter/triage (default: same as --summarizer-model, env: ACR_FP_FILTER_MODEL)")
+	rootCmd.Flags().StringVar(&fpFilterEffort, "fp-filter-effort", "",
+		"Reasoning effort for FP filter/triage (default: same as summarizer, env: ACR_FP_FILTER_EFFORT)")
 	rootCmd.Flags().BoolVar(&noPRFeedback, "no-pr-feedback", false,
 		"Disable reading PR comments for feedback context (env: ACR_PR_FEEDBACK=false)")
 	rootCmd.Flags().StringVar(&prFeedbackAgent, "pr-feedback-agent", "",
@@ -437,6 +446,9 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		SummarizerModelSet:     cmd.Flags().Changed("summarizer-model"),
 		SummarizerTimeoutSet:   cmd.Flags().Changed("summarizer-timeout"),
 		FPFilterTimeoutSet:     cmd.Flags().Changed("fp-filter-timeout"),
+		FPFilterAgentSet:       cmd.Flags().Changed("fp-filter-agent"),
+		FPFilterModelSet:       cmd.Flags().Changed("fp-filter-model"),
+		FPFilterEffortSet:      cmd.Flags().Changed("fp-filter-effort"),
 		GuidanceSet:            cmd.Flags().Changed("guidance"),
 		GuidanceFileSet:        cmd.Flags().Changed("guidance-file"),
 		NoFPFilterSet:          cmd.Flags().Changed("no-fp-filter"),
@@ -504,6 +516,9 @@ func loadAndResolveConfig(cmd *cobra.Command, wt worktreeResult, logger *termina
 		SummarizerModel:     summarizerModel,
 		SummarizerTimeout:   summarizerTimeout,
 		FPFilterTimeout:     fpFilterTimeout,
+		FPFilterAgent:       fpFilterAgentName,
+		FPFilterModel:       fpFilterModel,
+		FPFilterEffort:      fpFilterEffort,
 		Guidance:            guidance,
 		GuidanceFile:        guidanceFile,
 		FPFilterEnabled:     !noFPFilter,

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -180,10 +180,22 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	// re-invoke Resolve here (pure, cheap) solely for display purposes.
 	if opts.Verbose {
 		cliSumModelLog, legacySumModelLog := cliOrLegacy(opts.SummarizerModel, opts.SummarizerModelFromCLI)
+		fpAgentLog := opts.FPFilterAgent
+		if fpAgentLog == "" {
+			fpAgentLog = opts.SummarizerAgent
+		}
+		fpModelLog := opts.FPFilterModel
+		fpModelFromCLILog := opts.FPFilterModelFromCLI
+		if fpModelLog == "" {
+			fpModelLog = opts.SummarizerModel
+			fpModelFromCLILog = opts.SummarizerModelFromCLI
+		}
+		cliFPModelLog, legacyFPModelLog := cliOrLegacy(fpModelLog, fpModelFromCLILog)
+		cliFPEffortLog, legacyFPEffortLog := cliOrLegacy(opts.FPFilterEffort, opts.FPFilterEffortFromCLI)
 		fpSpecLog := modelconfig.Resolve(
-			opts.Models, sizeStr, modelconfig.RoleFPFilter, opts.SummarizerAgent,
-			cliSumModelLog, "",
-			legacySumModelLog, "",
+			opts.Models, sizeStr, modelconfig.RoleFPFilter, fpAgentLog,
+			cliFPModelLog, cliFPEffortLog,
+			legacyFPModelLog, legacyFPEffortLog,
 		)
 		prFeedbackAgentName := opts.PRFeedbackAgent
 		if prFeedbackAgentName == "" {
@@ -647,13 +659,41 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 		fpCtx, fpCancel := context.WithTimeout(ctx, opts.FPFilterTimeout)
 		defer fpCancel()
-		cliSumModelFP, legacySumModelFP := cliOrLegacy(opts.SummarizerModel, opts.SummarizerModelFromCLI)
+		fpAgentName := opts.FPFilterAgent
+		if fpAgentName == "" {
+			fpAgentName = opts.SummarizerAgent
+		}
+		if fpAgentName != opts.SummarizerAgent {
+			fpAg, err := agent.NewAgentWithOptions(fpAgentName, agent.AgentOptions{})
+			if err != nil {
+				fpSpinnerCancel()
+				<-fpSpinnerDone
+				logger.Logf(terminal.StyleError, "Invalid FP filter agent: %v", err)
+				return domain.ExitError
+			}
+			if err := fpAg.IsAvailable(); err != nil {
+				fpSpinnerCancel()
+				<-fpSpinnerDone
+				logger.Logf(terminal.StyleError, "%s CLI not found (fp-filter): %v", fpAgentName, err)
+				return domain.ExitError
+			}
+		}
+
+		fpModel := opts.FPFilterModel
+		fpModelFromCLI := opts.FPFilterModelFromCLI
+		if fpModel == "" {
+			fpModel = opts.SummarizerModel
+			fpModelFromCLI = opts.SummarizerModelFromCLI
+		}
+		cliFPModel, legacyFPModel := cliOrLegacy(fpModel, fpModelFromCLI)
+		cliFPEffort, legacyFPEffort := cliOrLegacy(opts.FPFilterEffort, opts.FPFilterEffortFromCLI)
+
 		fpSpec := modelconfig.Resolve(
-			opts.Models, sizeStr, modelconfig.RoleFPFilter, opts.SummarizerAgent,
-			cliSumModelFP, "",
-			legacySumModelFP, "",
+			opts.Models, sizeStr, modelconfig.RoleFPFilter, fpAgentName,
+			cliFPModel, cliFPEffort,
+			legacyFPModel, legacyFPEffort,
 		)
-		fpFilter := fpfilter.New(opts.SummarizerAgent, fpSpec.Model, fpSpec.Effort, opts.FPThreshold, opts.TriageEnabled, opts.Verbose, logger)
+		fpFilter := fpfilter.New(fpAgentName, fpSpec.Model, fpSpec.Effort, opts.FPThreshold, opts.TriageEnabled, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, priorFeedback, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone
@@ -685,6 +725,12 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				noiseFindingsForDisplay = append(noiseFindingsForDisplay, n.Finding)
 			}
 			stats.NoiseFilteredCount = fpResult.NoiseCount
+
+			if opts.ShowNoise && len(fpResult.Noise) > 0 {
+				for _, n := range fpResult.Noise {
+					summaryResult.Grouped.Findings = append(summaryResult.Grouped.Findings, n.Finding)
+				}
+			}
 		}
 	}
 	stats.FPFilteredCount = fpFilteredCount
@@ -835,6 +881,11 @@ func collectAllCLINames(opts ReviewOpts) []string {
 			ccName = opts.SummarizerAgent
 		}
 		names = append(names, agent.ParseAgentNames(ccName)...)
+	}
+
+	// FP filter: only if enabled and using a different agent
+	if opts.FPFilterEnabled && opts.FPFilterAgent != "" {
+		names = append(names, opts.FPFilterAgent)
 	}
 
 	return names

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -697,6 +697,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		len(aggregated),
 		summaryResult.Grouped.Info,
 		fpRemoved,
+		nil, // noiseRemoved: populated when triage is enabled
 		excludeFiltered,
 		summaryResult.Grouped.Findings,
 	)

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -634,6 +634,8 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 
 	var fpFilteredCount int
 	var fpRemoved []domain.FPRemovedInfo
+	var noiseRemoved []domain.FPRemovedInfo
+	var noiseFindingsForDisplay []domain.FindingGroup
 	if opts.FPFilterEnabled && summaryResult.ExitCode == 0 && len(summaryResult.Grouped.Findings) > 0 && ctx.Err() == nil {
 		fpSpinner := terminal.NewPhaseSpinner("Filtering false positives")
 		fpSpinnerCtx, fpSpinnerCancel := context.WithCancel(ctx)
@@ -672,6 +674,17 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 					Title:     r.Finding.Title,
 				})
 			}
+
+			for _, n := range fpResult.Noise {
+				noiseRemoved = append(noiseRemoved, domain.FPRemovedInfo{
+					Sources:   n.Finding.Sources,
+					FPScore:   n.FPScore,
+					Reasoning: n.Reasoning,
+					Title:     n.Finding.Title,
+				})
+				noiseFindingsForDisplay = append(noiseFindingsForDisplay, n.Finding)
+			}
+			stats.NoiseFilteredCount = fpResult.NoiseCount
 		}
 	}
 	stats.FPFilteredCount = fpFilteredCount
@@ -697,7 +710,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		len(aggregated),
 		summaryResult.Grouped.Info,
 		fpRemoved,
-		nil, // noiseRemoved: populated when triage is enabled
+		noiseRemoved,
 		excludeFiltered,
 		summaryResult.Grouped.Findings,
 	)
@@ -714,6 +727,12 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	ccBlocking := ccResult.HasBlockingFindings()
 	ccAdvisory := ccResult != nil && !ccBlocking && (ccResult.HasAdvisoryFindings() || ccResult.IsDegraded())
 	summaryResult.Grouped.ComputeVerdict(ccBlocking, ccAdvisory)
+
+	// Inject noise findings for display AFTER verdict computation so they
+	// don't affect exit codes or PR submission decisions.
+	if opts.ShowNoise {
+		summaryResult.Grouped.Findings = append(summaryResult.Grouped.Findings, noiseFindingsForDisplay...)
+	}
 
 	// Render and print report
 	if opts.Format == "json" {

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -651,7 +651,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			cliSumModelFP, "",
 			legacySumModelFP, "",
 		)
-		fpFilter := fpfilter.New(opts.SummarizerAgent, fpSpec.Model, fpSpec.Effort, opts.FPThreshold, opts.Verbose, logger)
+		fpFilter := fpfilter.New(opts.SummarizerAgent, fpSpec.Model, fpSpec.Effort, opts.FPThreshold, opts.TriageEnabled, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, priorFeedback, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -1975,6 +1975,20 @@ func TestBuildMediumDiffSpecs_FewFiles_Split(t *testing.T) {
 	}
 }
 
+func TestExitCode_NoiseDoesNotAffectErrorExit(t *testing.T) {
+	// Error stop (exit 2) is independent of noise/triage
+	// This is structural: error returns before verdict calculation
+	if domain.ExitError == domain.ExitFindings {
+		t.Error("ExitError and ExitFindings must be distinct")
+	}
+	if domain.ExitError == domain.ExitNoFindings {
+		t.Error("ExitError and ExitNoFindings must be distinct")
+	}
+	if domain.ExitNoFindings == domain.ExitFindings {
+		t.Error("ExitNoFindings and ExitFindings must be distinct")
+	}
+}
+
 func TestBuildMediumDiffSpecs_DiffPrecomputed(t *testing.T) {
 	sections := makeSectionsForReview(6, 10)
 	fullDiff := git.JoinDiffSections(sections)

--- a/internal/agent/process_windows.go
+++ b/internal/agent/process_windows.go
@@ -53,7 +53,7 @@ func processExited(pid int) (bool, error) {
 		}
 		return false, err
 	}
-	defer windows.CloseHandle(handle)
+	defer func() { _ = windows.CloseHandle(handle) }()
 
 	waitResult, err := windows.WaitForSingleObject(handle, 0)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,10 +130,13 @@ type CrossCheckConfig struct {
 }
 
 type FPFilterConfig struct {
-	Enabled   *bool `yaml:"enabled"`
-	Threshold *int  `yaml:"threshold"`
-	Triage    *bool `yaml:"triage"`
-	ShowNoise *bool `yaml:"show_noise"`
+	Enabled   *bool   `yaml:"enabled"`
+	Threshold *int    `yaml:"threshold"`
+	Triage    *bool   `yaml:"triage"`
+	ShowNoise *bool   `yaml:"show_noise"`
+	Agent     *string `yaml:"agent"`
+	Model     *string `yaml:"model"`
+	Effort    *string `yaml:"effort"`
 }
 
 // PRFeedbackConfig holds PR feedback summarization settings.
@@ -231,7 +234,7 @@ func (c *Config) validatePatterns() error {
 
 var knownTopLevelKeys = []string{"reviewers", "large_diff_reviewers", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models", "min_large_diff_reviewers", "min_medium_diff_reviewers", "role_prompts"}
 
-var knownFPFilterKeys = []string{"enabled", "threshold", "triage", "show_noise"}
+var knownFPFilterKeys = []string{"enabled", "threshold", "triage", "show_noise", "agent", "model", "effort"}
 
 var knownModelsKeys = []string{"defaults", "sizes", "agents"}
 
@@ -858,6 +861,11 @@ type ResolvedConfig struct {
 	GuidanceFile           string
 	FPFilterEnabled        bool
 	FPThreshold            int
+	FPFilterAgent          string
+	FPFilterModel          string
+	FPFilterEffort         string
+	FPFilterModelFromCLI   bool // true when fp-filter-model set via flag or env
+	FPFilterEffortFromCLI  bool // true when fp-filter-effort set via flag or env
 	PRFeedbackEnabled      bool
 	PRFeedbackAgent        string
 	CrossCheckEnabled      bool
@@ -897,6 +905,9 @@ type FlagState struct {
 	SummarizerModelSet     bool
 	SummarizerTimeoutSet   bool
 	FPFilterTimeoutSet     bool
+	FPFilterAgentSet       bool
+	FPFilterModelSet       bool
+	FPFilterEffortSet      bool
 	CrossCheckTimeoutSet   bool
 	GuidanceSet            bool
 	GuidanceFileSet        bool
@@ -949,6 +960,12 @@ type EnvState struct {
 	SummarizerTimeoutSet   bool
 	FPFilterTimeout        time.Duration
 	FPFilterTimeoutSet     bool
+	FPFilterAgent          string
+	FPFilterAgentSet       bool
+	FPFilterModel          string
+	FPFilterModelSet       bool
+	FPFilterEffort         string
+	FPFilterEffortSet      bool
 	Guidance               string
 	GuidanceSet            bool
 	GuidanceFile           string
@@ -1111,6 +1128,18 @@ func LoadEnvState() (EnvState, []string) {
 		} else {
 			warnings = append(warnings, fmt.Sprintf("ACR_FP_FILTER_TIMEOUT=%q is not a valid duration or integer, ignoring", v))
 		}
+	}
+	if v := os.Getenv("ACR_FP_FILTER_AGENT"); v != "" {
+		state.FPFilterAgent = v
+		state.FPFilterAgentSet = true
+	}
+	if v := os.Getenv("ACR_FP_FILTER_MODEL"); v != "" {
+		state.FPFilterModel = v
+		state.FPFilterModelSet = true
+	}
+	if v := os.Getenv("ACR_FP_FILTER_EFFORT"); v != "" {
+		state.FPFilterEffort = v
+		state.FPFilterEffortSet = true
 	}
 	if v := os.Getenv("ACR_GUIDANCE"); v != "" {
 		state.Guidance = v
@@ -1342,6 +1371,15 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.FPFilter.ShowNoise != nil {
 			result.ShowNoise = *cfg.FPFilter.ShowNoise
 		}
+		if cfg.FPFilter.Agent != nil {
+			result.FPFilterAgent = *cfg.FPFilter.Agent
+		}
+		if cfg.FPFilter.Model != nil {
+			result.FPFilterModel = *cfg.FPFilter.Model
+		}
+		if cfg.FPFilter.Effort != nil {
+			result.FPFilterEffort = *cfg.FPFilter.Effort
+		}
 		if cfg.PRFeedback.Enabled != nil {
 			result.PRFeedbackEnabled = *cfg.PRFeedback.Enabled
 		}
@@ -1437,6 +1475,15 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if envState.FPThresholdSet {
 		result.FPThreshold = envState.FPThreshold
 	}
+	if envState.FPFilterAgentSet {
+		result.FPFilterAgent = envState.FPFilterAgent
+	}
+	if envState.FPFilterModelSet {
+		result.FPFilterModel = envState.FPFilterModel
+	}
+	if envState.FPFilterEffortSet {
+		result.FPFilterEffort = envState.FPFilterEffort
+	}
 	if envState.PRFeedbackEnabledSet {
 		result.PRFeedbackEnabled = envState.PRFeedbackEnabled
 	}
@@ -1531,6 +1578,15 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if flagState.FPThresholdSet {
 		result.FPThreshold = flagValues.FPThreshold
 	}
+	if flagState.FPFilterAgentSet {
+		result.FPFilterAgent = flagValues.FPFilterAgent
+	}
+	if flagState.FPFilterModelSet {
+		result.FPFilterModel = flagValues.FPFilterModel
+	}
+	if flagState.FPFilterEffortSet {
+		result.FPFilterEffort = flagValues.FPFilterEffort
+	}
 	if flagState.NoPRFeedbackSet {
 		result.PRFeedbackEnabled = flagValues.PRFeedbackEnabled
 	}
@@ -1568,6 +1624,13 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	result.ReviewerModelFromCLI = flagState.ReviewerModelSet || envState.ReviewerModelSet
 	result.SummarizerModelFromCLI = flagState.SummarizerModelSet || envState.SummarizerModelSet
 	result.CrossCheckModelFromCLI = flagState.CrossCheckModelSet || envState.CrossCheckModelSet
+	result.FPFilterModelFromCLI = flagState.FPFilterModelSet || envState.FPFilterModelSet
+	result.FPFilterEffortFromCLI = flagState.FPFilterEffortSet || envState.FPFilterEffortSet
+
+	if !result.FPFilterEnabled {
+		result.TriageEnabled = false
+		result.ShowNoise = false
+	}
 
 	return result
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,8 @@ type CrossCheckConfig struct {
 type FPFilterConfig struct {
 	Enabled   *bool `yaml:"enabled"`
 	Threshold *int  `yaml:"threshold"`
+	Triage    *bool `yaml:"triage"`
+	ShowNoise *bool `yaml:"show_noise"`
 }
 
 // PRFeedbackConfig holds PR feedback summarization settings.
@@ -229,7 +231,7 @@ func (c *Config) validatePatterns() error {
 
 var knownTopLevelKeys = []string{"reviewers", "large_diff_reviewers", "medium_diff_reviewers", "small_diff_reviewers", "concurrency", "base", "timeout", "retries", "fetch", "reviewer_agent", "reviewer_agents", "arch_reviewer_agent", "diff_reviewer_agents", "summarizer_agent", "reviewer_model", "summarizer_model", "summarizer_timeout", "fp_filter_timeout", "cross_check_timeout", "guidance_file", "auto_phase", "filters", "fp_filter", "pr_feedback", "cross_check", "models", "min_large_diff_reviewers", "min_medium_diff_reviewers", "role_prompts"}
 
-var knownFPFilterKeys = []string{"enabled", "threshold"}
+var knownFPFilterKeys = []string{"enabled", "threshold", "triage", "show_noise"}
 
 var knownModelsKeys = []string{"defaults", "sizes", "agents"}
 
@@ -823,6 +825,8 @@ var Defaults = ResolvedConfig{
 	MinLargeDiffReviewers:  2,
 	MinMediumDiffReviewers: 2,
 	RolePrompts:            true,
+	TriageEnabled:          true,
+	ShowNoise:              false,
 }
 
 type ResolvedConfig struct {
@@ -864,6 +868,8 @@ type ResolvedConfig struct {
 	MinLargeDiffReviewers  int
 	MinMediumDiffReviewers int
 	RolePrompts            bool
+	TriageEnabled          bool
+	ShowNoise              bool
 	// ReviewerModelFromCLI is true when --reviewer-model or ACR_REVIEWER_MODEL
 	// set the ReviewerModel field, making it a CLI/env override that should win
 	// over models.agents/sizes/defaults config.
@@ -904,6 +910,8 @@ type FlagState struct {
 	AutoPhaseSet           bool
 	StrictSet              bool
 	RolePromptsSet         bool
+	ShowNoiseSet           bool
+	NoTriageSet            bool
 }
 
 type EnvState struct {
@@ -967,6 +975,10 @@ type EnvState struct {
 	StrictSet              bool
 	RolePrompts            bool
 	RolePromptsSet         bool
+	TriageEnabled          bool
+	TriageEnabledSet       bool
+	ShowNoise              bool
+	ShowNoiseSet           bool
 }
 
 // LoadEnvState reads environment variables and returns their state.
@@ -1212,6 +1224,32 @@ func LoadEnvState() (EnvState, []string) {
 		}
 	}
 
+	if v := os.Getenv("ACR_TRIAGE"); v != "" {
+		switch strings.ToLower(v) {
+		case "true", "1", "yes":
+			state.TriageEnabled = true
+			state.TriageEnabledSet = true
+		case "false", "0", "no":
+			state.TriageEnabled = false
+			state.TriageEnabledSet = true
+		default:
+			warnings = append(warnings, fmt.Sprintf("ACR_TRIAGE=%q is not a valid boolean (use true/false/1/0/yes/no), ignoring", v))
+		}
+	}
+
+	if v := os.Getenv("ACR_SHOW_NOISE"); v != "" {
+		switch strings.ToLower(v) {
+		case "true", "1", "yes":
+			state.ShowNoise = true
+			state.ShowNoiseSet = true
+		case "false", "0", "no":
+			state.ShowNoise = false
+			state.ShowNoiseSet = true
+		default:
+			warnings = append(warnings, fmt.Sprintf("ACR_SHOW_NOISE=%q is not a valid boolean (use true/false/1/0/yes/no), ignoring", v))
+		}
+	}
+
 	if v := os.Getenv("ACR_STRICT"); v != "" {
 		switch strings.ToLower(v) {
 		case "true", "1", "yes":
@@ -1292,8 +1330,17 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 		if cfg.FPFilter.Enabled != nil {
 			result.FPFilterEnabled = *cfg.FPFilter.Enabled
 		}
+		if cfg.FPFilter.Enabled != nil && !*cfg.FPFilter.Enabled {
+			result.TriageEnabled = false
+		}
 		if cfg.FPFilter.Threshold != nil {
 			result.FPThreshold = *cfg.FPFilter.Threshold
+		}
+		if cfg.FPFilter.Triage != nil {
+			result.TriageEnabled = *cfg.FPFilter.Triage
+		}
+		if cfg.FPFilter.ShowNoise != nil {
+			result.ShowNoise = *cfg.FPFilter.ShowNoise
 		}
 		if cfg.PRFeedback.Enabled != nil {
 			result.PRFeedbackEnabled = *cfg.PRFeedback.Enabled
@@ -1384,6 +1431,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if envState.FPFilterSet {
 		result.FPFilterEnabled = envState.FPFilterEnabled
 	}
+	if envState.FPFilterSet && !envState.FPFilterEnabled {
+		result.TriageEnabled = false
+	}
 	if envState.FPThresholdSet {
 		result.FPThreshold = envState.FPThreshold
 	}
@@ -1410,6 +1460,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	}
 	if envState.RolePromptsSet {
 		result.RolePrompts = envState.RolePrompts
+	}
+	if envState.TriageEnabledSet {
+		result.TriageEnabled = envState.TriageEnabled
+	}
+	if envState.ShowNoiseSet {
+		result.ShowNoise = envState.ShowNoise
 	}
 	if envState.StrictSet {
 		result.Strict = envState.Strict
@@ -1469,6 +1525,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	if flagState.NoFPFilterSet {
 		result.FPFilterEnabled = flagValues.FPFilterEnabled
 	}
+	if flagState.NoFPFilterSet && !flagValues.FPFilterEnabled {
+		result.TriageEnabled = false
+	}
 	if flagState.FPThresholdSet {
 		result.FPThreshold = flagValues.FPThreshold
 	}
@@ -1495,6 +1554,12 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	}
 	if flagState.RolePromptsSet {
 		result.RolePrompts = flagValues.RolePrompts
+	}
+	if flagState.NoTriageSet {
+		result.TriageEnabled = flagValues.TriageEnabled
+	}
+	if flagState.ShowNoiseSet {
+		result.ShowNoise = flagValues.ShowNoise
 	}
 	if flagState.StrictSet {
 		result.Strict = flagValues.Strict

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3361,3 +3361,85 @@ func TestResolve_NoFPFilter_DisablesTriage(t *testing.T) {
 		t.Error("--no-fp-filter should disable triage")
 	}
 }
+
+func TestResolve_FPFilterAgent_Precedence(t *testing.T) {
+	// flag > env > yaml > empty
+	// Subtest 1: yaml only
+	cfg := &Config{FPFilter: FPFilterConfig{Agent: strPtr("gemini")}}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.FPFilterAgent != "gemini" {
+		t.Errorf("expected gemini, got %s", result.FPFilterAgent)
+	}
+	// Subtest 2: env overrides yaml
+	env := EnvState{FPFilterAgent: "claude", FPFilterAgentSet: true}
+	result = Resolve(cfg, env, FlagState{}, ResolvedConfig{})
+	if result.FPFilterAgent != "claude" {
+		t.Errorf("expected claude, got %s", result.FPFilterAgent)
+	}
+	// Subtest 3: flag overrides env
+	flags := FlagState{FPFilterAgentSet: true}
+	flagVals := ResolvedConfig{FPFilterAgent: "codex"}
+	result = Resolve(cfg, env, flags, flagVals)
+	if result.FPFilterAgent != "codex" {
+		t.Errorf("expected codex, got %s", result.FPFilterAgent)
+	}
+}
+
+func TestResolve_FPFilterModel_Precedence(t *testing.T) {
+	// Same 3-tier pattern for model
+	cfg := &Config{FPFilter: FPFilterConfig{Model: strPtr("gpt-4o")}}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.FPFilterModel != "gpt-4o" {
+		t.Errorf("expected gpt-4o, got %s", result.FPFilterModel)
+	}
+	env := EnvState{FPFilterModel: "o3", FPFilterModelSet: true}
+	result = Resolve(cfg, env, FlagState{}, ResolvedConfig{})
+	if result.FPFilterModel != "o3" {
+		t.Errorf("expected o3, got %s", result.FPFilterModel)
+	}
+	flags := FlagState{FPFilterModelSet: true}
+	flagVals := ResolvedConfig{FPFilterModel: "claude-sonnet"}
+	result = Resolve(cfg, env, flags, flagVals)
+	if result.FPFilterModel != "claude-sonnet" {
+		t.Errorf("expected claude-sonnet, got %s", result.FPFilterModel)
+	}
+}
+
+func TestResolve_FPFilterModelFromCLI(t *testing.T) {
+	// false when only yaml
+	cfg := &Config{FPFilter: FPFilterConfig{Model: strPtr("gpt-4o")}}
+	result := Resolve(cfg, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.FPFilterModelFromCLI {
+		t.Error("expected FPFilterModelFromCLI=false for yaml-only")
+	}
+	// true when env set
+	env := EnvState{FPFilterModel: "o3", FPFilterModelSet: true}
+	result = Resolve(cfg, env, FlagState{}, ResolvedConfig{})
+	if !result.FPFilterModelFromCLI {
+		t.Error("expected FPFilterModelFromCLI=true for env")
+	}
+	// true when flag set
+	flags := FlagState{FPFilterModelSet: true}
+	flagVals := ResolvedConfig{FPFilterModel: "x"}
+	result = Resolve(&Config{}, EnvState{}, flags, flagVals)
+	if !result.FPFilterModelFromCLI {
+		t.Error("expected FPFilterModelFromCLI=true for flag")
+	}
+}
+
+func TestResolve_FPFilterFields_EmptyWhenUnset(t *testing.T) {
+	// All fields empty when nothing is configured
+	result := Resolve(&Config{}, EnvState{}, FlagState{}, ResolvedConfig{})
+	if result.FPFilterAgent != "" {
+		t.Errorf("expected empty FPFilterAgent, got %s", result.FPFilterAgent)
+	}
+	if result.FPFilterModel != "" {
+		t.Errorf("expected empty FPFilterModel, got %s", result.FPFilterModel)
+	}
+	if result.FPFilterEffort != "" {
+		t.Errorf("expected empty FPFilterEffort, got %s", result.FPFilterEffort)
+	}
+	if result.FPFilterModelFromCLI {
+		t.Error("expected FPFilterModelFromCLI=false")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3306,3 +3306,58 @@ func TestCheckUnknownKeys_RolePromptsIsKnown(t *testing.T) {
 		}
 	}
 }
+
+func TestResolve_TriageEnabled_Default(t *testing.T) {
+	resolved := Resolve(nil, EnvState{}, FlagState{}, Defaults)
+	if !resolved.TriageEnabled {
+		t.Error("TriageEnabled should default to true")
+	}
+	if resolved.ShowNoise {
+		t.Error("ShowNoise should default to false")
+	}
+}
+
+func TestResolve_TriageEnabled_ThreeTierPrecedence(t *testing.T) {
+	// Config sets true
+	trueVal := true
+	cfg := &Config{FPFilter: FPFilterConfig{Triage: &trueVal}}
+	// Env overrides to false
+	env := EnvState{TriageEnabled: false, TriageEnabledSet: true}
+	resolved := Resolve(cfg, env, FlagState{}, Defaults)
+	if resolved.TriageEnabled {
+		t.Error("env ACR_TRIAGE=false should override config triage=true")
+	}
+	// Flag overrides env
+	flag := FlagState{NoTriageSet: true}
+	flagVals := Defaults
+	flagVals.TriageEnabled = true
+	resolved = Resolve(cfg, env, flag, flagVals)
+	if !resolved.TriageEnabled {
+		t.Error("flag --triage should override env ACR_TRIAGE=false")
+	}
+}
+
+func TestResolve_ShowNoise_ThreeTierPrecedence(t *testing.T) {
+	trueVal := true
+	cfg := &Config{FPFilter: FPFilterConfig{ShowNoise: &trueVal}}
+	resolved := Resolve(cfg, EnvState{}, FlagState{}, Defaults)
+	if !resolved.ShowNoise {
+		t.Error("config show_noise=true should be applied")
+	}
+	// Env overrides
+	env := EnvState{ShowNoise: false, ShowNoiseSet: true}
+	resolved = Resolve(cfg, env, FlagState{}, Defaults)
+	if resolved.ShowNoise {
+		t.Error("env ACR_SHOW_NOISE=false should override config")
+	}
+}
+
+func TestResolve_NoFPFilter_DisablesTriage(t *testing.T) {
+	flag := FlagState{NoFPFilterSet: true}
+	flagVals := Defaults
+	flagVals.FPFilterEnabled = false
+	resolved := Resolve(nil, EnvState{}, flag, flagVals)
+	if resolved.TriageEnabled {
+		t.Error("--no-fp-filter should disable triage")
+	}
+}

--- a/internal/domain/disposition_test.go
+++ b/internal/domain/disposition_test.go
@@ -8,7 +8,7 @@ func TestBuildDispositions_InfoGroups(t *testing.T) {
 		[]FindingGroup{
 			{Title: "Style note", Sources: []int{0, 2}},
 		},
-		nil, nil, nil,
+		nil, nil, nil, nil,
 	)
 
 	if d := dispositions[0]; d.Kind != DispositionInfo || d.GroupTitle != "Style note" {
@@ -29,7 +29,7 @@ func TestBuildDispositions_FPFiltered(t *testing.T) {
 		[]FPRemovedInfo{
 			{Sources: []int{1}, FPScore: 85, Reasoning: "likely false positive", Title: "FP Group"},
 		},
-		nil, nil,
+		nil, nil, nil,
 	)
 
 	d := dispositions[1]
@@ -50,7 +50,7 @@ func TestBuildDispositions_FPFiltered(t *testing.T) {
 func TestBuildDispositions_Survived(t *testing.T) {
 	dispositions := BuildDispositions(
 		3,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 		[]FindingGroup{
 			{Title: "Real bug", Sources: []int{0, 2}},
 		},
@@ -70,7 +70,7 @@ func TestBuildDispositions_Survived(t *testing.T) {
 func TestBuildDispositions_ExcludeFiltered(t *testing.T) {
 	dispositions := BuildDispositions(
 		3,
-		nil, nil,
+		nil, nil, nil,
 		[]FindingGroup{
 			{Title: "Excluded finding", Sources: []int{0, 2}},
 		},
@@ -89,7 +89,7 @@ func TestBuildDispositions_ExcludeFiltered(t *testing.T) {
 }
 
 func TestBuildDispositions_UnmappedRemainUnmapped(t *testing.T) {
-	dispositions := BuildDispositions(2, nil, nil, nil, nil)
+	dispositions := BuildDispositions(2, nil, nil, nil, nil, nil)
 
 	if d := dispositions[0]; d.Kind != DispositionUnmapped {
 		t.Errorf("index 0: got %+v, want Unmapped", d)
@@ -109,7 +109,7 @@ func TestBuildDispositions_PriorityOverride(t *testing.T) {
 		[]FPRemovedInfo{
 			{Sources: []int{1}, FPScore: 90, Title: "FP"},
 		},
-		nil,
+		nil, nil,
 		[]FindingGroup{
 			{Title: "Survived", Sources: []int{2}},
 		},
@@ -127,7 +127,7 @@ func TestBuildDispositions_PriorityOverride(t *testing.T) {
 }
 
 func TestBuildDispositions_Empty(t *testing.T) {
-	dispositions := BuildDispositions(0, nil, nil, nil, nil)
+	dispositions := BuildDispositions(0, nil, nil, nil, nil, nil)
 	if len(dispositions) != 0 {
 		t.Errorf("expected empty map for 0 aggregated, got %d entries", len(dispositions))
 	}
@@ -142,6 +142,7 @@ func TestBuildDispositions_AllKindsCombined(t *testing.T) {
 		[]FPRemovedInfo{
 			{Sources: []int{1}, FPScore: 82, Reasoning: "noise", Title: "FP finding"},
 		},
+		nil,
 		[]FindingGroup{
 			{Title: "Excluded thing", Sources: []int{3}},
 		},

--- a/internal/domain/finding.go
+++ b/internal/domain/finding.go
@@ -35,9 +35,9 @@ type FindingGroup struct {
 	ArchReviewerCount int      `json:"arch_reviewer_count,omitempty"`
 	DiffReviewerCount int      `json:"diff_reviewer_count,omitempty"`
 	Sources           []int    `json:"sources"`
-	GroupKey          string   `json:"group_key,omitempty"`      // propagated from source findings
-	Severity          string   `json:"severity,omitempty"`       // "blocking" | "advisory" | "" (empty = advisory)
-	RawSeverity       string   `json:"raw_severity,omitempty"`   // backfillSeverity output before triage overwrite
+	GroupKey          string   `json:"group_key,omitempty"`    // propagated from source findings
+	Severity          string   `json:"severity,omitempty"`     // "blocking" | "advisory" | "" (empty = advisory)
+	RawSeverity       string   `json:"raw_severity,omitempty"` // backfillSeverity output before triage overwrite
 }
 
 // GroupedFindings represents the output from the summarizer.

--- a/internal/domain/finding.go
+++ b/internal/domain/finding.go
@@ -35,8 +35,9 @@ type FindingGroup struct {
 	ArchReviewerCount int      `json:"arch_reviewer_count,omitempty"`
 	DiffReviewerCount int      `json:"diff_reviewer_count,omitempty"`
 	Sources           []int    `json:"sources"`
-	GroupKey          string   `json:"group_key,omitempty"` // propagated from source findings
-	Severity          string   `json:"severity,omitempty"`  // "blocking" | "advisory" | "" (empty = advisory)
+	GroupKey          string   `json:"group_key,omitempty"`      // propagated from source findings
+	Severity          string   `json:"severity,omitempty"`       // "blocking" | "advisory" | "" (empty = advisory)
+	RawSeverity       string   `json:"raw_severity,omitempty"`   // backfillSeverity output before triage overwrite
 }
 
 // GroupedFindings represents the output from the summarizer.
@@ -99,6 +100,7 @@ const (
 	DispositionUnmapped        DispositionKind = iota // Could not trace through pipeline (zero value)
 	DispositionInfo                                   // Categorized as informational by summarizer
 	DispositionFilteredFP                             // Removed by FP filter
+	DispositionFilteredNoise                          // Removed by triage agent (severity == "noise")
 	DispositionFilteredExclude                        // Removed by exclude pattern
 	DispositionSurvived                               // Survived all filters (became a posted finding)
 )
@@ -124,6 +126,7 @@ func BuildDispositions(
 	aggregatedCount int,
 	infoGroups []FindingGroup,
 	fpRemoved []FPRemovedInfo,
+	noiseRemoved []FPRemovedInfo,
 	excludeFiltered []FindingGroup,
 	survivingFindings []FindingGroup,
 ) map[int]Disposition {
@@ -151,7 +154,19 @@ func BuildDispositions(
 		}
 	}
 
-	// 3. Mark exclude-filtered
+	// 3. Mark noise-filtered
+	for _, n := range noiseRemoved {
+		for _, src := range n.Sources {
+			dispositions[src] = Disposition{
+				Kind:       DispositionFilteredNoise,
+				FPScore:    n.FPScore,
+				Reasoning:  n.Reasoning,
+				GroupTitle: n.Title,
+			}
+		}
+	}
+
+	// 4. Mark exclude-filtered
 	for _, g := range excludeFiltered {
 		for _, src := range g.Sources {
 			dispositions[src] = Disposition{
@@ -161,7 +176,7 @@ func BuildDispositions(
 		}
 	}
 
-	// 4. Mark survivors
+	// 5. Mark survivors
 	for _, g := range survivingFindings {
 		for _, src := range g.Sources {
 			dispositions[src] = Disposition{
@@ -171,7 +186,7 @@ func BuildDispositions(
 		}
 	}
 
-	// 5. Fill remaining unmapped indices (zero value is DispositionUnmapped)
+	// 6. Fill remaining unmapped indices (zero value is DispositionUnmapped)
 	for i := range aggregatedCount {
 		if _, ok := dispositions[i]; !ok {
 			dispositions[i] = Disposition{}

--- a/internal/domain/finding_test.go
+++ b/internal/domain/finding_test.go
@@ -634,6 +634,53 @@ func TestAggregateFindings_PerPhaseReviewers_FlatReview(t *testing.T) {
 	}
 }
 
+func TestFindingGroup_RawSeverity_JSONOmitEmpty(t *testing.T) {
+	// RawSeverity empty → omitted from JSON
+	fg := FindingGroup{Severity: "blocking", RawSeverity: ""}
+	b, err := json.Marshal(fg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "raw_severity") {
+		t.Errorf("expected raw_severity omitted when empty; got %s", string(b))
+	}
+
+	// RawSeverity set → included in JSON
+	fg2 := FindingGroup{Severity: "blocking", RawSeverity: "advisory"}
+	b2, err := json.Marshal(fg2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b2), `"raw_severity":"advisory"`) {
+		t.Errorf("expected raw_severity:advisory in JSON; got %s", string(b2))
+	}
+}
+
+func TestBuildDispositions_NoiseFiltered(t *testing.T) {
+	dispositions := BuildDispositions(
+		3,
+		nil,
+		nil,
+		[]FPRemovedInfo{
+			{Sources: []int{0, 2}, FPScore: 30, Reasoning: "noise level", Title: "Noise finding"},
+		},
+		nil, nil,
+	)
+
+	if d := dispositions[0]; d.Kind != DispositionFilteredNoise {
+		t.Errorf("index 0: got kind %d, want DispositionFilteredNoise", d.Kind)
+	}
+	if d := dispositions[0]; d.GroupTitle != "Noise finding" {
+		t.Errorf("index 0: got GroupTitle %q, want 'Noise finding'", d.GroupTitle)
+	}
+	if d := dispositions[2]; d.Kind != DispositionFilteredNoise {
+		t.Errorf("index 2: got kind %d, want DispositionFilteredNoise", d.Kind)
+	}
+	if d := dispositions[1]; d.Kind != DispositionUnmapped {
+		t.Errorf("index 1: got %+v, want Unmapped", d)
+	}
+}
+
 func TestPhaseConstants_WireContract(t *testing.T) {
 	if PhaseArch != "arch" {
 		t.Errorf("PhaseArch = %q, wire contract requires %q", PhaseArch, "arch")

--- a/internal/domain/result.go
+++ b/internal/domain/result.go
@@ -33,6 +33,7 @@ type ReviewStats struct {
 	FPFilterDuration        time.Duration
 	CrossCheckDuration      time.Duration
 	FPFilteredCount         int
+	NoiseFilteredCount      int
 }
 
 // AllFailed returns true if all reviewers failed.

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -22,12 +22,15 @@ type EvaluatedFinding struct {
 	Finding   domain.FindingGroup
 	FPScore   int
 	Reasoning string
+	Severity  string // triage-assigned severity ("blocking" | "advisory" | "noise")
 }
 
 type Result struct {
 	Grouped      domain.GroupedFindings
 	Removed      []EvaluatedFinding
 	RemovedCount int
+	Noise        []EvaluatedFinding
+	NoiseCount   int
 	Duration     time.Duration
 	EvalErrors   int
 	Skipped      bool
@@ -91,6 +94,7 @@ type evaluationResponse struct {
 type findingEvaluation struct {
 	ID        int    `json:"id"`
 	FPScore   int    `json:"fp_score"`
+	Severity  string `json:"severity"` // "blocking" | "advisory" | "noise" (triage mode)
 	Reasoning string `json:"reasoning"`
 }
 

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -38,13 +38,13 @@ type Result struct {
 }
 
 type Filter struct {
-	agentName    string
-	model        string
-	effort       string
-	threshold    int
+	agentName     string
+	model         string
+	effort        string
+	threshold     int
 	triageEnabled bool
-	verbose      bool
-	logger       *terminal.Logger
+	verbose       bool
+	logger        *terminal.Logger
 }
 
 // New creates a new false positive filter.
@@ -58,13 +58,13 @@ func New(agentName, model, effort string, threshold int, triageEnabled, verbose 
 		threshold = DefaultThreshold
 	}
 	return &Filter{
-		agentName:    agentName,
-		model:        model,
-		effort:       effort,
-		threshold:    threshold,
+		agentName:     agentName,
+		model:         model,
+		effort:        effort,
+		threshold:     threshold,
 		triageEnabled: triageEnabled,
-		logger:       logger,
-		verbose:      verbose,
+		logger:        logger,
+		verbose:       verbose,
 	}
 }
 

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -80,11 +80,12 @@ type evaluationRequest struct {
 }
 
 type findingInput struct {
-	ID            int      `json:"id"`
-	Title         string   `json:"title"`
-	Summary       string   `json:"summary"`
-	Messages      []string `json:"messages"`
-	ReviewerCount int      `json:"reviewer_count"`
+	ID               int      `json:"id"`
+	Title            string   `json:"title"`
+	Summary          string   `json:"summary"`
+	Messages         []string `json:"messages"`
+	ReviewerCount    int      `json:"reviewer_count"`
+	ReviewerSeverity string   `json:"reviewer_severity"` // hint from summarizer.backfillSeverity
 }
 
 type evaluationResponse struct {

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -38,29 +38,33 @@ type Result struct {
 }
 
 type Filter struct {
-	agentName string
-	model     string
-	effort    string
-	threshold int
-	verbose   bool
-	logger    *terminal.Logger
+	agentName    string
+	model        string
+	effort       string
+	threshold    int
+	triageEnabled bool
+	verbose      bool
+	logger       *terminal.Logger
 }
 
 // New creates a new false positive filter.
 // The model parameter overrides the agent's default model (empty = default).
 // The effort parameter overrides the agent's default reasoning effort (empty = default).
+// When triageEnabled is true, severity-based classification (blocking/advisory/noise)
+// is applied in addition to fp_score filtering.
 // If verbose is true, non-fatal errors (like Close failures) are logged.
-func New(agentName, model, effort string, threshold int, verbose bool, logger *terminal.Logger) *Filter {
+func New(agentName, model, effort string, threshold int, triageEnabled, verbose bool, logger *terminal.Logger) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
 	return &Filter{
-		agentName: agentName,
-		model:     model,
-		effort:    effort,
-		threshold: threshold,
-		logger:    logger,
-		verbose:   verbose,
+		agentName:    agentName,
+		model:        model,
+		effort:       effort,
+		threshold:    threshold,
+		triageEnabled: triageEnabled,
+		logger:       logger,
+		verbose:      verbose,
 	}
 }
 
@@ -141,11 +145,12 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 	}
 	for i, finding := range grouped.Findings {
 		req.Findings[i] = findingInput{
-			ID:            i,
-			Title:         finding.Title,
-			Summary:       finding.Summary,
-			Messages:      finding.Messages,
-			ReviewerCount: finding.ReviewerCount,
+			ID:               i,
+			Title:            finding.Title,
+			Summary:          finding.Summary,
+			Messages:         finding.Messages,
+			ReviewerCount:    finding.ReviewerCount,
+			ReviewerSeverity: finding.Severity,
 		}
 	}
 
@@ -204,6 +209,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 
 	var kept []domain.FindingGroup
 	var removed []EvaluatedFinding
+	var noise []EvaluatedFinding
 	evalErrors := 0
 
 	for i, finding := range grouped.Findings {
@@ -214,15 +220,53 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 			continue
 		}
 
+		// Normalize LLM-returned severity to allow-list; preserve existing
+		// finding severity when the LLM returns empty or invalid values so
+		// summarizer-derived blocking is not silently downgraded.
+		switch eval.Severity {
+		case "blocking", "advisory", "noise":
+			// valid
+		default:
+			eval.Severity = finding.Severity
+		}
+
+		// RawSeverity: snapshot before any overwrite (triage-enabled only)
+		if f.triageEnabled {
+			finding.RawSeverity = finding.Severity
+		}
+
 		adjusted := min(eval.FPScore+agreementBonus(finding.ReviewerCount, totalReviewers), 100)
 
-		if adjusted >= f.threshold {
+		switch {
+		case f.triageEnabled && eval.Severity == "blocking":
+			// Safety valve: blocking findings are never filtered regardless of fp_score
+			finding.Severity = "blocking"
+			kept = append(kept, finding)
+
+		case adjusted >= f.threshold && (!f.triageEnabled || eval.Severity != "blocking"):
+			// FP threshold exceeded → remove as false positive
 			removed = append(removed, EvaluatedFinding{
 				Finding:   finding,
 				FPScore:   adjusted,
 				Reasoning: eval.Reasoning,
+				Severity:  eval.Severity,
 			})
-		} else {
+
+		case f.triageEnabled && eval.Severity == "noise" && adjusted < f.threshold:
+			// Noise: not FP, but low-value (style/docs suggestions)
+			finding.Severity = "noise"
+			noise = append(noise, EvaluatedFinding{
+				Finding:   finding,
+				FPScore:   adjusted,
+				Reasoning: eval.Reasoning,
+				Severity:  "noise",
+			})
+
+		default:
+			// Survived: kept with triage severity applied
+			if f.triageEnabled && eval.Severity != "" {
+				finding.Severity = eval.Severity
+			}
 			kept = append(kept, finding)
 		}
 	}
@@ -234,6 +278,8 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		},
 		Removed:      removed,
 		RemovedCount: len(removed),
+		Noise:        noise,
+		NoiseCount:   len(noise),
 		Duration:     time.Since(start),
 		EvalErrors:   evalErrors,
 	}

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -893,6 +893,130 @@ func TestApply_RawSeverity_PreservedBeforeOverwrite(t *testing.T) {
 	}
 }
 
+func TestTriage_RawSeverity_SeverityChanged(t *testing.T) {
+	// Simulate: triage changes severity from advisory to blocking
+	finding := domain.FindingGroup{Title: "Bug", Severity: "advisory", ReviewerCount: 2}
+
+	// triage-enabled Apply logic: snapshot then overwrite
+	finding.RawSeverity = finding.Severity
+	finding.Severity = "blocking"
+
+	if finding.RawSeverity != "advisory" {
+		t.Errorf("RawSeverity = %q, want advisory", finding.RawSeverity)
+	}
+	if finding.Severity != "blocking" {
+		t.Errorf("Severity = %q, want blocking", finding.Severity)
+	}
+	if finding.RawSeverity == finding.Severity {
+		t.Error("RawSeverity should differ from Severity when triage changed it")
+	}
+}
+
+func TestTriage_RawSeverity_SeverityUnchanged(t *testing.T) {
+	finding := domain.FindingGroup{Title: "Bug", Severity: "blocking", ReviewerCount: 3}
+
+	// triage keeps same severity
+	finding.RawSeverity = finding.Severity
+	// severity stays "blocking"
+
+	if finding.RawSeverity != finding.Severity {
+		t.Errorf("RawSeverity=%q should equal Severity=%q when triage didn't change it",
+			finding.RawSeverity, finding.Severity)
+	}
+}
+
+func TestTriage_RawSeverity_NoTriage(t *testing.T) {
+	finding := domain.FindingGroup{Title: "Bug", Severity: "advisory", ReviewerCount: 1}
+
+	// --no-triage mode: RawSeverity is never set
+	triageEnabled := false
+	if triageEnabled {
+		finding.RawSeverity = finding.Severity
+	}
+
+	if finding.RawSeverity != "" {
+		t.Errorf("RawSeverity = %q, want empty (triage disabled)", finding.RawSeverity)
+	}
+}
+
+func TestTriage_NoTriageMode_BackwardCompat(t *testing.T) {
+	// Full backward-compat test: with triage disabled, the classification
+	// logic should behave identically to the pre-triage code
+	threshold := 75
+	totalReviewers := 5
+	triageEnabled := false
+
+	findings := []domain.FindingGroup{
+		{Title: "F0", Severity: "advisory", ReviewerCount: 1}, // fp=80, severity=blocking → still removed (triage off)
+		{Title: "F1", Severity: "blocking", ReviewerCount: 3}, // fp=30, severity=noise → still kept (triage off)
+		{Title: "F2", Severity: "advisory", ReviewerCount: 1}, // fp=60, severity=advisory → kept
+	}
+	evals := []findingEvaluation{
+		{ID: 0, FPScore: 80, Severity: "blocking", Reasoning: "triage says blocking"},
+		{ID: 1, FPScore: 30, Severity: "noise", Reasoning: "triage says noise"},
+		{ID: 2, FPScore: 60, Severity: "advisory", Reasoning: "triage says advisory"},
+	}
+	evalMap := make(map[int]findingEvaluation)
+	for _, e := range evals {
+		evalMap[e.ID] = e
+	}
+
+	var kept []domain.FindingGroup
+	var removed []EvaluatedFinding
+	var noise []EvaluatedFinding
+
+	for i, finding := range findings {
+		eval, ok := evalMap[i]
+		if !ok {
+			kept = append(kept, finding)
+			continue
+		}
+		if triageEnabled {
+			finding.RawSeverity = finding.Severity
+		}
+		adjusted := min(eval.FPScore+agreementBonus(finding.ReviewerCount, totalReviewers), 100)
+		switch {
+		case triageEnabled && eval.Severity == "blocking":
+			finding.Severity = "blocking"
+			kept = append(kept, finding)
+		case adjusted >= threshold && (!triageEnabled || eval.Severity != "blocking"):
+			removed = append(removed, EvaluatedFinding{Finding: finding, FPScore: adjusted, Reasoning: eval.Reasoning, Severity: eval.Severity})
+		case triageEnabled && eval.Severity == "noise" && adjusted < threshold:
+			finding.Severity = "noise"
+			noise = append(noise, EvaluatedFinding{Finding: finding, FPScore: adjusted, Reasoning: eval.Reasoning, Severity: "noise"})
+		default:
+			if triageEnabled && eval.Severity != "" {
+				finding.Severity = eval.Severity
+			}
+			kept = append(kept, finding)
+		}
+	}
+
+	// With triage disabled:
+	// F0: fp=80+10(20%)=90 >= 75 → removed (severity ignored)
+	// F1: fp=30+0(60%)=30 < 75 → kept (severity ignored)
+	// F2: fp=60+10(20%)=70 < 75 → kept (severity ignored)
+	if len(removed) != 1 || removed[0].Finding.Title != "F0" {
+		t.Errorf("removed = %v, want [F0]", removed)
+	}
+	if len(kept) != 2 {
+		t.Fatalf("kept count = %d, want 2", len(kept))
+	}
+	if len(noise) != 0 {
+		t.Errorf("noise = %v, want empty (triage disabled)", noise)
+	}
+	// RawSeverity should NOT be set
+	for _, f := range kept {
+		if f.RawSeverity != "" {
+			t.Errorf("%s: RawSeverity = %q, want empty", f.Title, f.RawSeverity)
+		}
+	}
+	// Severity should NOT be overwritten
+	if kept[0].Severity != "blocking" {
+		t.Errorf("F1 Severity = %q, want blocking (unchanged)", kept[0].Severity)
+	}
+}
+
 func TestFilteringLogic(t *testing.T) {
 	// This test simulates the core filtering logic from Apply() without
 	// needing an external agent. We replicate the evalMap + threshold logic.

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -617,6 +617,58 @@ func TestFilteringLogic_WithAgreementBonus_LargeTeam(t *testing.T) {
 	}
 }
 
+func TestEvaluationResponse_WithSeverity(t *testing.T) {
+	// severity present
+	input := `{"evaluations":[{"id":0,"fp_score":30,"severity":"blocking","reasoning":"real"}]}`
+	var resp evaluationResponse
+	if err := json.Unmarshal([]byte(input), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(resp.Evaluations) != 1 {
+		t.Fatalf("expected 1 evaluation, got %d", len(resp.Evaluations))
+	}
+	if resp.Evaluations[0].Severity != "blocking" {
+		t.Errorf("Severity = %q, want %q", resp.Evaluations[0].Severity, "blocking")
+	}
+
+	// severity absent → empty string
+	input2 := `{"evaluations":[{"id":1,"fp_score":80,"reasoning":"FP"}]}`
+	var resp2 evaluationResponse
+	if err := json.Unmarshal([]byte(input2), &resp2); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp2.Evaluations[0].Severity != "" {
+		t.Errorf("Severity = %q, want empty", resp2.Evaluations[0].Severity)
+	}
+}
+
+func TestEvaluatedFinding_HasSeverity(t *testing.T) {
+	ef := EvaluatedFinding{Severity: "noise"}
+	if ef.Severity != "noise" {
+		t.Errorf("Severity = %q, want %q", ef.Severity, "noise")
+	}
+
+	ef2 := EvaluatedFinding{}
+	if ef2.Severity != "" {
+		t.Errorf("zero-value Severity = %q, want empty", ef2.Severity)
+	}
+}
+
+func TestResult_NoiseFields(t *testing.T) {
+	r := Result{
+		Noise: []EvaluatedFinding{
+			{Severity: "noise", FPScore: 20},
+		},
+		NoiseCount: 1,
+	}
+	if len(r.Noise) != 1 {
+		t.Errorf("Noise length = %d, want 1", len(r.Noise))
+	}
+	if r.NoiseCount != 1 {
+		t.Errorf("NoiseCount = %d, want 1", r.NoiseCount)
+	}
+}
+
 func TestFilteringLogic(t *testing.T) {
 	// This test simulates the core filtering logic from Apply() without
 	// needing an external agent. We replicate the evalMap + threshold logic.

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -400,6 +400,45 @@ func TestAgreementBonus(t *testing.T) {
 	}
 }
 
+func TestTriagePrompt_ContainsSeveritySection(t *testing.T) {
+	if !strings.Contains(fpEvaluationPrompt, "Severity Levels") {
+		t.Error("prompt should contain Severity Levels section")
+	}
+	if !strings.Contains(fpEvaluationPrompt, "blocking") && !strings.Contains(fpEvaluationPrompt, "advisory") && !strings.Contains(fpEvaluationPrompt, "noise") {
+		t.Error("prompt should define blocking, advisory, and noise severity levels")
+	}
+}
+
+func TestTriagePrompt_OutputFormat_IncludesSeverity(t *testing.T) {
+	if !strings.Contains(fpEvaluationPrompt, `"severity"`) {
+		t.Error("prompt output format should include severity field")
+	}
+}
+
+func TestTriagePrompt_ReviewerSeverityHint(t *testing.T) {
+	if !strings.Contains(fpEvaluationPrompt, "reviewer_severity") {
+		t.Error("prompt should reference reviewer_severity input field")
+	}
+}
+
+func TestFindingInput_IncludesReviewerSeverity(t *testing.T) {
+	input := findingInput{
+		ID:               0,
+		Title:            "Test",
+		Summary:          "Summary",
+		Messages:         []string{"msg"},
+		ReviewerCount:    1,
+		ReviewerSeverity: "blocking",
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"reviewer_severity":"blocking"`) {
+		t.Errorf("expected reviewer_severity in JSON; got %s", string(data))
+	}
+}
+
 func TestFilteringLogic_WithAgreementBonus(t *testing.T) {
 	threshold := 75
 	totalReviewers := 6

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFilter_New(t *testing.T) {
-	f := New("codex", "", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
 	if f == nil {
 		t.Fatal("New returned nil")
 	}
@@ -185,7 +185,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := New("codex", "", "", tt.threshold, false, logger)
+			f := New("codex", "", "", tt.threshold, false, false, logger)
 			if f.threshold != tt.expectedThreshold {
 				t.Errorf("threshold = %d, want %d", f.threshold, tt.expectedThreshold)
 			}
@@ -194,7 +194,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 }
 
 func TestApply_EmptyFindings(t *testing.T) {
-	f := New("codex", "", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -219,7 +219,7 @@ func TestApply_EmptyFindings(t *testing.T) {
 }
 
 func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
-	f := New("codex", "", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -233,7 +233,7 @@ func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
 }
 
 func TestApply_EmptyFindingsPreservesInfo(t *testing.T) {
-	f := New("codex", "", "", 75, false, terminal.NewLogger())
+	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 		Info: []domain.FindingGroup{
@@ -705,6 +705,191 @@ func TestResult_NoiseFields(t *testing.T) {
 	}
 	if r.NoiseCount != 1 {
 		t.Errorf("NoiseCount = %d, want 1", r.NoiseCount)
+	}
+}
+
+func TestFilteringLogic_Severity_BlockingOverridesFPScore(t *testing.T) {
+	threshold := 75
+	totalReviewers := 3
+	findings := []domain.FindingGroup{
+		{Title: "Critical bug", Severity: "advisory", ReviewerCount: 1},
+	}
+	response := evaluationResponse{
+		Evaluations: []findingEvaluation{
+			{ID: 0, FPScore: 100, Severity: "blocking", Reasoning: "real critical issue"},
+		},
+	}
+	evalMap := make(map[int]findingEvaluation)
+	for _, eval := range response.Evaluations {
+		evalMap[eval.ID] = eval
+	}
+
+	// Simulate triage-enabled Apply logic
+	var kept []domain.FindingGroup
+	var removed []EvaluatedFinding
+	triageEnabled := true
+
+	for i, finding := range findings {
+		eval, ok := evalMap[i]
+		if !ok {
+			kept = append(kept, finding)
+			continue
+		}
+		if triageEnabled {
+			finding.RawSeverity = finding.Severity
+		}
+		adjusted := min(eval.FPScore+agreementBonus(finding.ReviewerCount, totalReviewers), 100)
+		switch {
+		case triageEnabled && eval.Severity == "blocking":
+			finding.Severity = "blocking"
+			kept = append(kept, finding)
+		case adjusted >= threshold:
+			removed = append(removed, EvaluatedFinding{Finding: finding, FPScore: adjusted, Reasoning: eval.Reasoning, Severity: eval.Severity})
+		default:
+			kept = append(kept, finding)
+		}
+	}
+
+	if len(kept) != 1 {
+		t.Fatalf("expected 1 kept, got %d", len(kept))
+	}
+	if kept[0].Severity != "blocking" {
+		t.Errorf("Severity = %q, want blocking", kept[0].Severity)
+	}
+	if kept[0].RawSeverity != "advisory" {
+		t.Errorf("RawSeverity = %q, want advisory", kept[0].RawSeverity)
+	}
+	if len(removed) != 0 {
+		t.Errorf("expected 0 removed, got %d", len(removed))
+	}
+}
+
+func TestFilteringLogic_Severity_NoiseCategory(t *testing.T) {
+	threshold := 75
+	totalReviewers := 3
+	findings := []domain.FindingGroup{
+		{Title: "Style suggestion", Severity: "advisory", ReviewerCount: 1},
+	}
+	response := evaluationResponse{
+		Evaluations: []findingEvaluation{
+			{ID: 0, FPScore: 30, Severity: "noise", Reasoning: "style only"},
+		},
+	}
+	evalMap := make(map[int]findingEvaluation)
+	for _, eval := range response.Evaluations {
+		evalMap[eval.ID] = eval
+	}
+
+	var kept []domain.FindingGroup
+	var noise []EvaluatedFinding
+	triageEnabled := true
+
+	for i, finding := range findings {
+		eval, ok := evalMap[i]
+		if !ok {
+			kept = append(kept, finding)
+			continue
+		}
+		if triageEnabled {
+			finding.RawSeverity = finding.Severity
+		}
+		adjusted := min(eval.FPScore+agreementBonus(finding.ReviewerCount, totalReviewers), 100)
+		switch {
+		case triageEnabled && eval.Severity == "blocking":
+			finding.Severity = "blocking"
+			kept = append(kept, finding)
+		case adjusted >= threshold:
+			// removed
+		case triageEnabled && eval.Severity == "noise" && adjusted < threshold:
+			finding.Severity = "noise"
+			noise = append(noise, EvaluatedFinding{Finding: finding, FPScore: adjusted, Reasoning: eval.Reasoning, Severity: "noise"})
+		default:
+			kept = append(kept, finding)
+		}
+	}
+
+	if len(kept) != 0 {
+		t.Fatalf("expected 0 kept, got %d", len(kept))
+	}
+	if len(noise) != 1 {
+		t.Fatalf("expected 1 noise, got %d", len(noise))
+	}
+	if noise[0].Finding.Severity != "noise" {
+		t.Errorf("noise Severity = %q, want noise", noise[0].Finding.Severity)
+	}
+	if noise[0].Finding.RawSeverity != "advisory" {
+		t.Errorf("noise RawSeverity = %q, want advisory", noise[0].Finding.RawSeverity)
+	}
+}
+
+func TestFilteringLogic_Severity_EmptyFallback(t *testing.T) {
+	// When triageEnabled is false, severity is ignored — fp_score only
+	threshold := 75
+	totalReviewers := 3
+	findings := []domain.FindingGroup{
+		{Title: "Finding", Severity: "advisory", ReviewerCount: 2},
+	}
+	response := evaluationResponse{
+		Evaluations: []findingEvaluation{
+			{ID: 0, FPScore: 80, Severity: "blocking", Reasoning: "triage says blocking"},
+		},
+	}
+	evalMap := make(map[int]findingEvaluation)
+	for _, eval := range response.Evaluations {
+		evalMap[eval.ID] = eval
+	}
+
+	var kept []domain.FindingGroup
+	var removed []EvaluatedFinding
+	triageEnabled := false
+
+	for i, finding := range findings {
+		eval, ok := evalMap[i]
+		if !ok {
+			kept = append(kept, finding)
+			continue
+		}
+		if triageEnabled {
+			finding.RawSeverity = finding.Severity
+		}
+		adjusted := min(eval.FPScore+agreementBonus(finding.ReviewerCount, totalReviewers), 100)
+		switch {
+		case triageEnabled && eval.Severity == "blocking":
+			finding.Severity = "blocking"
+			kept = append(kept, finding)
+		case adjusted >= threshold && (!triageEnabled || eval.Severity != "blocking"):
+			removed = append(removed, EvaluatedFinding{Finding: finding, FPScore: adjusted})
+		default:
+			kept = append(kept, finding)
+		}
+	}
+
+	// Without triage, severity=blocking is ignored, fp_score 80 >= 75 → removed
+	if len(removed) != 1 {
+		t.Fatalf("expected 1 removed, got %d", len(removed))
+	}
+	if len(kept) != 0 {
+		t.Fatalf("expected 0 kept, got %d", len(kept))
+	}
+	// RawSeverity should NOT be set when triage is disabled
+	if removed[0].Finding.RawSeverity != "" {
+		t.Errorf("RawSeverity = %q, want empty (triage disabled)", removed[0].Finding.RawSeverity)
+	}
+}
+
+func TestApply_RawSeverity_PreservedBeforeOverwrite(t *testing.T) {
+	// This test verifies that RawSeverity captures the pre-triage value
+	fg := domain.FindingGroup{Title: "Bug", Severity: "advisory", ReviewerCount: 2}
+
+	// Simulate what Apply does
+	fg.RawSeverity = fg.Severity // snapshot
+	fg.Severity = "blocking"     // triage overwrite
+
+	if fg.RawSeverity != "advisory" {
+		t.Errorf("RawSeverity = %q, want advisory", fg.RawSeverity)
+	}
+	if fg.Severity != "blocking" {
+		t.Errorf("Severity = %q, want blocking", fg.Severity)
 	}
 }
 

--- a/internal/fpfilter/prompt.go
+++ b/internal/fpfilter/prompt.go
@@ -31,9 +31,9 @@ func buildPromptWithFeedback(basePrompt, priorFeedback string) string {
 	return basePrompt + fmt.Sprintf(priorFeedbackSection, priorFeedback)
 }
 
-const fpEvaluationPrompt = `# False Positive Evaluator
+const fpEvaluationPrompt = `# False Positive Evaluator & Severity Triage
 
-You are an expert code reviewer evaluating findings to determine which are likely false positives.
+You are an expert code reviewer evaluating findings to determine which are likely false positives and assigning severity for triage.
 
 ## Input Format
 JSON with "findings" array, each containing:
@@ -42,6 +42,7 @@ JSON with "findings" array, each containing:
 - summary: 1-2 sentence description
 - messages: evidence excerpts from reviewers
 - reviewer_count: how many independent reviewers found this issue
+- reviewer_severity: hint from the prior pipeline stage (may be empty)
 
 ## Your Task
 For each finding, think step-by-step:
@@ -51,10 +52,18 @@ For each finding, think step-by-step:
 4. Does the evidence support a real problem or is it speculative?
 5. Would fixing this prevent actual bugs or just change style?
 6. How many reviewers found this? (higher count = more likely real issue)
+7. What severity level best describes the impact of this finding?
 
 Then assign:
 - fp_score: 0-100 (100 = definitely false positive, 0 = definitely real issue)
+- severity: one of "blocking", "advisory", or "noise" (see Severity Levels below)
 - reasoning: Brief explanation (1-2 sentences)
+
+## Severity Levels
+
+blocking: Security vulnerabilities, crashes, data loss, logic errors that produce wrong results. These must be fixed before merge.
+advisory: Real concern but not critical — resource leaks in non-hot paths, missing edge-case handling, error messages that could be clearer. Worth fixing but not a merge blocker.
+noise: Style preferences, documentation suggestions, subjective refactoring ideas. Not false positives per se, but low-value for the reviewer's attention.
 
 ## Decision Criteria
 
@@ -80,6 +89,12 @@ UNCERTAIN (fp_score 40-60):
 - Depends on context not provided
 - Partially valid concern
 
+## Decision Matrix: fp_score vs severity
+
+- severity=blocking should rarely have high fp_score. A finding that is genuinely blocking (security, crash, data loss) is almost by definition a true positive. If you assign blocking, fp_score should typically be < 30.
+- severity=noise findings are style/doc suggestions that aren't false positives but are low-value. They may have low fp_score (the suggestion is technically valid) yet still be noise. Use noise to distinguish "real but unimportant" from "wrong".
+- fp_score >= threshold overrides severity for filtering purposes, except for blocking findings which act as a safety valve — even if the FP filter would remove them, the triage layer can preserve blocking findings.
+
 ## Reviewer Agreement Signal
 The reviewer_count indicates how many independent reviewers found this issue:
 - 5+ reviewers: Strong signal this is a real issue — bias toward lower fp_score
@@ -92,36 +107,42 @@ EXAMPLE 1:
 Finding: {"id": 0, "title": "Add error handling for database connection", "summary": "The database connection error is silently ignored", "messages": ["db.Connect() error not checked on line 42"], "reviewer_count": 4}
 Reasoning: Error from db.Connect() is discarded, which could hide connection failures and cause silent data loss.
 fp_score: 10
+severity: blocking
 Why: Specific bug - unchecked error that could cause real problems.
 
 EXAMPLE 2:
 Finding: {"id": 1, "title": "Consider adding comments", "summary": "Function lacks documentation", "messages": ["calculateDiscount() should have a docstring explaining parameters"], "reviewer_count": 1}
 Reasoning: Documentation suggestion, code functions correctly without it.
 fp_score: 90
+severity: noise
 Why: Style preference, not a bug. Code works fine.
 
 EXAMPLE 3:
 Finding: {"id": 2, "title": "Potential SQL injection", "summary": "User input concatenated into query", "messages": ["query := \"SELECT * FROM users WHERE id=\" + userId"], "reviewer_count": 3}
 Reasoning: Direct string concatenation in SQL query is a textbook injection vulnerability.
 fp_score: 5
+severity: blocking
 Why: Clear security vulnerability with specific evidence.
 
 EXAMPLE 4:
 Finding: {"id": 3, "title": "Use constants for magic numbers", "summary": "Magic number 86400 should be a named constant", "messages": ["seconds := 86400 // seconds in a day"], "reviewer_count": 1}
 Reasoning: Readability suggestion. The value is correct and commented.
 fp_score: 85
+severity: noise
 Why: Style preference with no functional impact.
 
 EXAMPLE 5:
 Finding: {"id": 4, "title": "Possible nil pointer dereference", "summary": "Pointer used without nil check", "messages": ["user.Name accessed but user could be nil if not found"], "reviewer_count": 2}
 Reasoning: If user lookup returns nil, accessing user.Name will panic.
 fp_score: 15
+severity: blocking
 Why: Concrete crash risk with specific code path identified.
 
 EXAMPLE 6:
 Finding: {"id": 5, "title": "Function is too long", "summary": "Consider breaking into smaller functions", "messages": ["processOrder() is 150 lines, consider refactoring"], "reviewer_count": 2}
 Reasoning: Refactoring suggestion for maintainability, not a bug.
 fp_score: 80
+severity: noise
 Why: Code works correctly, just style/maintainability concern.
 
 ## Output Format
@@ -131,6 +152,7 @@ Return ONLY valid JSON, no markdown fences or extra text:
     {
       "id": 0,
       "fp_score": 75,
+      "severity": "blocking",
       "reasoning": "Brief explanation here"
     }
   ]
@@ -141,4 +163,6 @@ Return ONLY valid JSON, no markdown fences or extra text:
 - Think through each finding before scoring
 - Be conservative: when genuinely uncertain, use fp_score 40-60
 - Security and crash risks should almost never be filtered (fp_score < 30)
-- Pure style/docs suggestions should usually be filtered (fp_score > 70)`
+- Pure style/docs suggestions should usually be filtered (fp_score > 70)
+- Use reviewer_severity as a hint but override it based on your own analysis
+- blocking findings should have fp_score < 30 unless you have strong evidence the issue is invalid`

--- a/internal/fpfilter/prompt.go
+++ b/internal/fpfilter/prompt.go
@@ -103,47 +103,75 @@ The reviewer_count indicates how many independent reviewers found this issue:
 
 ## Examples
 
-EXAMPLE 1:
+EXAMPLE 1 (blocking — unchecked error):
 Finding: {"id": 0, "title": "Add error handling for database connection", "summary": "The database connection error is silently ignored", "messages": ["db.Connect() error not checked on line 42"], "reviewer_count": 4}
 Reasoning: Error from db.Connect() is discarded, which could hide connection failures and cause silent data loss.
 fp_score: 10
 severity: blocking
 Why: Specific bug - unchecked error that could cause real problems.
 
-EXAMPLE 2:
-Finding: {"id": 1, "title": "Consider adding comments", "summary": "Function lacks documentation", "messages": ["calculateDiscount() should have a docstring explaining parameters"], "reviewer_count": 1}
-Reasoning: Documentation suggestion, code functions correctly without it.
-fp_score: 90
-severity: noise
-Why: Style preference, not a bug. Code works fine.
-
-EXAMPLE 3:
-Finding: {"id": 2, "title": "Potential SQL injection", "summary": "User input concatenated into query", "messages": ["query := \"SELECT * FROM users WHERE id=\" + userId"], "reviewer_count": 3}
+EXAMPLE 2 (blocking — security vulnerability):
+Finding: {"id": 1, "title": "Potential SQL injection", "summary": "User input concatenated into query", "messages": ["query := \"SELECT * FROM users WHERE id=\" + userId"], "reviewer_count": 3}
 Reasoning: Direct string concatenation in SQL query is a textbook injection vulnerability.
 fp_score: 5
 severity: blocking
 Why: Clear security vulnerability with specific evidence.
 
-EXAMPLE 4:
-Finding: {"id": 3, "title": "Use constants for magic numbers", "summary": "Magic number 86400 should be a named constant", "messages": ["seconds := 86400 // seconds in a day"], "reviewer_count": 1}
-Reasoning: Readability suggestion. The value is correct and commented.
-fp_score: 85
-severity: noise
-Why: Style preference with no functional impact.
-
-EXAMPLE 5:
-Finding: {"id": 4, "title": "Possible nil pointer dereference", "summary": "Pointer used without nil check", "messages": ["user.Name accessed but user could be nil if not found"], "reviewer_count": 2}
+EXAMPLE 3 (blocking — crash risk):
+Finding: {"id": 2, "title": "Possible nil pointer dereference", "summary": "Pointer used without nil check", "messages": ["user.Name accessed but user could be nil if not found"], "reviewer_count": 2}
 Reasoning: If user lookup returns nil, accessing user.Name will panic.
 fp_score: 15
 severity: blocking
 Why: Concrete crash risk with specific code path identified.
 
-EXAMPLE 6:
-Finding: {"id": 5, "title": "Function is too long", "summary": "Consider breaking into smaller functions", "messages": ["processOrder() is 150 lines, consider refactoring"], "reviewer_count": 2}
-Reasoning: Refactoring suggestion for maintainability, not a bug.
-fp_score: 80
+EXAMPLE 4 (advisory — error context):
+Finding: {"id": 3, "title": "Error returned without context", "summary": "Bare error propagation loses call-site information", "messages": ["return err on line 87 should wrap with fmt.Errorf for debugging context"], "reviewer_count": 3}
+Reasoning: Bare error return makes production debugging harder, but does not cause incorrect behavior.
+fp_score: 20
+severity: advisory
+Why: Valid improvement for operability. Not a crash or data loss, but worth fixing.
+
+EXAMPLE 5 (advisory — hardcoded config):
+Finding: {"id": 4, "title": "Hardcoded timeout without configuration", "summary": "Retry timeout 3600 is hardcoded with no comment or config option", "messages": ["time.Sleep(3600 * time.Second) in retry loop, no way to tune per environment"], "reviewer_count": 2}
+Reasoning: Hardcoded timeout with no explanation or config path. Different environments need different values.
+fp_score: 25
+severity: advisory
+Why: Genuinely confusing magic number in config-sensitive context. Worth extracting and documenting.
+
+EXAMPLE 6 (advisory — SRP violation):
+Finding: {"id": 5, "title": "Function mixes validation, business logic, and I/O", "summary": "processOrder() is 250 lines handling input parsing, pricing, and database writes", "messages": ["processOrder() violates SRP: validates input, calculates discount, writes DB, sends email"], "reviewer_count": 3}
+Reasoning: Function handles 4 distinct responsibilities. Testability and maintainability suffer concretely.
+fp_score: 25
+severity: advisory
+Why: Clear SRP violation with specific evidence of mixed concerns, not just a line-count complaint.
+
+EXAMPLE 7 (advisory — missing validation):
+Finding: {"id": 6, "title": "Missing input validation on public endpoint", "summary": "Page size parameter accepted without upper bound", "messages": ["GET /api/items?page_size=999999 could return unbounded result set"], "reviewer_count": 2}
+Reasoning: No upper bound on page_size allows clients to request excessive data, causing performance degradation.
+fp_score: 20
+severity: advisory
+Why: Real concern for API stability but not a security vulnerability or crash.
+
+EXAMPLE 8 (noise — documentation on clear code):
+Finding: {"id": 7, "title": "Consider adding comments", "summary": "Function lacks documentation", "messages": ["calculateDiscount() should have a docstring explaining parameters"], "reviewer_count": 1}
+Reasoning: Documentation suggestion for a well-named function with clear parameter names. Code is self-explanatory.
+fp_score: 90
 severity: noise
-Why: Code works correctly, just style/maintainability concern.
+Why: Style preference, not a bug. Function name and signature already communicate intent.
+
+EXAMPLE 9 (noise — already-documented magic number):
+Finding: {"id": 8, "title": "Use constants for magic numbers", "summary": "Magic number 86400 should be a named constant", "messages": ["seconds := 86400 // seconds in a day"], "reviewer_count": 1}
+Reasoning: Readability suggestion. The value is correct, already commented, and used in one place.
+fp_score: 85
+severity: noise
+Why: Already documented inline. Extracting a constant adds indirection without meaningful benefit.
+
+EXAMPLE 10 (noise — naming consistency):
+Finding: {"id": 9, "title": "Rename variable for consistency", "summary": "Variable 'cnt' should be 'count' to match project conventions", "messages": ["cnt is used on line 55 but count is used everywhere else in the codebase"], "reviewer_count": 1}
+Reasoning: Minor naming inconsistency in a local variable. Does not affect correctness or readability.
+fp_score: 75
+severity: noise
+Why: Subjective style preference with negligible impact on comprehension.
 
 ## Output Format
 Return ONLY valid JSON, no markdown fences or extra text:
@@ -151,8 +179,8 @@ Return ONLY valid JSON, no markdown fences or extra text:
   "evaluations": [
     {
       "id": 0,
-      "fp_score": 75,
-      "severity": "blocking",
+      "fp_score": 15,
+      "severity": "advisory",
       "reasoning": "Brief explanation here"
     }
   ]

--- a/internal/runner/report.go
+++ b/internal/runner/report.go
@@ -184,6 +184,16 @@ func RenderReport(
 			terminal.Color(terminal.Dim), stats.FPFilteredCount, findingWord, positiveWord, terminal.Color(terminal.Reset)))
 	}
 
+	if stats.NoiseFilteredCount > 0 {
+		findingWord := "finding"
+		if stats.NoiseFilteredCount != 1 {
+			findingWord = "findings"
+		}
+		lines = append(lines, "")
+		lines = append(lines, fmt.Sprintf("%sℹ %d %s filtered as noise%s",
+			terminal.Color(terminal.Dim), stats.NoiseFilteredCount, findingWord, terminal.Color(terminal.Reset)))
+	}
+
 	if stats.WallClockDuration > 0 || len(stats.ReviewerDurations) > 0 || summaryResult.Duration > 0 {
 		lines = append(lines, "")
 		lines = append(lines, fmt.Sprintf("%sTiming:%s", terminal.Color(terminal.Dim), terminal.Color(terminal.Reset)))
@@ -471,6 +481,8 @@ func formatDisposition(d domain.Disposition) string {
 		return "Categorized as informational during summarization"
 	case domain.DispositionFilteredFP:
 		return fmt.Sprintf("Filtered as likely false positive (score %d)", d.FPScore)
+	case domain.DispositionFilteredNoise:
+		return fmt.Sprintf("Filtered as noise (fp_score=%d: %s)", d.FPScore, d.Reasoning)
 	case domain.DispositionFilteredExclude:
 		return "Filtered by exclude pattern"
 	case domain.DispositionSurvived:

--- a/internal/runner/report_test.go
+++ b/internal/runner/report_test.go
@@ -1285,6 +1285,97 @@ func TestFormatPhaseLGTMCompletedSentence_Grouped(t *testing.T) {
 	}
 }
 
+func TestRenderReport_NoiseFilteredCount(t *testing.T) {
+	terminal.WithColorsDisabled(func() {
+		grouped := domain.GroupedFindings{}
+		summaryResult := &summarizer.Result{ExitCode: 0}
+		stats := domain.ReviewStats{
+			TotalReviewers:      2,
+			SuccessfulReviewers: 2,
+			NoiseFilteredCount:  3,
+		}
+
+		result := RenderReport(grouped, summaryResult, stats, nil)
+
+		if !strings.Contains(result, "3 findings filtered as noise") {
+			t.Errorf("expected noise filtered count in output, got:\n%s", result)
+		}
+	})
+}
+
+func TestRenderReport_NoiseFilteredCountSingular(t *testing.T) {
+	terminal.WithColorsDisabled(func() {
+		grouped := domain.GroupedFindings{}
+		summaryResult := &summarizer.Result{ExitCode: 0}
+		stats := domain.ReviewStats{
+			TotalReviewers:      2,
+			SuccessfulReviewers: 2,
+			NoiseFilteredCount:  1,
+		}
+
+		result := RenderReport(grouped, summaryResult, stats, nil)
+
+		if !strings.Contains(result, "1 finding filtered as noise") {
+			t.Errorf("expected singular noise filtered count in output, got:\n%s", result)
+		}
+	})
+}
+
+func TestRenderReport_NoiseFilteredCountZeroHidden(t *testing.T) {
+	terminal.WithColorsDisabled(func() {
+		grouped := domain.GroupedFindings{}
+		summaryResult := &summarizer.Result{ExitCode: 0}
+		stats := domain.ReviewStats{
+			TotalReviewers:      2,
+			SuccessfulReviewers: 2,
+			NoiseFilteredCount:  0,
+		}
+
+		result := RenderReport(grouped, summaryResult, stats, nil)
+
+		if strings.Contains(result, "noise") {
+			t.Errorf("expected no noise line when count is zero, got:\n%s", result)
+		}
+	})
+}
+
+func TestFormatDisposition_FilteredNoise(t *testing.T) {
+	d := domain.Disposition{
+		Kind:      domain.DispositionFilteredNoise,
+		FPScore:   25,
+		Reasoning: "stylistic nit with no functional impact",
+	}
+	got := formatDisposition(d)
+	expected := "Filtered as noise (fp_score=25: stylistic nit with no functional impact)"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestRenderLGTMMarkdown_WithNoiseDisposition(t *testing.T) {
+	comments := map[int][]AnnotatedComment{
+		1: {
+			{
+				Text: "Minor style issue",
+				Disposition: domain.Disposition{
+					Kind:      domain.DispositionFilteredNoise,
+					FPScore:   30,
+					Reasoning: "cosmetic only",
+				},
+			},
+		},
+	}
+
+	result := RenderLGTMMarkdown(domain.ReviewStats{TotalReviewers: 2, SuccessfulReviewers: 2}, comments, "dev")
+
+	if !strings.Contains(result, "Filtered as noise") {
+		t.Errorf("expected noise disposition annotation in LGTM markdown, got:\n%s", result)
+	}
+	if !strings.Contains(result, "fp_score=30") {
+		t.Errorf("expected fp_score in noise disposition, got:\n%s", result)
+	}
+}
+
 func TestRenderReport_FlatReviewNoRegression(t *testing.T) {
 	terminal.WithColorsDisabled(func() {
 		grouped := domain.GroupedFindings{


### PR DESCRIPTION
## Summary

- FP filter に severity triage（blocking/advisory/noise 3分類）を追加。既定 ON で後方互換
- `--show-noise` で noise findings を表示、`--no-triage` で従来の FP-only モードに切替可能
- FP filter の agent/model/effort を summarizer から独立して制御可能に（`--fp-filter-agent`, `--fp-filter-model`, `--fp-filter-effort`）
- triage プロンプトの few-shot 例を 6→10 に拡充（advisory カテゴリ追加）
- LLM 返却 severity の allow-list 正規化、verdict 汚染防止、preflight チェック強化

## Changes

### Triage 機能本体（Phase A-G）
- **domain**: `FindingGroup.RawSeverity`, `DispositionFilteredNoise`, `NoiseFilteredCount` 追加
- **fpfilter/prompt.go**: triage 用プロンプト設計（severity levels, decision matrix, 10 few-shot 例）
- **fpfilter/filter.go**: Apply() に severity ベースの 3分類ロジック + severity 正規化
- **config**: `--show-noise` / `--no-triage` の CLI/env/yaml 3 階層解決
- **review.go**: triage 結果の統合配線、noise injection を ComputeVerdict 後に配置
- **report.go**: noise フィルタ結果のレポート表示

### FP filter 独立制御
- `--fp-filter-agent`, `--fp-filter-model`, `--fp-filter-effort` CLI フラグ
- `FPFilterEffortFromCLI` による flags>env>yaml 優先度の正しい解決
- `config show` に triage/show_noise/fp_filter agent/model/effort 表示
- `collectAllCLINames` に FPFilterAgent 追加（preflight チェック）
- verbose model-matrix 表示を FP filter 実効値で算出

### テスト
- fpfilter: triage 分類、safety valve、noise/FP 分離、agreement bonus 等 ~410 行
- config: triage/show_noise 優先度、FPFilterModelFromCLI、FP filter 3 軸解決 ~137 行
- domain/runner: disposition、verdict、report rendering

## Stats
- 18 files changed, +1,147 / -85 lines
- テストコード ~700 行 / 実コード ~360 行

## Test plan
- [x] `go test ./...` 全パス
- [x] `go vet` / `go build` パス
- [x] テストビルドで `--local --base main --verbose` 実行確認（triage 既定 ON）
- [x] テストビルドで `--local --base main --show-noise --verbose` 実行確認（noise 表示）
- [x] `--no-triage` での FP-only 互換動作確認
- [x] `--fp-filter-agent` / `--fp-filter-model` 独立指定確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)