### PR TITLE
refactor: backend-specific agent options を nested struct に分離 (#43)

### DIFF
--- a/cmd/arc/review.go
+++ b/cmd/arc/review.go
@@ -27,9 +27,9 @@ func cliOrLegacy(value string, fromCLI bool) (cli, legacy string) {
 
 func agentOptions(model, effort string, opts ReviewOpts) agent.AgentOptions {
 	return agent.AgentOptions{
-		Model:     model,
-		Effort:    effort,
-		CodexHome: opts.CodexHome,
+		Model:  model,
+		Effort: effort,
+		Codex:  agent.CodexOptions{Home: opts.CodexHome},
 	}
 }
 
@@ -497,7 +497,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			)
 			ccSpecs = append(ccSpecs, summarizer.CrossCheckAgentSpec{
 				Name:    name,
-				Options: summarizer.CrossCheckOptions{Model: perSpec.Model, Effort: perSpec.Effort, CodexHome: opts.CodexHome},
+				Options: summarizer.CrossCheckOptions{AgentOptions: agentOptions(perSpec.Model, perSpec.Effort, opts)},
 			})
 		}
 		// Lazy CLI availability check: only verify cross-check agent CLIs are
@@ -510,7 +510,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			return domain.ExitError
 		}
 		for _, spec := range ccSpecs {
-			ccAg, err := agent.NewAgentWithOptions(spec.Name, agent.AgentOptions{Model: spec.Options.Model, Effort: spec.Options.Effort, CodexHome: spec.Options.CodexHome})
+			ccAg, err := agent.NewAgentWithOptions(spec.Name, spec.Options.AgentOptions)
 			if err != nil {
 				logger.Logf(terminal.StyleError, "Invalid cross-check agent %q: %v", spec.Name, err)
 				return domain.ExitError
@@ -561,7 +561,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 	summarizerCtx, summarizerCancel := context.WithTimeout(ctx, opts.SummarizerTimeout)
 	defer summarizerCancel()
 
-	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, summarizer.SummarizeOptions{Model: summSpec.Model, Effort: summSpec.Effort, CodexHome: opts.CodexHome}, aggregated, ccResult, opts.Verbose, logger)
+	summaryResult, err := summarizer.Summarize(summarizerCtx, opts.SummarizerAgent, summarizer.SummarizeOptions{AgentOptions: agentOptions(summSpec.Model, summSpec.Effort, opts)}, aggregated, ccResult, opts.Verbose, logger)
 	spinnerCancel()
 	<-spinnerDone
 
@@ -608,7 +608,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			fpAgentName = opts.SummarizerAgent
 		}
 		if fpAgentName != opts.SummarizerAgent {
-			fpAg, err := agent.NewAgentWithOptions(fpAgentName, agent.AgentOptions{CodexHome: opts.CodexHome})
+			fpAg, err := agent.NewAgentWithOptions(fpAgentName, agentOptions("", "", opts))
 			if err != nil {
 				fpSpinnerCancel()
 				<-fpSpinnerDone
@@ -637,7 +637,7 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 			cliFPModel, cliFPEffort,
 			legacyFPModel, legacyFPEffort,
 		)
-		fpFilter := fpfilter.New(fpAgentName, fpSpec.Model, fpSpec.Effort, opts.CodexHome, opts.FPThreshold, opts.TriageEnabled, opts.Verbose, logger)
+		fpFilter := fpfilter.New(fpAgentName, agentOptions(fpSpec.Model, fpSpec.Effort, opts), opts.FPThreshold, opts.TriageEnabled, opts.Verbose, logger)
 		fpResult := fpFilter.Apply(fpCtx, summaryResult.Grouped, stats.SuccessfulReviewers)
 		fpSpinnerCancel()
 		<-fpSpinnerDone

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -16,10 +16,15 @@ import (
 type AgentOptions struct {
 	Model  string
 	Effort string
-	// CodexHome is the resolved Codex home for codex subprocesses.
+	Codex  CodexOptions
+}
+
+// CodexOptions configures Codex-specific runtime behavior.
+type CodexOptions struct {
+	// Home is the resolved Codex home for codex subprocesses.
 	// It is supplied by operator-controlled environment resolution, not by
 	// repository .arc.yaml content.
-	CodexHome string
+	Home string
 }
 
 // Agent represents a backend that can execute code reviews and summarizations.

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -46,7 +46,7 @@ func NewCodexAgent(model string) *CodexAgent {
 
 // NewCodexAgentWithOptions creates a new CodexAgent instance with the given options.
 func NewCodexAgentWithOptions(opts AgentOptions) *CodexAgent {
-	return &CodexAgent{model: opts.Model, effort: opts.Effort, codexHome: opts.CodexHome}
+	return &CodexAgent{model: opts.Model, effort: opts.Effort, codexHome: opts.Codex.Home}
 }
 
 // Name returns the agent's identifier.
@@ -56,7 +56,7 @@ func (c *CodexAgent) Name() string {
 
 // Options returns the AgentOptions the agent was constructed with.
 func (c *CodexAgent) Options() AgentOptions {
-	return AgentOptions{Model: c.model, Effort: c.effort, CodexHome: c.codexHome}
+	return AgentOptions{Model: c.model, Effort: c.effort, Codex: CodexOptions{Home: c.codexHome}}
 }
 
 // IsAvailable checks if the codex CLI is installed and accessible.

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -26,6 +26,26 @@ func TestCodexAgent_Name(t *testing.T) {
 	}
 }
 
+func TestAgentOptionsCodexNesting(t *testing.T) {
+	configuredCodexHome := filepath.Join(t.TempDir(), "configured-codex")
+	agent := NewCodexAgentWithOptions(AgentOptions{
+		Model:  "gpt-test",
+		Effort: "high",
+		Codex:  CodexOptions{Home: configuredCodexHome},
+	})
+
+	got := agent.Options()
+	if got.Model != "gpt-test" {
+		t.Errorf("Options().Model = %q, want %q", got.Model, "gpt-test")
+	}
+	if got.Effort != "high" {
+		t.Errorf("Options().Effort = %q, want %q", got.Effort, "high")
+	}
+	if got.Codex.Home != configuredCodexHome {
+		t.Errorf("Options().Codex.Home = %q, want %q", got.Codex.Home, configuredCodexHome)
+	}
+}
+
 func TestCodexAgent_IsAvailable(t *testing.T) {
 	t.Run("available", func(t *testing.T) {
 		prepareMockCLI(t, "codex", "args")
@@ -325,7 +345,7 @@ func TestCodexAgent_ExecuteReview_PassesConfiguredCodexAuthEnv(t *testing.T) {
 	t.Setenv("APPDATA", appData)
 	t.Setenv("LOCALAPPDATA", localAppData)
 
-	agent := NewCodexAgentWithOptions(AgentOptions{CodexHome: configuredCodexHome})
+	agent := NewCodexAgentWithOptions(AgentOptions{Codex: CodexOptions{Home: configuredCodexHome}})
 	result, err := agent.ExecuteReview(context.Background(), &ReviewConfig{
 		BaseRef: "main",
 		WorkDir: t.TempDir(),
@@ -370,7 +390,7 @@ func TestCodexAgent_ExecuteReview_ConfiguredCodexHomeOverridesProcessEnv(t *test
 	t.Setenv("ARC_CODEX_HOME", arcCodexHome)
 	t.Setenv("CODEX_HOME", codexHome)
 
-	agent := NewCodexAgentWithOptions(AgentOptions{CodexHome: configuredCodexHome})
+	agent := NewCodexAgentWithOptions(AgentOptions{Codex: CodexOptions{Home: configuredCodexHome}})
 	result, err := agent.ExecuteReview(context.Background(), &ReviewConfig{
 		BaseRef: "main",
 		WorkDir: t.TempDir(),

--- a/internal/fpfilter/filter.go
+++ b/internal/fpfilter/filter.go
@@ -39,9 +39,7 @@ type Result struct {
 
 type Filter struct {
 	agentName     string
-	model         string
-	effort        string
-	codexHome     string
+	opts          agent.AgentOptions
 	threshold     int
 	triageEnabled bool
 	verbose       bool
@@ -49,21 +47,18 @@ type Filter struct {
 }
 
 // New creates a new false positive filter.
-// The model parameter overrides the agent's default model (empty = default).
-// The effort parameter overrides the agent's default reasoning effort (empty = default).
-// The codexHome parameter is passed through only to Codex agent subprocesses.
+// opts carries model, effort, and backend-specific runtime options to the
+// selected agent.
 // When triageEnabled is true, severity-based classification (blocking/advisory/noise)
 // is applied in addition to fp_score filtering.
 // If verbose is true, non-fatal errors (like Close failures) are logged.
-func New(agentName, model, effort, codexHome string, threshold int, triageEnabled, verbose bool, logger *terminal.Logger) *Filter {
+func New(agentName string, opts agent.AgentOptions, threshold int, triageEnabled, verbose bool, logger *terminal.Logger) *Filter {
 	if threshold < 1 || threshold > 100 {
 		threshold = DefaultThreshold
 	}
 	return &Filter{
 		agentName:     agentName,
-		model:         model,
-		effort:        effort,
-		codexHome:     codexHome,
+		opts:          opts,
 		threshold:     threshold,
 		triageEnabled: triageEnabled,
 		logger:        logger,
@@ -138,7 +133,7 @@ func (f *Filter) Apply(ctx context.Context, grouped domain.GroupedFindings, tota
 		}
 	}
 
-	ag, err := agent.NewAgentWithOptions(f.agentName, agent.AgentOptions{Model: f.model, Effort: f.effort, CodexHome: f.codexHome})
+	ag, err := agent.NewAgentWithOptions(f.agentName, f.opts)
 	if err != nil {
 		return skippedResult(grouped, start, "agent creation failed: "+err.Error())
 	}

--- a/internal/fpfilter/filter_test.go
+++ b/internal/fpfilter/filter_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/masa6161/arc-cli/internal/agent"
 	"github.com/masa6161/arc-cli/internal/domain"
 	"github.com/masa6161/arc-cli/internal/terminal"
 )
 
 func TestFilter_New(t *testing.T) {
-	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", agent.AgentOptions{}, 75, false, false, terminal.NewLogger())
 	if f == nil {
 		t.Fatal("New returned nil")
 	}
@@ -147,7 +148,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := New("codex", "", "", "", tt.threshold, false, false, logger)
+			f := New("codex", agent.AgentOptions{}, tt.threshold, false, false, logger)
 			if f.threshold != tt.expectedThreshold {
 				t.Errorf("threshold = %d, want %d", f.threshold, tt.expectedThreshold)
 			}
@@ -156,7 +157,7 @@ func TestNew_ThresholdClamping(t *testing.T) {
 }
 
 func TestApply_EmptyFindings(t *testing.T) {
-	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", agent.AgentOptions{}, 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -181,7 +182,7 @@ func TestApply_EmptyFindings(t *testing.T) {
 }
 
 func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
-	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", agent.AgentOptions{}, 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 	}
@@ -195,7 +196,7 @@ func TestApply_EmptyFindings_WithTotalReviewers(t *testing.T) {
 }
 
 func TestApply_EmptyFindingsPreservesInfo(t *testing.T) {
-	f := New("codex", "", "", "", 75, false, false, terminal.NewLogger())
+	f := New("codex", agent.AgentOptions{}, 75, false, false, terminal.NewLogger())
 	grouped := domain.GroupedFindings{
 		Findings: []domain.FindingGroup{},
 		Info: []domain.FindingGroup{

--- a/internal/runner/phase.go
+++ b/internal/runner/phase.go
@@ -9,13 +9,13 @@ import (
 
 // PhaseConfig defines a review phase and its parameters.
 type PhaseConfig struct {
-	Phase         string // "arch" | "diff"
-	ReviewerCount int    // Number of reviewers for this phase
-	AgentName     string // Which agent to use (empty = default from caller)
-	Model         string // Model override (empty = agent default)
-	Effort        string // Reasoning effort override (empty = agent default)
-	CodexHome     string // Codex home override passed only to Codex agents
-	Prompt        string // Per-phase guidance override (empty = use global guidance; phase prompt template is selected by Phase)
+	Phase         string             // "arch" | "diff"
+	ReviewerCount int                // Number of reviewers for this phase
+	AgentName     string             // Which agent to use (empty = default from caller)
+	Model         string             // Model override (empty = agent default)
+	Effort        string             // Reasoning effort override (empty = agent default)
+	Codex         agent.CodexOptions // Codex-specific runtime overrides
+	Prompt        string             // Per-phase guidance override (empty = use global guidance; phase prompt template is selected by Phase)
 }
 
 // BuildReviewerSpecs creates ReviewerSpecs from PhaseConfigs.
@@ -42,28 +42,28 @@ func BuildReviewerSpecs(phases []PhaseConfig, defaultAgents []agent.Agent, globa
 			var a agent.Agent
 			if pc.AgentName != "" {
 				var err error
-				a, err = agent.NewAgentWithOptions(pc.AgentName, agent.AgentOptions{Model: pc.Model, Effort: pc.Effort, CodexHome: pc.CodexHome})
+				a, err = agent.NewAgentWithOptions(pc.AgentName, agent.AgentOptions{Model: pc.Model, Effort: pc.Effort, Codex: pc.Codex})
 				if err != nil {
 					return nil, fmt.Errorf("phase %q agent %q: %w", pc.Phase, pc.AgentName, err)
 				}
 			} else {
 				base := agent.AgentForReviewer(defaultAgents, reviewerIdx)
-				if pc.Effort != "" || pc.Model != "" || pc.CodexHome != "" {
+				if pc.Effort != "" || pc.Model != "" || pc.Codex != (agent.CodexOptions{}) {
 					// Merge: pc.Effort/Model が空のときは base agent の既存値を継承する。
 					// 部分 override (例: pc.Effort="high" のみ) で base agent の model
 					// 設定が落ちないようにするための cascade。現状 caller はこの分岐に
 					// 到達しないが (parsePhases / auto-phase はいずれも pc.Effort/Model
 					// を空に保つ)、将来 caller が増えたときの regression を予防する。
 					baseOpts := base.Options()
-					merged := agent.AgentOptions{Model: pc.Model, Effort: pc.Effort, CodexHome: pc.CodexHome}
+					merged := agent.AgentOptions{Model: pc.Model, Effort: pc.Effort, Codex: pc.Codex}
 					if merged.Model == "" {
 						merged.Model = baseOpts.Model
 					}
 					if merged.Effort == "" {
 						merged.Effort = baseOpts.Effort
 					}
-					if merged.CodexHome == "" {
-						merged.CodexHome = baseOpts.CodexHome
+					if merged.Codex == (agent.CodexOptions{}) {
+						merged.Codex = baseOpts.Codex
 					}
 					var rebindErr error
 					a, rebindErr = agent.NewAgentWithOptions(base.Name(), merged)

--- a/internal/runner/phase_test.go
+++ b/internal/runner/phase_test.go
@@ -10,10 +10,10 @@ import (
 
 // mockPhaseAgent implements agent.Agent for phase testing.
 type mockPhaseAgent struct {
-	name      string
-	model     string
-	effort    string
-	codexHome string
+	name   string
+	model  string
+	effort string
+	codex  agent.CodexOptions
 }
 
 func (m *mockPhaseAgent) Name() string       { return m.name }
@@ -25,7 +25,7 @@ func (m *mockPhaseAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (
 	return nil, nil
 }
 func (m *mockPhaseAgent) Options() agent.AgentOptions {
-	return agent.AgentOptions{Model: m.model, Effort: m.effort, CodexHome: m.codexHome}
+	return agent.AgentOptions{Model: m.model, Effort: m.effort, Codex: m.codex}
 }
 
 func TestBuildReviewerSpecs_ArchAndDiff(t *testing.T) {
@@ -171,7 +171,7 @@ func TestDefaultPromptForPhase(t *testing.T) {
 // or .Model directly, so this guard exists purely to prevent a future caller from
 // re-introducing the Round-8 dead-code regression.
 func TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseOptions(t *testing.T) {
-	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: "", codexHome: "base-codex-home"}
+	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: "", codex: agent.CodexOptions{Home: "base-codex-home"}}
 	phases := []PhaseConfig{
 		{Phase: domain.PhaseDiff, ReviewerCount: 1, Effort: "high"},
 	}
@@ -191,15 +191,15 @@ func TestBuildReviewerSpecs_PhaseConfigEffortPreservesBaseOptions(t *testing.T) 
 	if got.Effort != "high" {
 		t.Errorf("phase override lost: Options().Effort = %q, want %q", got.Effort, "high")
 	}
-	if got.CodexHome != "base-codex-home" {
-		t.Errorf("base CodexHome dropped: Options().CodexHome = %q, want %q", got.CodexHome, "base-codex-home")
+	if got.Codex.Home != "base-codex-home" {
+		t.Errorf("base Codex.Home dropped: Options().Codex.Home = %q, want %q", got.Codex.Home, "base-codex-home")
 	}
 }
 
 func TestBuildReviewerSpecs_PhaseConfigCodexHomeOverridesBase(t *testing.T) {
-	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: "medium", codexHome: "base-codex-home"}
+	base := &mockPhaseAgent{name: "codex", model: "gpt-5", effort: "medium", codex: agent.CodexOptions{Home: "base-codex-home"}}
 	phases := []PhaseConfig{
-		{Phase: domain.PhaseDiff, ReviewerCount: 1, CodexHome: "phase-codex-home"},
+		{Phase: domain.PhaseDiff, ReviewerCount: 1, Codex: agent.CodexOptions{Home: "phase-codex-home"}},
 	}
 
 	specs, err := BuildReviewerSpecs(phases, []agent.Agent{base}, "", "", false)
@@ -217,7 +217,7 @@ func TestBuildReviewerSpecs_PhaseConfigCodexHomeOverridesBase(t *testing.T) {
 	if got.Effort != "medium" {
 		t.Errorf("base effort dropped: Options().Effort = %q, want %q", got.Effort, "medium")
 	}
-	if got.CodexHome != "phase-codex-home" {
-		t.Errorf("phase CodexHome override lost: Options().CodexHome = %q, want %q", got.CodexHome, "phase-codex-home")
+	if got.Codex.Home != "phase-codex-home" {
+		t.Errorf("phase Codex.Home override lost: Options().Codex.Home = %q, want %q", got.Codex.Home, "phase-codex-home")
 	}
 }

--- a/internal/summarizer/crosscheck.go
+++ b/internal/summarizer/crosscheck.go
@@ -299,12 +299,10 @@ func buildCrossCheckPayload(ccCtx CrossCheckContext) crossCheckPayload {
 	return payload
 }
 
-// CrossCheckOptions bundles model/effort resolution for the cross-check role.
-// Empty fields fall back to the agent's built-in defaults.
+// CrossCheckOptions bundles agent runtime options for the cross-check role.
+// Empty fields in the embedded AgentOptions fall back to the agent's built-in defaults.
 type CrossCheckOptions struct {
-	Model     string
-	Effort    string
-	CodexHome string
+	agent.AgentOptions
 }
 
 // CrossCheckAgentSpec bundles a cross-check agent name with its pre-resolved
@@ -428,7 +426,7 @@ func runCrossCheckAgent(
 	start := time.Now()
 	result := AgentCrossCheckResult{AgentName: agentName}
 
-	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort, CodexHome: opts.CodexHome})
+	ag, err := agent.NewAgentWithOptions(agentName, opts.AgentOptions)
 	if err != nil {
 		result.Err = fmt.Errorf("agent creation failed: %w", err)
 		result.Duration = time.Since(start)

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -109,12 +109,10 @@ type inputItem struct {
 	Severity  string `json:"severity,omitempty"`
 }
 
-// SummarizeOptions bundles model/effort resolution for the summarizer role.
-// Empty fields fall back to the agent's built-in defaults.
+// SummarizeOptions bundles agent runtime options for the summarizer role.
+// Empty fields in the embedded AgentOptions fall back to the agent's built-in defaults.
 type SummarizeOptions struct {
-	Model     string
-	Effort    string
-	CodexHome string
+	agent.AgentOptions
 }
 
 // Summarize summarizes the aggregated findings using an LLM.
@@ -134,7 +132,7 @@ func Summarize(ctx context.Context, agentName string, opts SummarizeOptions, agg
 	}
 
 	// Create agent
-	ag, err := agent.NewAgentWithOptions(agentName, agent.AgentOptions{Model: opts.Model, Effort: opts.Effort, CodexHome: opts.CodexHome})
+	ag, err := agent.NewAgentWithOptions(agentName, opts.AgentOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- `AgentOptions.CodexHome` を `CodexOptions` nested struct に分離し、backend-specific option の漏出を解消
- `SummarizeOptions`, `CrossCheckOptions` を `AgentOptions` embed に変更し、中間構造体での手動フィールド複製を廃止
- `fpfilter.Filter` の `model`/`effort`/`codexHome` を `AgentOptions` に統合
- 新 backend option の追加コストを **CodexOptions に 1 行 + agentOptions() に 1 行** に削減

## 変更内容

| ファイル | 変更 |
|---------|------|
| `internal/agent/agent.go` | `CodexOptions` struct 新設、`AgentOptions.Codex` フィールドに移行 |
| `internal/agent/codex.go` | `opts.CodexHome` → `opts.Codex.Home` |
| `internal/runner/phase.go` | `PhaseConfig.CodexHome` → `Codex agent.CodexOptions` |
| `internal/summarizer/summarizer.go` | `SummarizeOptions` を `AgentOptions` embed に |
| `internal/summarizer/crosscheck.go` | `CrossCheckOptions` を `AgentOptions` embed に |
| `internal/fpfilter/filter.go` | `Filter` の 3 フィールドを `AgentOptions` に統合 |
| `cmd/arc/review.go` | 全 call site を `agentOptions()` ヘルパー経由に統一 |
| テスト 3 ファイル | 構造変更に追従 + `TestAgentOptionsCodexNesting` 新規追加 |

## 設計判断

- `ResolvedConfig.CodexHome` / `EnvState.CodexHome` は維持（env 解決 + `arc config show` 表示用）
- `Effort` は全 3 backend で使用されるため本リファクタのスコープ外
- `internal/feedback/` は PR #54 で削除済みのためスキップ

## Test plan

- [x] `go build ./cmd/arc`
- [x] `go test ./...` — 全 12 パッケージ PASS
- [x] `go vet ./...`
- [x] ARC レビュー実行 — blocking findings なし (verdict: advisory)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)