### PR TITLE
fix: grouped diff review で sandbox shell failure を blocking coverage loss として扱わない

### DIFF
--- a/cmd/acr/review.go
+++ b/cmd/acr/review.go
@@ -1041,7 +1041,8 @@ func buildCrossCheckContext(findings []domain.AggregatedFinding, specs []runner.
 	}
 
 	// Aggregate outcomes by group key. A group succeeds if >=1 reviewer for it
-	// returned without timeout/auth failure.
+	// returned exit 0, or produced findings despite non-zero exit, without
+	// timeout/auth failure.
 	outcomeByKey := make(map[string]*summarizer.GroupOutcome, len(groupInfos))
 	for _, g := range groupInfos {
 		outcomeByKey[g.GroupKey] = &summarizer.GroupOutcome{GroupKey: g.GroupKey}
@@ -1063,8 +1064,16 @@ func buildCrossCheckContext(findings []domain.AggregatedFinding, specs []runner.
 		if r.AuthFailed {
 			o.AuthFailed = true
 		}
-		if !r.TimedOut && !r.AuthFailed && r.ExitCode == 0 {
-			o.Succeeded = true
+		if !r.TimedOut && !r.AuthFailed {
+			if r.ExitCode == 0 {
+				o.Succeeded = true
+			} else if len(r.Findings) > 0 {
+				// Non-zero exit with findings: the reviewer ran far enough to
+				// produce results (e.g., sandbox shell failure after review).
+				// Treating this as a gap would re-introduce Issue #42.
+				o.Succeeded = true
+				o.PartialExit = true
+			}
 		}
 		o.FindingCount += len(r.Findings)
 	}

--- a/cmd/acr/review_test.go
+++ b/cmd/acr/review_test.go
@@ -747,6 +747,94 @@ func TestBuildCrossCheckContext_UsesSpecReviewerID(t *testing.T) {
 	}
 }
 
+func TestBuildCrossCheckContext_PartialExitWithFindings(t *testing.T) {
+	specs := []runner.ReviewerSpec{
+		{ReviewerID: 1, Phase: domain.PhaseDiff, GroupKey: "g01", TargetFiles: []string{"a.go"}},
+	}
+	findings := []domain.Finding{
+		{Text: "issue found", ReviewerID: 1, GroupKey: "g01"},
+	}
+	aggregated := domain.AggregateFindings(findings)
+	results := []domain.ReviewerResult{
+		{ReviewerID: 1, ExitCode: 1, Findings: findings},
+	}
+
+	ccCtx := buildCrossCheckContext(aggregated, specs, results)
+
+	o := ccCtx.Outcomes[0]
+	if !o.Succeeded {
+		t.Errorf("expected Succeeded=true for non-zero exit with findings, got false")
+	}
+	if !o.PartialExit {
+		t.Errorf("expected PartialExit=true for non-zero exit with findings, got false")
+	}
+	if o.FindingCount != 1 {
+		t.Errorf("expected FindingCount=1, got %d", o.FindingCount)
+	}
+}
+
+func TestBuildCrossCheckContext_FailedNoFindings(t *testing.T) {
+	specs := []runner.ReviewerSpec{
+		{ReviewerID: 1, Phase: domain.PhaseDiff, GroupKey: "g01", TargetFiles: []string{"a.go"}},
+	}
+	results := []domain.ReviewerResult{
+		{ReviewerID: 1, ExitCode: 1},
+	}
+
+	ccCtx := buildCrossCheckContext(nil, specs, results)
+
+	o := ccCtx.Outcomes[0]
+	if o.Succeeded {
+		t.Errorf("expected Succeeded=false for non-zero exit with no findings, got true")
+	}
+	if o.PartialExit {
+		t.Errorf("expected PartialExit=false for non-zero exit with no findings, got true")
+	}
+}
+
+func TestBuildCrossCheckContext_AuthFailedWithFindings(t *testing.T) {
+	specs := []runner.ReviewerSpec{
+		{ReviewerID: 1, Phase: domain.PhaseDiff, GroupKey: "g01", TargetFiles: []string{"a.go"}},
+	}
+	findings := []domain.Finding{
+		{Text: "issue found", ReviewerID: 1, GroupKey: "g01"},
+	}
+	aggregated := domain.AggregateFindings(findings)
+	results := []domain.ReviewerResult{
+		{ReviewerID: 1, ExitCode: 1, AuthFailed: true, Findings: findings},
+	}
+
+	ccCtx := buildCrossCheckContext(aggregated, specs, results)
+
+	o := ccCtx.Outcomes[0]
+	if o.Succeeded {
+		t.Errorf("expected Succeeded=false for auth failure even with findings, got true")
+	}
+}
+
+func TestBuildCrossCheckContext_CleanExitNotPartial(t *testing.T) {
+	specs := []runner.ReviewerSpec{
+		{ReviewerID: 1, Phase: domain.PhaseDiff, GroupKey: "g01", TargetFiles: []string{"a.go"}},
+	}
+	findings := []domain.Finding{
+		{Text: "issue found", ReviewerID: 1, GroupKey: "g01"},
+	}
+	aggregated := domain.AggregateFindings(findings)
+	results := []domain.ReviewerResult{
+		{ReviewerID: 1, ExitCode: 0, Findings: findings},
+	}
+
+	ccCtx := buildCrossCheckContext(aggregated, specs, results)
+
+	o := ccCtx.Outcomes[0]
+	if !o.Succeeded {
+		t.Errorf("expected Succeeded=true for clean exit, got false")
+	}
+	if o.PartialExit {
+		t.Errorf("expected PartialExit=false for clean exit, got true")
+	}
+}
+
 // --- isLGTM gate tests ---
 
 // TestReviewGate_CrossCheckOnlyBlocking_FailsGate: grouped has no findings but

--- a/internal/summarizer/crosscheck.go
+++ b/internal/summarizer/crosscheck.go
@@ -83,6 +83,7 @@ type GroupOutcome struct {
 	TimedOut     bool
 	AuthFailed   bool
 	FindingCount int
+	PartialExit  bool
 }
 
 // CrossCheckResult contains the cross-group verification results.
@@ -186,10 +187,11 @@ Key context:
 - "arch" group reviewed the ENTIRE change for architectural concerns
 - "diff" groups (g01, g02, ...) each reviewed a SUBSET of files
 - Groups with succeeded=false or finding_count=0 may indicate blind spots
+- Groups with partial_exit=true (present only when true; absent means false) completed review despite non-fatal tool errors (e.g., sandbox shell failures) - treat their findings as valid, not as coverage gaps
 
 Tasks:
 1. CONTRADICTIONS: findings from different groups giving mutually exclusive recommendations
-2. GAPS: arch concerns not addressed by any succeeding diff group, OR cross-file issues split across group boundaries. A diff group with succeeded=false is a gap source (no data, not "no issues").
+2. GAPS: arch concerns not addressed by any succeeding diff group, OR cross-file issues split across group boundaries. A diff group with succeeded=false is a gap source (no data, not "no issues"). A diff group with succeeded=true and partial_exit=true is NOT a gap - it reviewed the diff successfully despite optional tool failures.
 3. ESCALATIONS: findings whose severity should increase when seen in multi-group context (e.g., pattern affects files across multiple groups)
 
 Output (JSON only, no prose):
@@ -210,6 +212,7 @@ Rules:
 - Return ONLY valid JSON
 - Only report genuine cross-group issues - do not restate existing findings
 - A diff group with succeeded=false means its coverage is unknown - flag as gap
+- A diff group with partial_exit=true but succeeded=true is NOT a gap - its findings are valid
 - If no cross-group issues: {"findings": []}
 `
 
@@ -223,6 +226,7 @@ type crossCheckGroupJSON struct {
 	Succeeded    bool     `json:"succeeded"`
 	TimedOut     bool     `json:"timed_out,omitempty"`
 	AuthFailed   bool     `json:"auth_failed,omitempty"`
+	PartialExit  bool     `json:"partial_exit,omitempty"`
 	FindingCount int      `json:"finding_count"`
 }
 
@@ -267,6 +271,7 @@ func buildCrossCheckPayload(ccCtx CrossCheckContext) crossCheckPayload {
 			Succeeded:    o.Succeeded,
 			TimedOut:     o.TimedOut,
 			AuthFailed:   o.AuthFailed,
+			PartialExit:  o.PartialExit,
 			FindingCount: o.FindingCount,
 		})
 	}

--- a/internal/summarizer/crosscheck_test.go
+++ b/internal/summarizer/crosscheck_test.go
@@ -128,6 +128,27 @@ func TestBuildCrossCheckPayload_OutcomesMergedByKey(t *testing.T) {
 	}
 }
 
+func TestBuildCrossCheckPayload_PartialExitPropagated(t *testing.T) {
+	ccCtx := CrossCheckContext{
+		Groups: []GroupInfo{
+			{GroupKey: "g01", Phase: domain.PhaseDiff, TargetFiles: []string{"a.go"}},
+		},
+		Outcomes: []GroupOutcome{
+			{GroupKey: "g01", Succeeded: true, PartialExit: true, FindingCount: 2},
+		},
+	}
+	payload := buildCrossCheckPayload(ccCtx)
+	if len(payload.Groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(payload.Groups))
+	}
+	if !payload.Groups[0].PartialExit {
+		t.Errorf("expected PartialExit=true in payload, got false")
+	}
+	if !payload.Groups[0].Succeeded {
+		t.Errorf("expected Succeeded=true in payload, got false")
+	}
+}
+
 func TestCrossCheck_SkippedForSingleGroup(t *testing.T) {
 	ccCtx := CrossCheckContext{
 		Groups: []GroupInfo{{GroupKey: domain.PhaseArch}},


### PR DESCRIPTION
## Summary

- grouped diff review で、reviewer が sandbox/shell failure により非ゼロ終了しても所見を生成している場合、`Succeeded=true, PartialExit=true`（部分的成功）として認識するよう修正
- cross-check プロンプトを更新し、`partial_exit=true` のグループを coverage gap ではなく有効なレビュー結果として扱うよう指示
- TDD テスト5件追加（Red→Green で検証済み）

## 変更内容

| ファイル | 変更 |
|---------|------|
| `internal/summarizer/crosscheck.go` | `GroupOutcome` + `crossCheckGroupJSON` に `PartialExit` フィールド追加、payload 伝播、プロンプト更新 |
| `cmd/acr/review.go` | `buildCrossCheckContext` で非ゼロ終了+所見ありを部分的成功として認識 |
| `cmd/acr/review_test.go` | テスト4件追加 |
| `internal/summarizer/crosscheck_test.go` | テスト1件追加 |

## 背景 (Issue #42)

auto-phase large の grouped review で、nested reviewer agent が Windows sandbox 制限によりシェルコマンド実行に失敗した場合（`CreateProcessWithLogonW failed: 1326` 等）、cross-check がこれを blocking coverage gap として昇格していた。reviewer が有効な subset diff を受け取り、コード所見を生成していても、非ゼロ終了コードだけで coverage unknown と判定されていた。

## Test plan

- [x] `TestBuildCrossCheckContext_PartialExitWithFindings` — 非ゼロ終了+所見あり → Succeeded=true, PartialExit=true
- [x] `TestBuildCrossCheckContext_FailedNoFindings` — 非ゼロ終了+所見なし → Succeeded=false
- [x] `TestBuildCrossCheckContext_AuthFailedWithFindings` — auth failure → 所見ありでも Succeeded=false
- [x] `TestBuildCrossCheckContext_CleanExitNotPartial` — 正常終了 → PartialExit=false
- [x] `TestBuildCrossCheckPayload_PartialExitPropagated` — PartialExit が JSON payload に伝播
- [x] `go test ./...` 全パッケージ回帰なし

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)