### PR TITLE
refactor: size 文字列リテラルを domain 定数に統一

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -94,8 +94,8 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	}
 
 	// --phase large: override sizeStr so model resolution uses sizes.large.
-	if opts.Phase == "large" && sizeStr != "large" {
-		sizeStr = "large"
+	if opts.Phase == domain.SizeLarge && sizeStr != domain.SizeLarge {
+		sizeStr = domain.SizeLarge
 	}
 
 	// Resolve generic (phase="") reviewer specs with per-agent-name effort/model
@@ -294,7 +294,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			phaseFromAuto = size != git.DiffSizeSmall
 			if opts.Verbose {
 				switch {
-				case apr.UseGrouped && sizeStr == "large":
+				case apr.UseGrouped && sizeStr == domain.SizeLarge:
 					logger.Logf(terminal.StyleInfo, "Auto-phase: grouped (arch+%d diff groups)",
 						len(groupedSpecs)-1)
 					logPerPhaseModelMatrix(logger, opts, sizeStr)
@@ -320,7 +320,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	}
 
 	// --phase large: build grouped specs before dispatch (defensive fallback to medium)
-	if phaseStr == "large" && !useGroupedSpecs {
+	if phaseStr == domain.SizeLarge && !useGroupedSpecs {
 		plr, agentsErr := resolvePhaseLarge(diff, opts.Guidance, diffPrecomputed,
 			func() (agent.Agent, []agent.Agent, error) {
 				return buildPhaseAgents(opts, sizeStr)
@@ -393,9 +393,9 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	} else if phaseStr != "" {
 		totalForParse := opts.Reviewers
 		switch phaseStr {
-		case "small":
+		case domain.SizeSmall:
 			totalForParse = opts.SmallDiffReviewers
-		case "medium":
+		case domain.SizeMedium:
 			totalForParse = opts.MediumDiffReviewers + 1
 		}
 		phases, phaseErr := parsePhases(phaseStr, totalForParse)
@@ -527,7 +527,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	// Medium grouped specs also set useGroupedSpecs=true but cross-check
 	// config/model resolution only supports sizes.large.
 	var ccResult *summarizer.CrossCheckResult
-	if useGroupedSpecs && sizeStr == "large" && opts.CrossCheckEnabled && ctx.Err() == nil {
+	if useGroupedSpecs && sizeStr == domain.SizeLarge && opts.CrossCheckEnabled && ctx.Err() == nil {
 		// Lazy resolve: top-level cross_check.model parsing and per-agent
 		// modelconfig.Resolve happen here, NOT at startup. The sizeStr=="large"
 		// guard ensures the size layer cascade lines up with
@@ -846,7 +846,7 @@ func specsHaveArch(specs []runner.ReviewerSpec) bool {
 // paths (--phase small/medium, --no-auto-phase without --phase large) cannot
 // trigger cross-check, so validation is safely skipped.
 func shouldRunRuntimeValidation(autoPhase bool, phaseFlag string) bool {
-	return (autoPhase && phaseFlag == "") || phaseFlag == "large"
+	return (autoPhase && phaseFlag == "") || phaseFlag == domain.SizeLarge
 }
 
 // collectAllCLINames returns CLI names that may be invoked during an auto-phase
@@ -906,11 +906,11 @@ func parsePhases(phaseStr string, totalReviewers int) ([]runner.PhaseConfig, err
 		return nil, fmt.Errorf("totalReviewers must be >= 1, got %d", totalReviewers)
 	}
 	switch phaseStr {
-	case "small":
+	case domain.SizeSmall:
 		return []runner.PhaseConfig{
 			{Phase: domain.PhaseDiff, ReviewerCount: totalReviewers},
 		}, nil
-	case "medium":
+	case domain.SizeMedium:
 		if totalReviewers < 2 {
 			return nil, fmt.Errorf("phase %q requires >= 2 reviewers (1 arch + >= 1 diff), got %d", phaseStr, totalReviewers)
 		}
@@ -1110,7 +1110,7 @@ func resolveAutoPhase(
 	switch size {
 	case git.DiffSizeSmall:
 		// Small: flat diff path; reviewer count comes from small_diff_reviewers.
-		return autoPhaseResult{PhaseStr: "small"}, nil
+		return autoPhaseResult{PhaseStr: domain.SizeSmall}, nil
 	case git.DiffSizeLarge:
 		fileCount := len(git.ParseDiffSections(diff))
 		effectiveGroups := largeDiffReviewers
@@ -1126,7 +1126,7 @@ func resolveAutoPhase(
 			// buildAgents, so per-phase override CLI availability does not gate
 			// the fallback.
 			return autoPhaseResult{
-				PhaseStr:        "medium",
+				PhaseStr:        domain.SizeMedium,
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason: fmt.Sprintf(
 					"only %d non-empty diff group(s) possible (file_count=%d, large_diff_reviewers=%d)",
@@ -1145,7 +1145,7 @@ func resolveAutoPhase(
 		specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, effectiveGroups)
 		if err != nil {
 			return autoPhaseResult{
-				PhaseStr:        "medium",
+				PhaseStr:        domain.SizeMedium,
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason:  fmt.Sprintf("buildGroupedDiffSpecs failed: %v", err),
 			}, nil
@@ -1154,7 +1154,7 @@ func resolveAutoPhase(
 		diffGroupCount := len(specs) - 1
 		if diffGroupCount < 2 {
 			return autoPhaseResult{
-				PhaseStr:        "medium",
+				PhaseStr:        domain.SizeMedium,
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason:  fmt.Sprintf("only %d non-empty diff group(s) after building", diffGroupCount),
 			}, nil
@@ -1166,7 +1166,7 @@ func resolveAutoPhase(
 	default: // medium
 		if diff == "" {
 			return autoPhaseResult{
-				PhaseStr:        "medium",
+				PhaseStr:        domain.SizeMedium,
 				MediumDiffCount: mediumDiffReviewers,
 			}, nil
 		}
@@ -1180,7 +1180,7 @@ func resolveAutoPhase(
 		}
 		if effectiveGroups < 2 {
 			return autoPhaseResult{
-				PhaseStr:        "medium",
+				PhaseStr:        domain.SizeMedium,
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason: fmt.Sprintf(
 					"only %d non-empty diff group(s) possible (file_count=%d, medium_diff_reviewers=%d)",
@@ -1197,7 +1197,7 @@ func resolveAutoPhase(
 		}
 		if medSpecs == nil {
 			return autoPhaseResult{
-				PhaseStr:        "medium",
+				PhaseStr:        domain.SizeMedium,
 				MediumDiffCount: mediumDiffReviewers,
 				FallbackReason:  "diff split not viable after grouping",
 			}, nil
@@ -1231,7 +1231,7 @@ func resolvePhaseLarge(
 	}
 	if effectiveGroups < 2 {
 		return autoPhaseResult{
-			PhaseStr:        "medium",
+			PhaseStr:        domain.SizeMedium,
 			MediumDiffCount: mediumDiffReviewers,
 			FallbackReason:  fmt.Sprintf("only %d file(s), need >=2 for grouped review", fileCount),
 		}, nil
@@ -1243,7 +1243,7 @@ func resolvePhaseLarge(
 	specs, err := buildGroupedDiffSpecs(diff, guidance, diffPrecomputed, archAgent, diffAgents, effectiveGroups)
 	if err != nil {
 		return autoPhaseResult{
-			PhaseStr:        "medium",
+			PhaseStr:        domain.SizeMedium,
 			MediumDiffCount: mediumDiffReviewers,
 			FallbackReason:  fmt.Sprintf("buildGroupedDiffSpecs failed: %v", err),
 		}, nil
@@ -1251,7 +1251,7 @@ func resolvePhaseLarge(
 	diffGroupCount := len(specs) - 1
 	if diffGroupCount < 2 {
 		return autoPhaseResult{
-			PhaseStr:        "medium",
+			PhaseStr:        domain.SizeMedium,
 			MediumDiffCount: mediumDiffReviewers,
 			FallbackReason:  fmt.Sprintf("only %d non-empty diff group(s) after building", diffGroupCount),
 		}, nil

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -25,19 +25,19 @@ func TestParsePhases(t *testing.T) {
 	}{
 		{
 			name:      "small with 1 reviewer",
-			phaseStr:  "small",
+			phaseStr:  domain.SizeSmall,
 			reviewers: 1,
 			want:      []runner.PhaseConfig{{Phase: domain.PhaseDiff, ReviewerCount: 1}},
 		},
 		{
 			name:      "small with 3 reviewers",
-			phaseStr:  "small",
+			phaseStr:  domain.SizeSmall,
 			reviewers: 3,
 			want:      []runner.PhaseConfig{{Phase: domain.PhaseDiff, ReviewerCount: 3}},
 		},
 		{
 			name:      "medium with 3 reviewers",
-			phaseStr:  "medium",
+			phaseStr:  domain.SizeMedium,
 			reviewers: 3,
 			want: []runner.PhaseConfig{
 				{Phase: domain.PhaseArch, ReviewerCount: 1},
@@ -46,7 +46,7 @@ func TestParsePhases(t *testing.T) {
 		},
 		{
 			name:      "medium with 2 reviewers (minimum)",
-			phaseStr:  "medium",
+			phaseStr:  domain.SizeMedium,
 			reviewers: 2,
 			want: []runner.PhaseConfig{
 				{Phase: domain.PhaseArch, ReviewerCount: 1},
@@ -55,7 +55,7 @@ func TestParsePhases(t *testing.T) {
 		},
 		{
 			name:      "medium with 1 reviewer errors (needs >= 2)",
-			phaseStr:  "medium",
+			phaseStr:  domain.SizeMedium,
 			reviewers: 1,
 			wantErr:   true,
 		},
@@ -79,13 +79,13 @@ func TestParsePhases(t *testing.T) {
 		},
 		{
 			name:      "zero reviewers",
-			phaseStr:  "small",
+			phaseStr:  domain.SizeSmall,
 			reviewers: 0,
 			wantErr:   true,
 		},
 		{
 			name:      "negative reviewers",
-			phaseStr:  "small",
+			phaseStr:  domain.SizeSmall,
 			reviewers: -1,
 			wantErr:   true,
 		},
@@ -300,7 +300,7 @@ func TestAutoPhase_Large_FallbackOnError(t *testing.T) {
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when buildGroupedDiffSpecs fails")
 	}
-	if apr.PhaseStr != "medium" {
+	if apr.PhaseStr != domain.SizeMedium {
 		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 2 {
@@ -498,11 +498,11 @@ func TestResolveCrossCheckAgents_ResolvesFromSizesModelsTree(t *testing.T) {
 		CrossCheckModel:   "",
 		Models: config.ModelsConfig{
 			Sizes: map[string]config.RoleModels{
-				"large": {CrossCheck: &config.ModelSpec{Model: "gpt-5.4-large"}},
+				domain.SizeLarge: {CrossCheck: &config.ModelSpec{Model: "gpt-5.4-large"}},
 			},
 		},
 	}}
-	_, models, err := resolveCrossCheckAgents(opts, "large")
+	_, models, err := resolveCrossCheckAgents(opts, domain.SizeLarge)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -625,7 +625,7 @@ func TestResolveAutoPhase_OneDiffGroup_FallsBackToFlat(t *testing.T) {
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false for large_diff_reviewers=1")
 	}
-	if apr.PhaseStr != "medium" {
+	if apr.PhaseStr != domain.SizeMedium {
 		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.FallbackReason == "" {
@@ -817,7 +817,7 @@ func TestExecuteReview_NoArgs_UsesAutoPhasePath(t *testing.T) {
 func TestExecuteReview_PhaseSmall_UsesFlatPath(t *testing.T) {
 	opts := ReviewOpts{
 		ResolvedConfig: config.ResolvedConfig{AutoPhase: true},
-		Phase:          "small",
+		Phase:          domain.SizeSmall,
 	}
 	if shouldUseAutoPhase(opts) {
 		t.Error("expected shouldUseAutoPhase=false when Phase is explicitly set")
@@ -845,25 +845,25 @@ func TestShouldRunRuntimeValidation_AutoPhase_NoExplicitPhase(t *testing.T) {
 }
 
 func TestShouldRunRuntimeValidation_AutoPhase_PhaseLarge(t *testing.T) {
-	if !shouldRunRuntimeValidation(true, "large") {
+	if !shouldRunRuntimeValidation(true, domain.SizeLarge) {
 		t.Error("expected true: --phase large can trigger cross-check via grouped review")
 	}
 }
 
 func TestShouldRunRuntimeValidation_NoAutoPhase_PhaseLarge(t *testing.T) {
-	if !shouldRunRuntimeValidation(false, "large") {
+	if !shouldRunRuntimeValidation(false, domain.SizeLarge) {
 		t.Error("expected true: --no-auto-phase --phase large still triggers cross-check")
 	}
 }
 
 func TestShouldRunRuntimeValidation_AutoPhase_PhaseSmall(t *testing.T) {
-	if shouldRunRuntimeValidation(true, "small") {
+	if shouldRunRuntimeValidation(true, domain.SizeSmall) {
 		t.Error("expected false: --phase small cannot trigger cross-check")
 	}
 }
 
 func TestShouldRunRuntimeValidation_AutoPhase_PhaseMedium(t *testing.T) {
-	if shouldRunRuntimeValidation(true, "medium") {
+	if shouldRunRuntimeValidation(true, domain.SizeMedium) {
 		t.Error("expected false: --phase medium cannot trigger cross-check")
 	}
 }
@@ -1060,7 +1060,7 @@ func TestResolveAutoPhase_LargeFallbackToMedium_WhenFileCountTooSmall(t *testing
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false when fileCount<2")
 	}
-	if apr.PhaseStr != "medium" {
+	if apr.PhaseStr != domain.SizeMedium {
 		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 3 {
@@ -1079,7 +1079,7 @@ func TestResolveAutoPhase_MediumUsesMediumDiffReviewersKnob(t *testing.T) {
 	if apr.UseGrouped {
 		t.Fatal("expected UseGrouped=false on medium")
 	}
-	if apr.PhaseStr != "medium" {
+	if apr.PhaseStr != domain.SizeMedium {
 		t.Errorf("expected PhaseStr 'medium', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 4 {
@@ -1122,7 +1122,7 @@ func TestResolveAutoPhase_Small(t *testing.T) {
 	if apr.UseGrouped {
 		t.Errorf("expected UseGrouped=false for small")
 	}
-	if apr.PhaseStr != "small" {
+	if apr.PhaseStr != domain.SizeSmall {
 		t.Errorf("expected PhaseStr 'small', got %q", apr.PhaseStr)
 	}
 	if apr.MediumDiffCount != 0 {
@@ -1226,7 +1226,7 @@ func TestResolvePhaseLarge_InsufficientFiles_FallbackToMedium(t *testing.T) {
 	if result.UseGrouped {
 		t.Fatal("expected UseGrouped=false for 1 file")
 	}
-	if result.PhaseStr != "medium" {
+	if result.PhaseStr != domain.SizeMedium {
 		t.Errorf("expected PhaseStr 'medium', got %q", result.PhaseStr)
 	}
 	if result.FallbackReason == "" {
@@ -1516,7 +1516,7 @@ func TestLogPerPhaseModelMatrix_EmptyReviewerAgentsWithArchOverride(t *testing.T
 			DiffReviewerAgents: []string{"claude"},
 		},
 	}
-	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, domain.SizeLarge)
 }
 
 func TestLogPerPhaseModelMatrix_ArchOverrideTakesPrecedence(t *testing.T) {
@@ -1532,7 +1532,7 @@ func TestLogPerPhaseModelMatrix_ArchOverrideTakesPrecedence(t *testing.T) {
 			ArchReviewerAgent: "claude",
 		},
 	}
-	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, domain.SizeLarge)
 }
 
 func TestLogPerPhaseModelMatrix_ReviewerAgentsFallback(t *testing.T) {
@@ -1547,7 +1547,7 @@ func TestLogPerPhaseModelMatrix_ReviewerAgentsFallback(t *testing.T) {
 			ReviewerAgents: []string{"codex", "claude"},
 		},
 	}
-	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, domain.SizeLarge)
 }
 
 func TestLogPerPhaseModelMatrix_BothEmpty_GracefulDegrade(t *testing.T) {
@@ -1565,7 +1565,7 @@ func TestLogPerPhaseModelMatrix_BothEmpty_GracefulDegrade(t *testing.T) {
 			DiffReviewerAgents: nil,
 		},
 	}
-	logPerPhaseModelMatrix(terminal.NewLogger(), opts, "large")
+	logPerPhaseModelMatrix(terminal.NewLogger(), opts, domain.SizeLarge)
 }
 
 // --- logCrossCheckModelMatrix tests ---
@@ -1594,7 +1594,7 @@ func TestLogCrossCheckModelMatrix_ResolveErrorEmitsWarningNoPanic(t *testing.T) 
 			Models:            config.ModelsConfig{}, // empty: no path resolves
 		},
 	}
-	logCrossCheckModelMatrix(terminal.NewLogger(), opts, "large")
+	logCrossCheckModelMatrix(terminal.NewLogger(), opts, domain.SizeLarge)
 }
 
 func TestLogCrossCheckModelMatrix_AgentDefaultsToSummarizerWhenCrossCheckAgentEmpty(t *testing.T) {
@@ -1613,7 +1613,7 @@ func TestLogCrossCheckModelMatrix_AgentDefaultsToSummarizerWhenCrossCheckAgentEm
 			CrossCheckModel:   "gpt-5.4-mini",
 		},
 	}
-	logCrossCheckModelMatrix(terminal.NewLogger(), opts, "large")
+	logCrossCheckModelMatrix(terminal.NewLogger(), opts, domain.SizeLarge)
 }
 
 func TestLogCrossCheckModelMatrix_EmitsOneRowPerResolvedAgent(t *testing.T) {
@@ -1639,7 +1639,7 @@ func TestLogCrossCheckModelMatrix_EmitsOneRowPerResolvedAgent(t *testing.T) {
 			},
 		},
 	}
-	logCrossCheckModelMatrix(terminal.NewLogger(), opts, "large")
+	logCrossCheckModelMatrix(terminal.NewLogger(), opts, domain.SizeLarge)
 }
 
 // --- collectAllCLINames tests ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/richhaase/agentic-code-reviewer/internal/agent"
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 	"github.com/richhaase/agentic-code-reviewer/internal/git"
 )
 
@@ -670,7 +671,7 @@ func canResolveCrossCheckModelForAgent(m ModelsConfig, agentName string) bool {
 	// Other size layers (sizes.small / sizes.medium) are dead code for this role
 	// and intentionally rejected here so users get a clear validate-time error
 	// rather than a silent "validates OK but cross-check never runs".
-	if rm, ok := m.Sizes["large"]; ok {
+	if rm, ok := m.Sizes[domain.SizeLarge]; ok {
 		if rm.CrossCheck != nil && strings.TrimSpace(rm.CrossCheck.Model) != "" {
 			return true
 		}
@@ -720,7 +721,7 @@ func (c *Config) validateModelsAgents() []string {
 	return errs
 }
 
-var validSizeKeys = []string{"small", "medium", "large"}
+var validSizeKeys = []string{domain.SizeSmall, domain.SizeMedium, domain.SizeLarge}
 
 // validateModelsSizes checks that all size keys in models.sizes are valid.
 func (c *Config) validateModelsSizes() []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 func TestLoadFromDirWithWarnings_ValidConfig(t *testing.T) {
@@ -2084,7 +2086,7 @@ func TestConfig_ModelsSection_Parses(t *testing.T) {
 	}
 
 	// sizes
-	small, ok := m.Sizes["small"]
+	small, ok := m.Sizes[domain.SizeSmall]
 	if !ok {
 		t.Fatal("sizes.small not found")
 	}
@@ -2094,7 +2096,7 @@ func TestConfig_ModelsSection_Parses(t *testing.T) {
 	if small.Reviewer.Effort != "low" {
 		t.Errorf("sizes.small.reviewer.effort: got %q, want %q", small.Reviewer.Effort, "low")
 	}
-	large, ok := m.Sizes["large"]
+	large, ok := m.Sizes[domain.SizeLarge]
 	if !ok {
 		t.Fatal("sizes.large not found")
 	}
@@ -2414,11 +2416,11 @@ func TestConfig_ModelsEffort_CaseInsensitive_Sizes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected case-insensitive effort to be accepted in sizes, got: %v", err)
 	}
-	small := result.Config.Models.Sizes["small"]
+	small := result.Config.Models.Sizes[domain.SizeSmall]
 	if small.Reviewer == nil || small.Reviewer.Effort != "LOW" {
 		t.Errorf("expected sizes.small.reviewer.effort=LOW, got %+v", small.Reviewer)
 	}
-	large := result.Config.Models.Sizes["large"]
+	large := result.Config.Models.Sizes[domain.SizeLarge]
 	if large.ArchReviewer == nil || large.ArchReviewer.Effort != "MediuM" {
 		t.Errorf("expected sizes.large.arch_reviewer.effort=MediuM, got %+v", large.ArchReviewer)
 	}
@@ -3090,7 +3092,7 @@ func TestValidateRuntime_CrossCheckModelsTreeFallback(t *testing.T) {
 			CrossCheckTimeout: 5 * time.Minute,
 			Models: ModelsConfig{
 				Sizes: map[string]RoleModels{
-					"large": {CrossCheck: &ModelSpec{Model: "gpt-5.4-large"}},
+					domain.SizeLarge: {CrossCheck: &ModelSpec{Model: "gpt-5.4-large"}},
 				},
 			},
 		}
@@ -3160,7 +3162,7 @@ func TestValidateRuntime_CrossCheckModelsTreeFallback(t *testing.T) {
 			CrossCheckTimeout: 5 * time.Minute,
 			Models: ModelsConfig{
 				Sizes: map[string]RoleModels{
-					"small": {CrossCheck: &ModelSpec{Model: "gpt-5.4-small"}},
+					domain.SizeSmall: {CrossCheck: &ModelSpec{Model: "gpt-5.4-small"}},
 				},
 			},
 		}
@@ -3182,7 +3184,7 @@ func TestValidateRuntime_CrossCheckModelsTreeFallback(t *testing.T) {
 			CrossCheckTimeout: 5 * time.Minute,
 			Models: ModelsConfig{
 				Sizes: map[string]RoleModels{
-					"medium": {CrossCheck: &ModelSpec{Model: "gpt-5.4-medium"}},
+					domain.SizeMedium: {CrossCheck: &ModelSpec{Model: "gpt-5.4-medium"}},
 				},
 			},
 		}
@@ -3206,7 +3208,7 @@ func TestValidateRuntime_CrossCheckModelsTreeFallback(t *testing.T) {
 			CrossCheckTimeout: 5 * time.Minute,
 			Models: ModelsConfig{
 				Sizes: map[string]RoleModels{
-					"large": {CrossCheck: &ModelSpec{Model: "gpt-5.4-large"}},
+					domain.SizeLarge: {CrossCheck: &ModelSpec{Model: "gpt-5.4-large"}},
 				},
 			},
 		}

--- a/internal/domain/size.go
+++ b/internal/domain/size.go
@@ -1,0 +1,7 @@
+package domain
+
+const (
+	SizeSmall  = "small"
+	SizeMedium = "medium"
+	SizeLarge  = "large"
+)

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
 )
 
 // UpdateBranchResult contains the result of an UpdateCurrentBranch operation.
@@ -264,11 +266,11 @@ const (
 func (d DiffSize) String() string {
 	switch d {
 	case DiffSizeSmall:
-		return "small"
+		return domain.SizeSmall
 	case DiffSizeMedium:
-		return "medium"
+		return domain.SizeMedium
 	case DiffSizeLarge:
-		return "large"
+		return domain.SizeLarge
 	default:
 		return "unknown"
 	}

--- a/internal/git/diff_size_test.go
+++ b/internal/git/diff_size_test.go
@@ -1,6 +1,10 @@
 package git
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/richhaase/agentic-code-reviewer/internal/domain"
+)
 
 func TestParseDiffStat(t *testing.T) {
 	tests := []struct {
@@ -96,9 +100,9 @@ func TestDiffSize_String(t *testing.T) {
 		size DiffSize
 		want string
 	}{
-		{DiffSizeSmall, "small"},
-		{DiffSizeMedium, "medium"},
-		{DiffSizeLarge, "large"},
+		{DiffSizeSmall, domain.SizeSmall},
+		{DiffSizeMedium, domain.SizeMedium},
+		{DiffSizeLarge, domain.SizeLarge},
 		{DiffSize(99), "unknown"},
 	}
 

--- a/internal/modelconfig/resolver_test.go
+++ b/internal/modelconfig/resolver_test.go
@@ -68,10 +68,10 @@ func TestResolve(t *testing.T) {
 						Reviewer: ms("x", ""),
 					},
 					Sizes: map[string]config.RoleModels{
-						"large": {Reviewer: ms("large-only", "")},
+						domain.SizeLarge: {Reviewer: ms("large-only", "")},
 					},
 				},
-				size:      "large",
+				size:      domain.SizeLarge,
 				role:      RoleReviewer,
 				agentName: "codex",
 			},
@@ -82,13 +82,13 @@ func TestResolve(t *testing.T) {
 			args: args{
 				cfgModels: config.ModelsConfig{
 					Sizes: map[string]config.RoleModels{
-						"large": {Reviewer: ms("large", "")},
+						domain.SizeLarge: {Reviewer: ms("large", "")},
 					},
 					Agents: map[string]config.RoleModels{
 						"codex": {Reviewer: ms("codex-only", "")},
 					},
 				},
-				size:      "large",
+				size:      domain.SizeLarge,
 				role:      RoleReviewer,
 				agentName: "codex",
 			},
@@ -155,7 +155,7 @@ func TestResolve(t *testing.T) {
 			args: args{
 				cfgModels: config.ModelsConfig{
 					Sizes: map[string]config.RoleModels{
-						"large": {Reviewer: ms("x", "")},
+						domain.SizeLarge: {Reviewer: ms("x", "")},
 					},
 				},
 				size:      "",
@@ -304,10 +304,10 @@ func TestResolveReviewer(t *testing.T) {
 						Reviewer: ms("def-gen", "med"),
 					},
 					Sizes: map[string]config.RoleModels{
-						"large": {DiffReviewer: ms("large-diff", "high")},
+						domain.SizeLarge: {DiffReviewer: ms("large-diff", "high")},
 					},
 				},
-				size:      "large",
+				size:      domain.SizeLarge,
 				phase:     domain.PhaseDiff,
 				agentName: "codex",
 			},


### PR DESCRIPTION
## Summary

- `internal/domain/size.go` に `SizeSmall`/`SizeMedium`/`SizeLarge` 定数を新規定義
- プロダクションコードおよびテストコード全体で散在していた `"small"`/`"medium"`/`"large"` マジック文字列を定数参照に置換
- タイポや不整合のリスクを排除し、`domain.PhaseArch`/`domain.PhaseDiff` と対称的な設計に統一

## Changed Files

| ファイル | 変更内容 |
|---------|---------|
| `internal/domain/size.go` | 新規: 定数定義 |
| `internal/git/diff.go` | `DiffSize.String()` を定数参照に変更 |
| `cmd/acr/review.go` | 全 size リテラル比較を定数に置換 |
| `cmd/acr/review_test.go` | テスト内リテラルを定数に置換 |
| `internal/config/config.go` | `validSizeKeys`, `Sizes["large"]` を定数に置換 |
| `internal/config/config_test.go` | テスト内マップキーを定数に置換 |
| `internal/git/diff_size_test.go` | テスト内リテラルを定数に置換 |
| `internal/modelconfig/resolver_test.go` | テスト内リテラルを定数に置換 |

## Test plan

- [x] `go build ./cmd/acr` 成功
- [x] `go test ./internal/domain/... ./internal/git/... ./internal/config/... ./internal/modelconfig/... ./cmd/acr/...` 全 PASS
- [x] `go vet ./...` PASS

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)