### PR TITLE
Fix Codex auth home propagation

### DIFF
--- a/.acr.yaml
+++ b/.acr.yaml
@@ -56,6 +56,12 @@ diff_reviewer_agents:
 
 # Agent for summarization: codex, claude, gemini
 summarizer_agent: claude
+
+# Codex CLI home is intentionally not configured in .acr.yaml because this file
+# is repository-controlled. Set ACR_CODEX_HOME as a Windows User environment
+# variable instead.
+# Precedence: ACR_CODEX_HOME > CODEX_HOME > USERPROFILE/HOME/.codex
+
 # Path to file containing review guidance
 # guidance_file: ""
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ PR feedback summarization runs in parallel with the reviewers and is enabled by 
 | `ACR_ARCH_REVIEWER_AGENT` | Single agent for arch phase in auto-phase grouped diff |
 | `ACR_DIFF_REVIEWER_AGENTS`| Agent(s) for diff phase in auto-phase grouped diff |
 | `ACR_SUMMARIZER_AGENT`    | Default summarizer agent  |
+| `ACR_CODEX_HOME`          | Codex home directory passed to `codex` subprocesses; set as a user environment variable, not in `.acr.yaml` |
+| `CODEX_HOME`              | Fallback Codex home directory when `ACR_CODEX_HOME` is unset |
 | `ACR_SUMMARIZER_TIMEOUT`  | Timeout for summarizer phase (e.g., "5m" or "300") |
 | `ACR_FP_FILTER_TIMEOUT`   | Timeout for false positive filter phase (e.g., "5m" or "300") |
 | `ACR_AUTO_PHASE`          | Enable auto-phase selection (true/false)   |
@@ -325,6 +327,14 @@ PR feedback summarization runs in parallel with the reviewers and is enabled by 
 | `ACR_STRICT`              | Exit 1 on any advisory verdict (true/false) |
 | `ACR_GUIDANCE`            | Steering context appended to review prompt |
 | `ACR_GUIDANCE_FILE`       | Path to file containing review guidance    |
+
+Codex auth home is intentionally operator-controlled. On Windows, prefer a User
+environment variable and restart the terminal/agent process so child `codex`
+processes inherit it:
+
+```powershell
+[Environment]::SetEnvironmentVariable("ACR_CODEX_HOME", "C:\Users\<you>\.acr-codex-home", "User")
+```
 
 ## Configuration
 
@@ -346,6 +356,9 @@ fetch: true               # Fetch base ref from origin before diff
 #   - claude
 #   - gemini
 # summarizer_agent: codex # Agent for summarization (codex, claude, gemini)
+# Codex home is intentionally not configurable in .acr.yaml because repository
+# config is shared. Set ACR_CODEX_HOME as a user environment variable instead.
+# Precedence: ACR_CODEX_HOME > CODEX_HOME > USERPROFILE/HOME/.codex
 # reviewer_model: ""      # LLM model override for review agents
 # summarizer_model: ""    # LLM model override for summarizer/FP filter agents
 summarizer_timeout: 5m    # Timeout for summarizer phase

--- a/cmd/acr/config_cmd.go
+++ b/cmd/acr/config_cmd.go
@@ -96,6 +96,11 @@ func newConfigShowCmd() *cobra.Command {
 				fmt.Fprintf(out, "  %-32s %s\n", "diff_reviewer_agents:", "(reviewer_agents)")
 			}
 			fmt.Fprintf(out, "  %-32s %s\n", "summarizer_agent:", resolved.SummarizerAgent)
+			if resolved.CodexHome != "" {
+				fmt.Fprintf(out, "  %-32s %s\n", "codex_home (env):", resolved.CodexHome)
+			} else {
+				fmt.Fprintf(out, "  %-32s %s\n", "codex_home (env):", "(ACR_CODEX_HOME/CODEX_HOME env or USERPROFILE/HOME/.codex)")
+			}
 			fmt.Fprintln(out)
 
 			// Models
@@ -244,6 +249,10 @@ func newConfigInitCmd() *cobra.Command {
 
 # Agent for summarization: codex, claude, gemini
 # summarizer_agent: codex
+
+# Codex CLI home is not read from .acr.yaml because repository config is shared.
+# Set ACR_CODEX_HOME as a Windows User environment variable instead.
+# Precedence: ACR_CODEX_HOME > CODEX_HOME > USERPROFILE/HOME/.codex
 
 # Timeout for summarizer phase (default: 5m)
 # summarizer_timeout: 5m

--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -28,6 +28,14 @@ func cliOrLegacy(value string, fromCLI bool) (cli, legacy string) {
 	return "", value
 }
 
+func agentOptions(model, effort string, opts ReviewOpts) agent.AgentOptions {
+	return agent.AgentOptions{
+		Model:     model,
+		Effort:    effort,
+		CodexHome: opts.CodexHome,
+	}
+}
+
 func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger) domain.ExitCode {
 	if err := agent.ValidateAgentNames(opts.ReviewerAgents); err != nil {
 		logger.Logf(terminal.StyleError, "Invalid agent: %v", err)
@@ -113,7 +121,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		)
 		reviewerSpecs = append(reviewerSpecs, agent.AgentSpec{
 			Name:    name,
-			Options: agent.AgentOptions{Model: spec.Model, Effort: spec.Effort},
+			Options: agentOptions(spec.Model, spec.Effort, opts),
 		})
 	}
 	reviewAgents, err := agent.CreateAgentsFromSpecs(reviewerSpecs)
