### PR TITLE
fix: codex JSONL パーサーの非 JSON 行耐性を追加

### DIFF
--- a/internal/agent/codex_parser_test.go
+++ b/internal/agent/codex_parser_test.go
@@ -142,27 +142,27 @@ func TestCodexOutputParser_ParseErrors(t *testing.T) {
 			wantParseErrors: 0,
 		},
 		{
-			name: "single parse error",
+			name: "non-JSON lines silently skipped",
 			input: `not valid json
 {"item": {"type": "agent_message", "text": "Valid finding"}}`,
 			wantFindings:    1,
-			wantParseErrors: 1,
+			wantParseErrors: 0,
 		},
 		{
-			name: "multiple parse errors",
+			name: "non-JSON lines skipped but malformed JSON counted",
 			input: `not valid json
 {"item": {"type": "agent_message", "text": "Finding 1"}}
 {malformed json
 also invalid
 {"item": {"type": "agent_message", "text": "Finding 2"}}`,
 			wantFindings:    2,
-			wantParseErrors: 3,
+			wantParseErrors: 1,
 		},
 		{
-			name:            "all lines invalid",
+			name:            "all lines non-JSON produces no findings",
 			input:           "invalid\nalso invalid\nstill invalid",
 			wantFindings:    0,
-			wantParseErrors: 3,
+			wantParseErrors: 0,
 		},
 		{
 			name:            "empty input no errors",

--- a/internal/agent/codex_review_parser.go
+++ b/internal/agent/codex_review_parser.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
@@ -36,8 +35,8 @@ func NewCodexOutputParser(reviewerID int) *CodexOutputParser {
 //
 // Returns a finding when one is found.
 // Returns (nil, nil) when no more findings are available (end of stream).
-// Returns (nil, RecoverableParseError) for malformed lines - caller should continue.
 // Returns (nil, error) for fatal scanner errors - caller should stop.
+// Non-JSON lines (e.g. codex CLI status messages) are silently skipped.
 func (p *CodexOutputParser) ReadFinding(scanner *bufio.Scanner) (*domain.Finding, error) {
 	for scanner.Scan() {
 		p.lineNum++
@@ -48,7 +47,7 @@ func (p *CodexOutputParser) ReadFinding(scanner *bufio.Scanner) (*domain.Finding
 			continue
 		}
 
-		// Parse the JSONL event
+		// Parse the JSONL event; skip non-JSON lines (CLI status messages etc.)
 		var event struct {
 			Item struct {
 				Type string `json:"type"`
@@ -57,11 +56,10 @@ func (p *CodexOutputParser) ReadFinding(scanner *bufio.Scanner) (*domain.Finding
 		}
 
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			p.parseErrors++
-			return nil, &RecoverableParseError{
-				Line:    p.lineNum,
-				Message: fmt.Sprintf("invalid JSON: %v", err),
+			if len(line) > 0 && line[0] == '{' {
+				p.parseErrors++
 			}
+			continue
 		}
 
 		// Only process agent_message items with non-empty, actionable text

--- a/internal/agent/codex_summary_parser.go
+++ b/internal/agent/codex_summary_parser.go
@@ -1,10 +1,10 @@
 package agent
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/domain"
@@ -36,19 +36,26 @@ type codexEvent struct {
 // Decodes the event stream and returns the text from the last item.completed agent_message,
 // with markdown code fences stripped.
 func (p *CodexSummaryParser) ExtractText(data []byte) (string, error) {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	var messageText string
-	var decodeErr error
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	ConfigureScanner(scanner)
 
-	for {
-		var event codexEvent
-		err := decoder.Decode(&event)
-		if err == io.EOF {
-			break
+	var messageText string
+	var skippedLines int
+	var firstSkippedLine string
+
+	for scanner.Scan() {
+		b := scanner.Bytes()
+		if len(bytes.TrimSpace(b)) == 0 {
+			continue
 		}
-		if err != nil {
-			decodeErr = err
-			break
+
+		var event codexEvent
+		if err := json.Unmarshal(b, &event); err != nil {
+			skippedLines++
+			if firstSkippedLine == "" {
+				firstSkippedLine = string(b)
+			}
+			continue
 		}
 
 		// Extract text from completed agent_message items.
@@ -60,12 +67,16 @@ func (p *CodexSummaryParser) ExtractText(data []byte) (string, error) {
 		}
 	}
 
-	if decodeErr != nil {
-		return "", fmt.Errorf("failed to decode codex JSONL output: %w", decodeErr)
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read codex output: %w", err)
 	}
 
 	if messageText == "" {
 		preview := truncate(string(data), 200)
+		if skippedLines > 0 {
+			return "", fmt.Errorf("no agent_message found in codex output (%d non-JSON lines skipped, first: %q, received: %s)",
+				skippedLines, truncate(firstSkippedLine, 200), preview)
+		}
 		return "", fmt.Errorf("no agent_message found in codex output (received: %s)", preview)
 	}
 
@@ -74,7 +85,7 @@ func (p *CodexSummaryParser) ExtractText(data []byte) (string, error) {
 
 // Parse parses the summary output and returns grouped findings.
 // Handles JSONL event stream format from codex --json output.
-// Events may be newline-separated or concatenated without separators.
+// Events are expected as newline-separated JSONL; non-JSON lines are skipped.
 func (p *CodexSummaryParser) Parse(data []byte) (*domain.GroupedFindings, error) {
 	cleaned, err := p.ExtractText(data)
 	if err != nil {

--- a/internal/agent/codex_summary_parser_test.go
+++ b/internal/agent/codex_summary_parser_test.go
@@ -113,6 +113,32 @@ func TestCodexSummaryParser_Parse(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:  "non-JSON lines at start are skipped",
+			input: []byte("Starting session...\n" + wrapInJSONL(`"{\"findings\": [], \"info\": []}"`)),
+			want: &domain.GroupedFindings{
+				Findings: []domain.FindingGroup{},
+				Info:     []domain.FindingGroup{},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "non-JSON lines interspersed are skipped",
+			input: []byte(`{"type":"thread.started","thread_id":"test"}` + "\nSearching codebase...\n" + `{"type":"item.completed","item":{"type":"agent_message","text":"{\"findings\": [{\"title\": \"Bug\", \"summary\": \"A bug\", \"messages\": [\"m\"], \"reviewer_count\": 1, \"sources\": [0]}], \"info\": []}"}}` + "\nDone.\n"),
+			want: &domain.GroupedFindings{
+				Findings: []domain.FindingGroup{
+					{Title: "Bug", Summary: "A bug", Messages: []string{"m"}, ReviewerCount: 1, Sources: []int{0}},
+				},
+				Info: []domain.FindingGroup{},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "only non-JSON lines returns error",
+			input:   []byte("Starting session...\nSearching...\nDone."),
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	parser := NewCodexSummaryParser()
@@ -157,20 +183,21 @@ func TestCodexSummaryParser_SummaryParserInterface(t *testing.T) {
 	var _ SummaryParser = (*CodexSummaryParser)(nil)
 }
 
-func TestCodexSummaryParser_DecodeErrorIncluded(t *testing.T) {
+func TestCodexSummaryParser_NoAgentMessageError(t *testing.T) {
 	parser := NewCodexSummaryParser()
 
-	// Malformed JSON that will cause a decode error
+	// Two JSON objects concatenated on a single line: json.Unmarshal rejects the
+	// line, so it is skipped entirely and no agent_message is found.
 	input := []byte(`{"type":"thread.started"}{invalid json here}`)
 
 	_, err := parser.Parse(input)
 	if err == nil {
-		t.Fatal("expected error for malformed JSON")
+		t.Fatal("expected error when no agent_message is found")
 	}
 
-	// Error should mention decode failure
-	if !strings.Contains(err.Error(), "failed to decode") {
-		t.Errorf("error should include decode failure details, got: %v", err)
+	// Error should indicate that no agent_message was found
+	if !strings.Contains(err.Error(), "no agent_message found") {
+		t.Errorf("error should mention no agent_message found, got: %v", err)
 	}
 }
 

--- a/internal/agent/extract_text_test.go
+++ b/internal/agent/extract_text_test.go
@@ -32,6 +32,11 @@ func TestCodexSummaryParser_ExtractText(t *testing.T) {
 			input:   "not json",
 			wantErr: true,
 		},
+		{
+			name:  "non-JSON line before valid JSONL is skipped",
+			input: "Status: ready\n{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"{\\\"evaluations\\\":[]}\"}}",
+			want:  `{"evaluations":[]}`,
+		},
 	}
 
 	p := NewCodexSummaryParser()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -315,21 +316,21 @@ invalid json line here
 
 	result := r.runReviewer(context.Background(), 1)
 
-	// Should have 2 findings despite 1 parse error
+	// Should have 2 findings; non-JSON line is silently skipped (no parse error)
 	if len(result.Findings) != 2 {
 		t.Errorf("expected 2 findings, got %d", len(result.Findings))
 	}
-	if result.ParseErrors != 1 {
-		t.Errorf("expected 1 parse error, got %d", result.ParseErrors)
+	if result.ParseErrors != 0 {
+		t.Errorf("expected 0 parse errors (non-JSON lines skipped), got %d", result.ParseErrors)
 	}
 }
 
-func TestRunReviewer_RecoverableParseError(t *testing.T) {
-	// Test that runner continues parsing when parser returns RecoverableParseError
-	// This tests the explicit contract between parser and runner
+func TestRunReviewer_NonJSONLinesSkipped(t *testing.T) {
+	// Test that codex parser silently skips plain-text non-JSON lines (no parse errors).
+	// Lines starting with '{' that fail JSON parse ARE counted as parse errors.
 	mockAgent := &mockStreamingAgent{
-		name:   "codex", // Use codex parser
-		output: "line1\nline2\nline3\n",
+		name:   "codex",
+		output: "status line\n{malformed json\n",
 	}
 
 	r := &Runner{
@@ -342,10 +343,24 @@ func TestRunReviewer_RecoverableParseError(t *testing.T) {
 
 	result := r.runReviewer(context.Background(), 1)
 
-	// The codex parser will treat all non-JSON lines as parse errors but continue.
-	// This verifies the parser continues after recoverable errors.
-	if result.ParseErrors != 3 {
-		t.Errorf("expected 3 parse errors for non-JSON lines, got %d", result.ParseErrors)
+	// "status line" is plain text → skipped silently (0 errors)
+	// "{malformed json" starts with '{' → counted as parse error (1 error)
+	if result.ParseErrors != 1 {
+		t.Errorf("expected 1 parse error (malformed JSON only), got %d", result.ParseErrors)
+	}
+}
+
+func TestRunReviewer_RecoverableParseErrorContract(t *testing.T) {
+	// Verify the runner's IsRecoverable branch (runner.go:349-356) is correct.
+	// No current parser returns RecoverableParseError, but the branch is retained
+	// for future parser implementations. This test validates the contract at the
+	// type level rather than through an integration path.
+	var err error = &agent.RecoverableParseError{Line: 5, Message: "test"}
+	if !agent.IsRecoverable(err) {
+		t.Error("RecoverableParseError should be identified by IsRecoverable")
+	}
+	if agent.IsRecoverable(fmt.Errorf("fatal error")) {
+		t.Error("regular error should not be identified as recoverable")
 	}
 }
 


### PR DESCRIPTION
## Summary

- codex CLI が `--json` フラグ付きでも stdout に出力する非 JSON テキスト（ステータスメッセージ等）に対して、summary パーサーと review パーサーの両方を耐障害化
- `CodexSummaryParser.ExtractText` を `json.NewDecoder` → `bufio.Scanner` + 行単位 `json.Unmarshal` に変更し、cross-check / fpfilter で codex 出力が丸ごと失われる問題を解消
- `CodexOutputParser.ReadFinding` で非 JSON 行を `RecoverableParseError` → サイレントスキップに変更し、誤警告 `⚠ JSONL parse errors: N` を解消

## 背景

cross-check で codex が `invalid character 'S'` エラーを出し、codex の cross-check 出力が丸ごと失われる問題が 2 回のレビュー実行で再現していた（間欠的、3 回中 1 回失敗）。原因は `CodexSummaryParser` が `json.NewDecoder` を使用しており、非 JSON 行で即座に fatal error になるため。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `internal/agent/codex_summary_parser.go` | `ExtractText` を行単位パースに書き換え、エラー診断強化、`Parse` コメント更新 |
| `internal/agent/codex_review_parser.go` | 非 JSON 行をサイレントスキップに変更、`fmt` import 削除 |
| `internal/agent/codex_summary_parser_test.go` | 既存テスト修正 + 非 JSON 行混入パターン 3 件追加 |
| `internal/agent/extract_text_test.go` | 非 JSON 行スキップテスト 1 件追加 |
| `internal/agent/codex_parser_test.go` | ParseErrors 期待値を 0 に更新 |
| `internal/runner/runner_test.go` | ParseErrors 期待値を 0 に更新、テスト改名 |

## Test plan

- [x] `go test ./...` 全 14 パッケージパス
- [x] `go build -o .\acr.exe .\cmd\acr` ビルド成功
- [x] テストビルドでセルフレビュー実行 — cross-check が正常動作することを確認
- [ ] マージ後、安定バイナリで実レビュー実行し codex cross-check の成功率改善を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)