### PR TITLE
fix: ACR レビュースキルの cross-check finding に修正方針と通し番号を追加

### DIFF
--- a/.claude/commands/acr-review.md
+++ b/.claude/commands/acr-review.md
@@ -276,10 +276,12 @@ Iteration N (N = 1 から開始):
 
 ### Finding ブロック
 
+全 finding（findings[] と cross_check.findings[] の両方）に対して 1 から始まる通し番号 `{seq}` を振る。findings[] を先に番号付けし、cross_check.findings[] はその続番とする。
+
 各 finding について以下のブロックを出力:
 
 ```markdown
-### [{SEVERITY}] {title}
+### #{seq} [{SEVERITY}] {title}
 - **Severity**: {severity}
 - **Phase**: {phase}
 
@@ -303,13 +305,24 @@ Iteration N (N = 1 から開始):
 
 ### Cross-Check Finding ブロック
 
+Cross-check finding 固有のフィールド導出ルール:
+- `{SEVERITY}`: Finding ブロックと同一ルール（`severity` を大文字化。空文字の場合は "ADVISORY"）
+- `{type}`: `type` フィールドをそのまま使用（"escalation" / "gap" 等）
+- `{involved_groups}`: `involved_groups` 配列をカンマ区切りで結合
+- **修正方針**: cross-check の内容と `related_finding_ids` で紐づく arch/diff findings を分析し、修正方針を策定する。対応する arch/diff finding（`#{seq}`）で既に同等の修正方針を述べている場合は番号参照でよい
+
 ```markdown
-### [CROSS-CHECK] {title}
+### #{seq} [{SEVERITY}] [CROSS-CHECK] {title}
 - **Severity**: {severity}
 - **Type**: {type}
 - **関連グループ**: {involved_groups をカンマ区切りで表示}
 
 **要約:** {summary}
+
+**修正方針:**
+{cross-check の内容と関連する arch/diff findings を分析し、具体的な修正方針を策定する。
+ 関連する arch/diff finding で既に修正方針を述べている場合は、そちらを参照する形でよい
+ （例: "上記 #{seq} の修正方針に準ずる"）}
 ```
 
 ### カウントの計算


### PR DESCRIPTION
## Summary
- Cross-Check Finding ブロックに `**修正方針:**` フィールドを追加。blocking 指摘が cross-check からのみ発生した場合に修正指針が欠落する構造的欠陥を修正
- 関連する arch/diff finding の方針参照も許容する形式
- 全 finding（findings[] + cross_check.findings[]）に通し番号 `#{N}` を振る仕様を追加

## 背景
PR #44 の検証で ACR を実行した際、blocking 2件がすべて cross-check の escalation から発生したが、cross-check テンプレートに修正方針がなく、ゲートモードでの修正指針が不在だった。

## Test plan
- [x] ACR レビュースキルを単発モードで実行し、cross-check findings に修正方針が出力されることを確認
- [x] 通し番号が findings → cross-check findings の順で連番になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)