@@ -137,7 +145,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			cliRevModel, "",
 			legacyRevModel, "",
 		)
-		a, err := agent.NewAgentWithOptions(name, agent.AgentOptions{Model: spec.Model, Effort: spec.Effort})
+		a, err := agent.NewAgentWithOptions(name, agentOptions(spec.Model, spec.Effort, opts))
 		if err != nil {
 			return origAgent
 		}
@@ -150,7 +158,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		cliSumModel, "",
 		legacySumModel, "",
 	)
-	summarizerAgent, err := agent.NewAgentWithOptions(opts.SummarizerAgent, agent.AgentOptions{Model: summSpec.Model, Effort: summSpec.Effort})
+	summarizerAgent, err := agent.NewAgentWithOptions(opts.SummarizerAgent, agentOptions(summSpec.Model, summSpec.Effort, opts))
 	if err != nil {
 		logger.Logf(terminal.StyleError, "Invalid summarizer agent: %v", err)
 		return domain.ExitError
@@ -474,7 +482,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 				cliSumModelPR, "",
 				legacySumModelPR, "",
 			)
-			summarizer := feedback.NewSummarizer(feedbackAgentName, prSpec.Model, prSpec.Effort, opts.Verbose, logger)
+			summarizer := feedback.NewSummarizer(feedbackAgentName, prSpec.Model, prSpec.Effort, opts.CodexHome, opts.Verbose, logger)
 			feedbackCtx, feedbackCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 			defer feedbackCancel()
 
@@ -548,7 +556,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			)
 			ccSpecs = append(ccSpecs, summarizer.CrossCheckAgentSpec{
 				Name:    name,
-				Options: summarizer.CrossCheckOptions{Model: perSpec.Model, Effort: perSpec.Effort},
+				Options: summarizer.CrossCheckOptions{Model: perSpec.Model, Effort: perSpec.Effort, CodexHome: opts.CodexHome},
 			})
 		}
 		// Lazy CLI availability check: only verify cross-check agent CLIs are
@@ -561,7 +569,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			return domain.ExitError
 		}
 		for _, spec := range ccSpecs {
-			ccAg, err := agent.NewAgentWithOptions(spec.Name, agent.AgentOptions{Model: spec.Options.Model, Effort: spec.Options.Effort})
+			ccAg, err := agent.NewAgentWithOptions(spec.Name, agent.AgentOptions{Model: spec.Options.Model, Effort: spec.Options.Effort, CodexHome: spec.Options.CodexHome})
 			if err != nil {
 				logger.Logf(terminal.StyleError, "Invalid cross-check agent %q: %v", spec.Name, err)
 				return domain.ExitError
@@ -612,7 +620,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	summarizerCtx, summarizerCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 	defer summarizerCancel()
 
-	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, summarizer.SummarizeOptions{Model: summSpec.Model, Effort: summSpec.Effort}, aggregated, ccResult, opts.Verbose, logger)
+	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, summarizer.SummarizeOptions{Model: summSpec.Model, Effort: summSpec.Effort, CodexHome: opts.CodexHome}, aggregated, ccResult, opts.Verbose, logger)
 	spinnerCancel()
 	<-spinnerDone
 
@@ -664,7 +672,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			fpAgentName = opts.SummarizerAgent
 		}
 		if fpAgentName != opts.SummarizerAgent {
-			fpAg, err := agent.NewAgentWithOptions(fpAgentName, agent.AgentOptions{})
+			fpAg, err := agent.NewAgentWithOptions(fpAgentName, agent.AgentOptions{CodexHome: opts.CodexHome})
 			if err != nil {
 				fpSpinnerCancel()
 				<-fpSpinnerDone
@@ -693,7 +701,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			cliFPModel, cliFPEffort,
 			legacyFPModel, legacyFPEffort,
 		)
-		fpFilter := fpfilter.New(fpAgentName, fpSpec.Model, fpSpec.Effort, opts.FPThreshold, opts.TriageEnabled, opts.Verbose, logger)
+		fpFilter := fpfilter.New(fpAgentName, fpSpec.Model, fpSpec.Effort, opts.CodexHome, opts.FPThreshold, opts.TriageEnabled, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, priorFeedback, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone
@@ -1284,7 +1292,7 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 		cliRevModel, "",
 		legacyRevModel, "",
 	)
-	archAgent, err := agent.NewAgentWithOptions(archAgentName, agent.AgentOptions{Model: archSpec.Model, Effort: archSpec.Effort})
+	archAgent, err := agent.NewAgentWithOptions(archAgentName, agentOptions(archSpec.Model, archSpec.Effort, opts))
 	if err != nil {
 		return nil, nil, fmt.Errorf("arch reviewer %q: %w", archAgentName, err)
 	}
@@ -1307,7 +1315,7 @@ func buildPhaseAgents(opts ReviewOpts, sizeStr string) (agent.Agent, []agent.Age
 			cliRevModel, "",
 			legacyRevModel, "",
 		)
-		a, err := agent.NewAgentWithOptions(name, agent.AgentOptions{Model: spec.Model, Effort: spec.Effort})
+		a, err := agent.NewAgentWithOptions(name, agentOptions(spec.Model, spec.Effort, opts))
 		if err != nil {
 			return nil, nil, fmt.Errorf("diff reviewer %q: %w", name, err)
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,6 +16,10 @@ import (
 type AgentOptions struct {
 	Model  string
 	Effort string
+	// CodexHome is the resolved Codex home for codex subprocesses.
+	// It is supplied by operator-controlled environment resolution, not by
+	// repository .acr.yaml content.
+	CodexHome string
 }
 
 // Agent represents a backend that can execute code reviews and summarizations.
@@ -44,6 +48,6 @@ type Agent interface {
 
 	// Options returns the AgentOptions the agent was constructed with.
 	// Used by callers (e.g., runner.BuildReviewerSpecs) to merge per-phase
-	// overrides with the agent's existing model/effort configuration.
+	// overrides with the agent's existing construction options.
 	Options() AgentOptions
 }

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -31,8 +33,9 @@ var _ Agent = (*CodexAgent)(nil)
 
 // CodexAgent implements the Agent interface for the Codex CLI backend.
 type CodexAgent struct {
-	model  string
-	effort string
+	model     string
+	effort    string
+	codexHome string
 }
 
 // NewCodexAgent creates a new CodexAgent instance.
@@ -43,7 +46,7 @@ func NewCodexAgent(model string) *CodexAgent {
 
 // NewCodexAgentWithOptions creates a new CodexAgent instance with the given options.
 func NewCodexAgentWithOptions(opts AgentOptions) *CodexAgent {
-	return &CodexAgent{model: opts.Model, effort: opts.Effort}
+	return &CodexAgent{model: opts.Model, effort: opts.Effort, codexHome: opts.CodexHome}
 }
 
 // Name returns the agent's identifier.
@@ -53,7 +56,7 @@ func (c *CodexAgent) Name() string {
 
 // Options returns the AgentOptions the agent was constructed with.
 func (c *CodexAgent) Options() AgentOptions {
-	return AgentOptions{Model: c.model, Effort: c.effort}
+	return AgentOptions{Model: c.model, Effort: c.effort, CodexHome: c.codexHome}
 }
 
 // IsAvailable checks if the codex CLI is installed and accessible.
@@ -97,6 +100,7 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 		return executeDiffBasedReview(ctx, config, diffReviewConfig{
 			Command:       "codex",
 			Args:          args,
+			Env:           c.codexEnv(),
 			DefaultPrompt: DefaultCodexPrompt,
 			RefFilePrompt: DefaultCodexRefFilePrompt,
 		})
@@ -111,6 +115,7 @@ func (c *CodexAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*
 	return executeCommand(ctx, executeOptions{
 		Command: "codex",
 		Args:    args,
+		Env:     c.codexEnv(),
 		WorkDir: config.WorkDir,
 	})
 }
@@ -144,5 +149,47 @@ func (c *CodexAgent) ExecuteSummary(ctx context.Context, prompt string, input []
 		Command: "codex",
 		Args:    args,
 		Stdin:   stdin,
+		Env:     c.codexEnv(),
 	})
+}
+
+func (c *CodexAgent) codexEnv() map[string]string {
+	env := make(map[string]string)
+
+	codexHome := strings.TrimSpace(c.codexHome)
+	if codexHome == "" {
+		codexHome = strings.TrimSpace(os.Getenv("ACR_CODEX_HOME"))
+	}
+	if codexHome == "" {
+		codexHome = strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	}
+	if codexHome == "" {
+		codexHome = defaultCodexHome()
+	}
+	if codexHome != "" {
+		env["CODEX_HOME"] = codexHome
+	}
+
+	userProfile := strings.TrimSpace(os.Getenv("USERPROFILE"))
+	home := strings.TrimSpace(os.Getenv("HOME"))
+
+	if userProfile == "" && home != "" {
+		env["USERPROFILE"] = home
+	}
+	if home == "" && userProfile != "" {
+		env["HOME"] = userProfile
+	}
+	env["LC_ALL"] = "C"
+
+	return env
+}
+
+func defaultCodexHome() string {
+	if userProfile := strings.TrimSpace(os.Getenv("USERPROFILE")); userProfile != "" {
+		return filepath.Join(userProfile, ".codex")
+	}
+	if home := strings.TrimSpace(os.Getenv("HOME")); home != "" {
+		return filepath.Join(home, ".codex")
+	}
+	return ""
 }

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -311,6 +311,142 @@ func TestCodexAgent_ExecuteSummary_Args(t *testing.T) {
 	}
 }
 
+func TestCodexAgent_ExecuteReview_PassesConfiguredCodexAuthEnv(t *testing.T) {
+	prepareMockCLI(t, "codex", "env")
+
+	configuredCodexHome := filepath.Join(t.TempDir(), "configured-codex")
+	userProfile := filepath.Join(t.TempDir(), "profile")
+	appData := filepath.Join(t.TempDir(), "appdata")
+	localAppData := filepath.Join(t.TempDir(), "localappdata")
+	t.Setenv("ACR_CODEX_HOME", "")
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", userProfile)
+	t.Setenv("APPDATA", appData)
+	t.Setenv("LOCALAPPDATA", localAppData)
+
+	agent := NewCodexAgentWithOptions(AgentOptions{CodexHome: configuredCodexHome})
+	result, err := agent.ExecuteReview(context.Background(), &ReviewConfig{
+		BaseRef: "main",
+		WorkDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	env := parseEnvOutput(string(output))
+
+	if got := env["CODEX_HOME"]; got != configuredCodexHome {
+		t.Errorf("CODEX_HOME = %q, want %q", got, configuredCodexHome)
+	}
+	if got := env["USERPROFILE"]; got != userProfile {
+		t.Errorf("USERPROFILE = %q, want %q", got, userProfile)
+	}
+	if got := env["HOME"]; got != userProfile {
+		t.Errorf("HOME = %q, want %q", got, userProfile)
+	}
+	if got := env["APPDATA"]; got != appData {
+		t.Errorf("APPDATA = %q, want %q", got, appData)
+	}
+	if got := env["LOCALAPPDATA"]; got != localAppData {
+		t.Errorf("LOCALAPPDATA = %q, want %q", got, localAppData)
+	}
+	if got := env["LC_ALL"]; got != "C" {
+		t.Errorf("LC_ALL = %q, want %q", got, "C")
+	}
+}
+
+func TestCodexAgent_ExecuteReview_ConfiguredCodexHomeOverridesProcessEnv(t *testing.T) {
+	prepareMockCLI(t, "codex", "env")
+
+	configuredCodexHome := filepath.Join(t.TempDir(), "configured-codex")
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	acrCodexHome := filepath.Join(t.TempDir(), "acr-codex-home")
+	t.Setenv("ACR_CODEX_HOME", acrCodexHome)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	agent := NewCodexAgentWithOptions(AgentOptions{CodexHome: configuredCodexHome})
+	result, err := agent.ExecuteReview(context.Background(), &ReviewConfig{
+		BaseRef: "main",
+		WorkDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	env := parseEnvOutput(string(output))
+	if got := env["CODEX_HOME"]; got != configuredCodexHome {
+		t.Errorf("CODEX_HOME = %q, want %q", got, configuredCodexHome)
+	}
+}
+
+func TestCodexAgent_ExecuteReview_CodexHomeFallsBackToProcessEnv(t *testing.T) {
+	prepareMockCLI(t, "codex", "env")
+
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	acrCodexHome := filepath.Join(t.TempDir(), "acr-codex-home")
+	t.Setenv("ACR_CODEX_HOME", acrCodexHome)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	agent := NewCodexAgent("")
+	result, err := agent.ExecuteReview(context.Background(), &ReviewConfig{
+		BaseRef: "main",
+		WorkDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	env := parseEnvOutput(string(output))
+	if got := env["CODEX_HOME"]; got != acrCodexHome {
+		t.Errorf("CODEX_HOME = %q, want %q", got, acrCodexHome)
+	}
+}
+
+func TestCodexAgent_ExecuteReview_DefaultCodexHomeFromUserProfile(t *testing.T) {
+	prepareMockCLI(t, "codex", "env")
+
+	userProfile := filepath.Join(t.TempDir(), "profile")
+	t.Setenv("ACR_CODEX_HOME", "")
+	t.Setenv("CODEX_HOME", "")
+	t.Setenv("USERPROFILE", userProfile)
+
+	agent := NewCodexAgent("")
+	result, err := agent.ExecuteReview(context.Background(), &ReviewConfig{
+		BaseRef: "main",
+		WorkDir: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+	env := parseEnvOutput(string(output))
+	want := filepath.Join(userProfile, ".codex")
+	if got := env["CODEX_HOME"]; got != want {
+		t.Errorf("CODEX_HOME = %q, want %q", got, want)
+	}
+}
+
 func TestCodexReasoningEffortArgs(t *testing.T) {
 	cases := []struct {
 		in   string
@@ -337,6 +473,17 @@ func TestCodexReasoningEffortArgs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func parseEnvOutput(output string) map[string]string {
+	env := make(map[string]string)
+	for _, line := range strings.Split(output, "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if ok {
+			env[key] = value
+		}
+	}
+	return env
 }
 
 func TestCodexAgent_ExecuteReview_WithEffort(t *testing.T) {

--- a/internal/agent/diff_review.go
+++ b/internal/agent/diff_review.go
@@ -15,6 +15,8 @@ type diffReviewConfig struct {
 	Command string
 	// Args are the CLI arguments (e.g., ["--print", "-"] for claude).
 	Args []string
+	// Env adds or overrides environment variables for this command.
+	Env map[string]string
 	// DefaultPrompt is the standard review prompt template for this agent.
 	DefaultPrompt string
 	// RefFilePrompt is the review prompt template used when diff is in a file (must have %s for path).
@@ -83,6 +85,7 @@ func executeDiffBasedReview(ctx context.Context, config *ReviewConfig, dc diffRe
 		Command:      dc.Command,
 		Args:         dc.Args,
 		Stdin:        stdin,
+		Env:          dc.Env,
 		WorkDir:      config.WorkDir,
 		TempFilePath: tempFilePath,
 	})

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 )
 
@@ -66,6 +69,8 @@ type executeOptions struct {
 	Stdin io.Reader
 	// WorkDir sets the working directory for the command.
 	WorkDir string
+	// Env adds or overrides environment variables for this command.
+	Env map[string]string
 	// TempFilePath is a temp file to clean up on Close (used by ref-file pattern).
 	TempFilePath string
 }
@@ -84,6 +89,9 @@ func executeCommand(ctx context.Context, opts executeOptions) (*ExecutionResult,
 	// #nosec G204 - Command is always one of the known agent CLIs (codex, claude, gemini)
 	// passed from trusted code in the agent implementations, not user input.
 	cmd := exec.CommandContext(ctx, opts.Command, opts.Args...)
+	if len(opts.Env) > 0 {
+		cmd.Env = mergeEnv(os.Environ(), opts.Env)
+	}
 
 	if opts.Stdin != nil {
 		cmd.Stdin = opts.Stdin
@@ -123,4 +131,45 @@ func executeCommand(ctx context.Context, opts executeOptions) (*ExecutionResult,
 	}
 
 	return reader.ToExecutionResult(), nil
+}
+
+func mergeEnv(base []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+
+	out := make([]string, 0, len(base)+len(overrides))
+	seen := make(map[string]int, len(base)+len(overrides))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			out = append(out, entry)
+			continue
+		}
+		norm := normalizeEnvKey(key)
+		seen[norm] = len(out)
+		out = append(out, entry)
+	}
+
+	for key, value := range overrides {
+		if key == "" {
+			continue
+		}
+		entry := key + "=" + value
+		norm := normalizeEnvKey(key)
+		if idx, ok := seen[norm]; ok {
+			out[idx] = entry
+			continue
+		}
+		seen[norm] = len(out)
+		out = append(out, entry)
+	}
+	return out
+}
+
+func normalizeEnvKey(key string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
 }

--- a/internal/agent/testhelpers_test.go
+++ b/internal/agent/testhelpers_test.go
@@ -35,6 +35,8 @@ func runAgentTestHelper() int {
 		return emitArgs(false, false)
 	case "args-prefix-stdin":
 		return emitArgs(true, true)
+	case "env":
+		return emitEnv("CODEX_HOME", "HOME", "USERPROFILE", "APPDATA", "LOCALAPPDATA", "LC_ALL")
 	case "stdin":
 		_, _ = io.Copy(os.Stdout, os.Stdin)
 		return 0
@@ -60,6 +62,14 @@ func runAgentTestHelper() int {
 		_, _ = io.Copy(io.Discard, os.Stdin)
 		return 0
 	}
+}
+
+func emitEnv(keys ...string) int {
+	for _, key := range keys {
+		fmt.Fprintf(os.Stdout, "%s=%s\n", key, os.Getenv(key))
+	}
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	return 0
 }
 
 func emitArgs(prefix bool, copyStdin bool) int {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -856,6 +856,7 @@ type ResolvedConfig struct {
 	// ReviewerAgents.
 	DiffReviewerAgents     []string
 	SummarizerAgent        string
+	CodexHome              string
 	ReviewerModel          string
 	SummarizerModel        string
 	SummarizerTimeout      time.Duration
@@ -956,6 +957,8 @@ type EnvState struct {
 	DiffReviewerAgentsSet  bool
 	SummarizerAgent        string
 	SummarizerAgentSet     bool
+	CodexHome              string
+	CodexHomeSet           bool
 	ReviewerModel          string
 	ReviewerModelSet       bool
 	SummarizerModel        string
@@ -1102,6 +1105,13 @@ func LoadEnvState() (EnvState, []string) {
 	if v := os.Getenv("ACR_SUMMARIZER_AGENT"); v != "" {
 		state.SummarizerAgent = v
 		state.SummarizerAgentSet = true
+	}
+	if v := strings.TrimSpace(os.Getenv("ACR_CODEX_HOME")); v != "" {
+		state.CodexHome = v
+		state.CodexHomeSet = true
+	} else if v := strings.TrimSpace(os.Getenv("CODEX_HOME")); v != "" {
+		state.CodexHome = v
+		state.CodexHomeSet = true
 	}
 	if v := os.Getenv("ACR_REVIEWER_MODEL"); v != "" {
 		state.ReviewerModel = v
@@ -1458,6 +1468,9 @@ func Resolve(cfg *Config, envState EnvState, flagState FlagState, flagValues Res
 	}
 	if envState.SummarizerAgentSet {
 		result.SummarizerAgent = envState.SummarizerAgent
+	}
+	if envState.CodexHomeSet {
+		result.CodexHome = envState.CodexHome
 	}
 	if envState.ReviewerModelSet {
 		result.ReviewerModel = envState.ReviewerModel

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -420,6 +420,62 @@ func TestResolve_ConfigOverridesDefault(t *testing.T) {
 	}
 }
 
+func TestResolve_CodexHomeFromEnvOnly(t *testing.T) {
+	envState := EnvState{CodexHome: "env-codex-home", CodexHomeSet: true}
+	result := Resolve(&Config{}, envState, FlagState{}, ResolvedConfig{})
+	if result.CodexHome != "env-codex-home" {
+		t.Errorf("expected env CodexHome, got %q", result.CodexHome)
+	}
+}
+
+func TestLoadEnvState_CodexHomePrecedence(t *testing.T) {
+	t.Setenv("ACR_CODEX_HOME", "acr-codex-home")
+	t.Setenv("CODEX_HOME", "codex-home")
+
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.CodexHomeSet {
+		t.Fatal("expected CodexHomeSet=true")
+	}
+	if state.CodexHome != "acr-codex-home" {
+		t.Errorf("expected ACR_CODEX_HOME to win, got %q", state.CodexHome)
+	}
+}
+
+func TestLoadEnvState_CodexHomeFallsBackToCodexHome(t *testing.T) {
+	t.Setenv("ACR_CODEX_HOME", "")
+	t.Setenv("CODEX_HOME", "codex-home")
+
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.CodexHomeSet {
+		t.Fatal("expected CodexHomeSet=true")
+	}
+	if state.CodexHome != "codex-home" {
+		t.Errorf("expected CODEX_HOME fallback, got %q", state.CodexHome)
+	}
+}
+
+func TestLoadEnvState_CodexHomeTrimsWhitespaceAndFallsBack(t *testing.T) {
+	t.Setenv("ACR_CODEX_HOME", "   ")
+	t.Setenv("CODEX_HOME", " codex-home ")
+
+	state, warnings := LoadEnvState()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+	if !state.CodexHomeSet {
+		t.Fatal("expected CodexHomeSet=true")
+	}
+	if state.CodexHome != "codex-home" {
+		t.Errorf("expected trimmed CODEX_HOME fallback, got %q", state.CodexHome)
+	}
+}
+
 func TestResolve_DefaultsUsedWhenNothingSet(t *testing.T) {
 	cfg := &Config{} // empty config
 	envState := EnvState{}
@@ -3347,6 +3403,30 @@ func TestCheckUnknownKeys_RolePromptsIsKnown(t *testing.T) {
 		if strings.Contains(w, "role_prompts") {
 			t.Errorf("role_prompts should be a known key, got warning: %s", w)
 		}
+	}
+}
+
+func TestLoadFromPathWithWarnings_CodexHomeIsUnknown(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, ".acr.yaml")
+
+	content := "codex_home: C:/Users/example/.codex\n"
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := LoadFromPathWithWarnings(configPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "codex_home") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected unknown-key warning for codex_home, got %v", result.Warnings)
 	}
 }
 

--- a/internal/feedback/summarizer.go
+++ b/internal/feedback/summarizer.go
@@ -15,6 +15,7 @@ type Summarizer struct {
 	agentName string
 	model     string
 	effort    string
+	codexHome string
 	verbose   bool
 	logger    *terminal.Logger
 }
@@ -22,11 +23,13 @@ type Summarizer struct {
 // NewSummarizer creates a new PR feedback summarizer.
 // The model parameter overrides the agent's default model (empty = default).
 // The effort parameter overrides the agent's default reasoning effort (empty = default).
-func NewSummarizer(agentName, model, effort string, verbose bool, logger *terminal.Logger) *Summarizer {
+// The codexHome parameter is passed through only to Codex agent subprocesses.
+func NewSummarizer(agentName, model, effort, codexHome string, verbose bool, logger *terminal.Logger) *Summarizer {
 	return &Summarizer{
 		agentName: agentName,
 		model:     model,
 		effort:    effort,
+		codexHome: codexHome,
 		verbose:   verbose,
 		logger:    logger,
 	}
@@ -52,7 +55,7 @@ func (s *Summarizer) Summarize(ctx context.Context, prNumber string) (string, er
 	input := s.buildInput(prCtx)
 
 	// Create agent
-	ag, err := agent.NewAgentWithOptions(s.agentName, agent.AgentOptions{Model: s.model, Effort: s.effort})
+	ag, err := agent.NewAgentWithOptions(s.agentName, agent.AgentOptions{Model: s.model, Effort: s.effort, CodexHome: s.codexHome})
 	if err != nil {
 		return "", fmt.Errorf("failed to create agent: %w", err)
 	}

--- a/internal/feedback/summarizer_test.go
+++ b/internal/feedback/summarizer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSummarizer_EmptyPRNumber(t *testing.T) {
-	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", "", false, terminal.NewLogger())
 	_, err := s.Summarize(context.Background(), "")
 	if err == nil {
 		t.Error("expected error for empty PR number")
@@ -17,14 +17,14 @@ func TestSummarizer_EmptyPRNumber(t *testing.T) {
 }
 
 func TestNewSummarizer(t *testing.T) {
-	s := NewSummarizer("claude", "", "", true, terminal.NewLogger())
+	s := NewSummarizer("claude", "", "", "", true, terminal.NewLogger())
 	if s == nil {
 		t.Fatal("NewSummarizer returned nil")
 	}
 }
 
 func TestBuildInput_DescriptionOnly(t *testing.T) {
-	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Description: "This PR fixes the login bug",
 	}
@@ -43,7 +43,7 @@ func TestBuildInput_DescriptionOnly(t *testing.T) {
 }
 
 func TestBuildInput_CommentsOnly(t *testing.T) {
-	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Comments: []Comment{
 			{Author: "alice", Body: "LGTM"},
@@ -68,7 +68,7 @@ func TestBuildInput_CommentsOnly(t *testing.T) {
 }
 
 func TestBuildInput_WithReplies(t *testing.T) {
-	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Description: "Fix issue",
 		Comments: []Comment{
@@ -97,7 +97,7 @@ func TestBuildInput_WithReplies(t *testing.T) {
 }
 
 func TestBuildInput_EmptyContext(t *testing.T) {
-	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{}
 
 	result := s.buildInput(prCtx)
@@ -114,7 +114,7 @@ func TestBuildInput_EmptyContext(t *testing.T) {
 }
 
 func TestBuildInput_FullContext(t *testing.T) {
-	s := NewSummarizer("codex", "", "", false, terminal.NewLogger())
+	s := NewSummarizer("codex", "", "", "", false, terminal.NewLogger())
 	prCtx := &PRContext{
 		Number:      "42",
 		Description: "Refactor auth module to use JWT tokens",

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -41,6 +41,7 @@ type Filter struct {
 	agentName     string
 	model         string
 	effort        string
+	codexHome     string
 	threshold     int
 	triageEnabled bool
 	verbose       bool
@@ -50,10 +51,11 @@ type Filter struct {
 // New creates a new false positive filter.
 // The model parameter overrides the agent's default model (empty = default).
 // The effort parameter overrides the agent's default reasoning effort (empty = default).
+// The codexHome parameter is passed through only to Codex agent subprocesses.
 // When triageEnabled is true, severity-based classification (blocking/advisory/noise)
 // is applied in addition to fp_score filtering.
 // If verbose is true, non-fatal errors (like Close failures) are logged.
-func New(agentName, model, effort string, threshold int, triageEnabled, verbose bool, logger *terminal.Logger) *Filter {
+func New(agentName, model, effort, codexHome string, threshold int, triageEnabled, verbose bool, logger *terminal.Logger) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
@@ -61,6 +63,7 @@ func New(agentName, model, effort string, threshold int, triageEnabled, verbose 
 		agentName:     agentName,
 		model:         model,
 		effort:        effort,
+		codexHome:     codexHome,
 		threshold:     threshold,
 		triageEnabled: triageEnabled,
 		logger:        logger,
@@ -135,7 +138,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, prio
 		}
 	}
 
-	ag, err := agent.NewAgentWithOptions(f.agentName, agent.AgentOptions{Model: f.model, Effort: f.effort})
+	ag, err := agent.NewAgentWithOptions(f.agentName, agent.AgentOptions{Model: f.model, Effort: f.effort, CodexHome: f.codexHome})
 	if err != nil {
 		return skippedResult(grouped, start, "agent creation failed: "+err.Error())
 	}

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFilter_New(t *testing.T) {
-	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
 	if f == nil {
 		t.Fatal("New returned nil")
 	}
@@ -185,7 +185,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := New("codex", "", "", tt.threshold, false, false, logger)
+			f := New("codex", "", "", "", tt.threshold, false, false, logger)
 			if f.threshold != tt.expectedThreshold {
 				t.Errorf("threshold = %d, want %d", f.threshold, tt.expectedThreshold)
 			}
@@ -194,7 +194,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 }
 
 func TestApply_EmptyFindings(t *testing.T) {
-	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -219,7 +219,7 @@ func TestApply_EmptyFindings(t *testing.T) {
 }
 
 func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
-	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -233,7 +233,7 @@ func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
 }
 
 func TestApply_EmptyFindingsPreservesInfo(t *testing.T) {
-	f := New("codex", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 		Info: []domain.FindingGroup{

--- a/internal/runner/phase.go
+++ b/internal/runner/phase.go
@@ -14,6 +14,7 @@ type PhaseConfig struct {
 	AgentName     string // Which agent to use (empty = default from caller)
 	Model         string // Model override (empty = agent default)
 	Effort        string // Reasoning effort override (empty = agent default)
+	CodexHome     string // Codex home override passed only to Codex agents
 	Prompt        string // Per-phase guidance override (empty = use global guidance; phase prompt template is selected by Phase)
 }
 
@@ -41,25 +42,28 @@ func BuildReviewerSpecs(phases []PhaseConfig, defaultAgents []agent.Agent, globa
 			var a agent.Agent
 			if pc.AgentName != "" {
 				var err error
-				a, err = agent.NewAgentWithOptions(pc.AgentName, agent.AgentOptions{Model: pc.Model, Effort: pc.Effort})
+				a, err = agent.NewAgentWithOptions(pc.AgentName, agent.AgentOptions{Model: pc.Model, Effort: pc.Effort, CodexHome: pc.CodexHome})
 				if err != nil {
 					return nil, fmt.Errorf("phase %q agent %q: %w", pc.Phase, pc.AgentName, err)
 				}
 			} else {
 				base := agent.AgentForReviewer(defaultAgents, reviewerIdx)
-				if pc.Effort != "" || pc.Model != "" {
+				if pc.Effort != "" || pc.Model != "" || pc.CodexHome != "" {
 					// Merge: pc.Effort/Model が空のときは base agent の既存値を継承する。
 					// 部分 override (例: pc.Effort="high" のみ) で base agent の model
 					// 設定が落ちないようにするための cascade。現状 caller はこの分岐に
 					// 到達しないが (parsePhases / auto-phase はいずれも pc.Effort/Model
 					// を空に保つ)、将来 caller が増えたときの regression を予防する。
 					baseOpts := base.Options()
-					merged := agent.AgentOptions{Model: pc.Model, Effort: pc.Effort}
+					merged := agent.AgentOptions{Model: pc.Model, Effort: pc.Effort, CodexHome: pc.CodexHome}
 					if merged.Model == "" {
 						merged.Model = baseOpts.Model
 					}
 					if merged.Effort == "" {
 						merged.Effort = baseOpts.Effort
+					}
+					if merged.CodexHome == "" {
+						merged.CodexHome = baseOpts.CodexHome
 					}
 					var rebindErr error
 					a, rebindErr = agent.NewAgentWithOptions(base.Name(), merged)

--- a/internal/runner/phase_test.go
+++ b/internal/runner/phase_test.go
@@ -10,9 +10,10 @@ import (
 
 // mockPhaseAgent implements agent.Agent for phase testing.
 type mockPhaseAgent struct {
-	name   string
-	model  string
-	effort string
+	name      string
+	model     string
+	effort    string
+	codexHome string
 }
 
 func (m *mockPhaseAgent) Name() string       { return m.name }
@@ -24,7 +25,7 @@ func (m *mockPhaseAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (
 	return nil, nil
 }
 func (m *mockPhaseAgent) Options() agent.AgentOptions {
-	return agent.AgentOptions{Model: m.model, Effort: m.effort}
+	return agent.AgentOptions{Model: m.model, Effort: m.effort, CodexHome: m.codexHome}
 }
 
 func TestBuildReviewerSpecs_ArchAndDiff(t *testing.T) {
@@ -162,15 +163,15 @@ func TestDefaultPromptForPhase(t *testing.T) {
 	}
 }
 
-// TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseModel locks in the
+// TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseOptions locks in the
 // cascade-merge behavior added in Round-9: when a PhaseConfig overrides only
 // Effort (or only Model) on the AgentName=="" path, the rebuilt agent must
-// inherit the unset field from the base agent's existing options instead of
-// silently dropping it. The current callers never populate PhaseConfig.Effort
-// or .Model, so this guard exists purely to prevent a future caller from
+// inherit unset fields from the base agent's existing options instead of
+// silently dropping them. The current callers never populate PhaseConfig.Effort
+// or .Model directly, so this guard exists purely to prevent a future caller from
 // re-introducing the Round-8 dead-code regression.
-func TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseModel(t *testing.T) {
-	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: ""}
+func TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseOptions(t *testing.T) {
+	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: "", codexHome: "base-codex-home"}
 	phases := []PhaseConfig{
 		{Phase: domain.PhaseDiff, ReviewerCount: 1, Effort: "high"},
 	}
@@ -189,5 +190,34 @@ func TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseModel(t *testing.T) {
 	}
 	if got.Effort != "high" {
 		t.Errorf("phase override lost: Options().Effort = %q, want %q", got.Effort, "high")
+	}
+	if got.CodexHome != "base-codex-home" {
+		t.Errorf("base CodexHome dropped: Options().CodexHome = %q, want %q", got.CodexHome, "base-codex-home")
+	}
+}
+
+func TestBuildReviewerSpecs_PhaseConfigCodexHomeOverridesBase(t *testing.T) {
+	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: "medium", codexHome: "base-codex-home"}
+	phases := []PhaseConfig{
+		{Phase: domain.PhaseDiff, ReviewerCount: 1, CodexHome: "phase-codex-home"},
+	}
+
+	specs, err := BuildReviewerSpecs(phases, []agent.Agent{base}, "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("got %d specs, want 1", len(specs))
+	}
+
+	got := specs[0].Agent.Options()
+	if got.Model != "gpt-5" {
+		t.Errorf("base model dropped: Options().Model = %q, want %q", got.Model, "gpt-5")
+	}
+	if got.Effort != "medium" {
+		t.Errorf("base effort dropped: Options().Effort = %q, want %q", got.Effort, "medium")
+	}
+	if got.CodexHome != "phase-codex-home" {
+		t.Errorf("phase CodexHome override lost: Options().CodexHome = %q, want %q", got.CodexHome, "phase-codex-home")
 	}
 }

--- a/internal/summarizer/crosscheck.go
+++ b/internal/summarizer/crosscheck.go
@@ -297,8 +297,9 @@ func buildCrossCheckPayload(ccCtx CrossCheckContext) crossCheckPayload {
 // CrossCheckOptions bundles model/effort resolution for the cross-check role.
 // Empty fields fall back to the agent's built-in defaults.
 type CrossCheckOptions struct {
-	Model  string
-	Effort string
+	Model     string
+	Effort    string
+	CodexHome string
 }
 
 // CrossCheckAgentSpec bundles a cross-check agent name with its pre-resolved
@@ -422,7 +423,7 @@ func runCrossCheckAgent(
 	start := time.Now()
 	result := AgentCrossCheckResult{AgentName: agentName}
 
-	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort})
+	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort, CodexHome: opts.CodexHome})
 	if err != nil {
 		result.Err = fmt.Errorf("agent creation failed: %w", err)
 		result.Duration = time.Since(start)

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -112,8 +112,9 @@ type inputItem struct {
 // SummarizeOptions bundles model/effort resolution for the summarizer role.
 // Empty fields fall back to the agent's built-in defaults.
 type SummarizeOptions struct {
-	Model  string
-	Effort string
+	Model     string
+	Effort    string
+	CodexHome string
 }
 
 // Summarize summarizes the aggregated findings using an LLM.
@@ -133,7 +134,7 @@ func Summarize(ctx context.Context, agentName string, opts SummarizeOptions, agg
 	}
 
 	// Create agent
-	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort})
+	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort, CodexHome: opts.CodexHome})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 概要

- Codex の認証 home を、リポジトリ設定ではなくオペレータ制御の環境変数（`ACR_CODEX_HOME` / `CODEX_HOME`）から解決するようにします。
- reviewer、summarizer、false-positive filter、cross-check、PR feedback の各 Codex subprocess に、解決済み Codex home を渡します。
- auto-phase grouped review の phase reviewer rebinding でも、同じ Codex home が落ちないようにします。

## 検証

- `go test ./...`
- `go build -o .\acr.exe .\cmd\acr`
- mock Codex subprocess を使ったローカル ACR smoke で、`CODEX_HOME=C:\Users\kondo\.acr-codex-home` が subprocess 側に渡ることを確認しました。
- 実 Codex reviewer を使った ACR 単回レビューを実行しました。残った blocking verdict は grouped diff / sandbox coverage の meta issue として切り分け、#42 に登録済みです。

## 関連 issue

- #42: grouped diff reviewer における任意の sandbox shell 失敗を blocking coverage loss として扱わないようにする。
- #43: backend-specific agent runtime options の将来リファクタ。
- close #36 

## 注意点

- `.acr.yaml` では repository-controlled な `codex_home` をサポートしません。認証に関わる Codex home は Windows User 環境変数など、オペレータ制御の経路で設定します。
- ACR reviewer subprocess の挙動に関わる変更なので、merge 前の確認用として draft PR にしています。
