### PR TITLE
fix: CLI 未インストール時の起動前エラー表示を改善

### DIFF
--- a/cmd/arc/review.go
+++ b/cmd/arc/review.go
@@ -39,15 +39,16 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		return domain.ExitError
 	}
 
-	// Early CLI availability preflight when auto-phase is active.
-	// Auto-phase may invoke any configured agent role (arch, diff, cross-check)
-	// depending on diff size, so verify all CLIs upfront to avoid wasting
-	// review cycles on a missing binary.
+	// Preflight: verify required CLIs exist before any work.
+	// Auto-phase may invoke additional agent roles (arch, diff, cross-check),
+	// so check all of them; non-auto-phase only needs reviewer agents.
+	preflightNames := opts.ReviewerAgents
 	if shouldUseAutoPhase(opts) {
-		if err := agent.CheckCLIAvailability(collectAllCLINames(opts)); err != nil {
-			logger.Logf(terminal.StyleError, "Preflight check failed: %v", err)
-			return domain.ExitError
-		}
+		preflightNames = collectAllCLINames(opts)
+	}
+	if err := agent.CheckCLIAvailability(preflightNames); err != nil {
+		logger.Logf(terminal.StyleError, "Preflight check failed: %v", err)
+		return domain.ExitError
 	}
 
 	// Resolve the base ref once before launching parallel reviewers.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -311,6 +311,7 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		if r.verbose() {
 			r.logger.Logf(terminal.StyleWarning, "Reviewer #%d: execute error: %v", reviewerID, err)
 		}
+		result.Stderr = err.Error()
 		result.ExitCode = -1
 		result.Duration = time.Since(start)
 		return result

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -422,6 +422,22 @@ func (m *mockAuthFailAgent) ExecuteSummary(_ context.Context, _ string, _ []byte
 
 func (m *mockAuthFailAgent) Options() agent.AgentOptions { return agent.AgentOptions{} }
 
+// mockExecErrorAgent returns an error from ExecuteReview (simulates CLI not found).
+type mockExecErrorAgent struct {
+	name   string
+	errMsg string
+}
+
+func (m *mockExecErrorAgent) Name() string       { return m.name }
+func (m *mockExecErrorAgent) IsAvailable() error { return nil }
+func (m *mockExecErrorAgent) ExecuteReview(_ context.Context, _ *agent.ReviewConfig) (*agent.ExecutionResult, error) {
+	return nil, fmt.Errorf("%s", m.errMsg)
+}
+func (m *mockExecErrorAgent) ExecuteSummary(_ context.Context, _ string, _ []byte) (*agent.ExecutionResult, error) {
+	return nil, nil
+}
+func (m *mockExecErrorAgent) Options() agent.AgentOptions { return agent.AgentOptions{} }
+
 func TestRunReviewerWithRetry_SkipsRetryOnAuthFailure(t *testing.T) {
 	mock := &mockAuthFailAgent{name: "gemini", exitCode: 41, stderr: ""}
 
@@ -710,5 +726,30 @@ func TestRunReviewer_NoStderrOnSuccess(t *testing.T) {
 	}
 	if result.Stderr != "" {
 		t.Errorf("expected empty Stderr on success, got %q", result.Stderr)
+	}
+}
+
+func TestRunReviewer_PopulatesStderrOnExecError(t *testing.T) {
+	errMsg := "codex CLI not found in PATH: exec: \"codex\": executable file not found in %PATH%"
+	mock := &mockExecErrorAgent{name: "codex", errMsg: errMsg}
+
+	r := &Runner{
+		config:    Config{Reviewers: 1, Timeout: 10 * time.Second},
+		agents:    []agent.Agent{mock},
+		specs:     []ReviewerSpec{{ReviewerID: 1, Agent: mock}},
+		logger:    terminal.NewLogger(),
+		completed: new(atomic.Int32),
+	}
+
+	result := r.runReviewer(context.Background(), 1)
+
+	if result.ExitCode != -1 {
+		t.Errorf("expected exit code -1, got %d", result.ExitCode)
+	}
+	if result.Stderr != errMsg {
+		t.Errorf("expected Stderr=%q, got %q", errMsg, result.Stderr)
+	}
+	if result.AgentName != "codex" {
+		t.Errorf("expected AgentName=%q, got %q", "codex", result.AgentName)
 	}
 }


### PR DESCRIPTION
## Summary

- 全パス共通のレビュワー CLI preflight チェックを追加（従来は auto-phase パスのみ）
- `runReviewer` の `ExecuteReview` エラーパスで `result.Stderr` にエラー内容を格納（defense-in-depth）

Closes #50

## 変更内容

### 1. Preflight チェックの拡張 (`cmd/arc/review.go`)

`ValidateAgentNames` 直後に `CheckCLIAvailability(opts.ReviewerAgents)` を全パス共通で実行。
設定ファイルまたは CLI フラグで指定されたレビュワー CLI が存在しなければ、レビュー実行前に
即停止する。

従来は auto-phase パスのみ `collectAllCLINames` で全 CLI を検証していたが、
非 auto-phase パス（`--no-auto-phase` / `--phase small` 等）ではチェックがなく、
N 個のレビュワーがそれぞれ失敗してから「All reviewers failed」のみが表示されていた。

### 2. ExecuteReview エラーパスの Stderr 格納 (`internal/runner/runner.go`)

`ExecuteReview` がエラーを返す（CLI 不在以外の理由も含む）パスで `result.Stderr = err.Error()`
を設定。preflight をすり抜けるケースへの defense-in-depth。

### 3. テスト追加 (`internal/runner/runner_test.go`)

- `mockExecErrorAgent`: `ExecuteReview` が `(nil, error)` を返すモック
- `TestRunReviewer_PopulatesStderrOnExecError`: エラー時に `Stderr` が設定されることを検証

## Test plan

- [x] `go test ./internal/runner` — 新規テスト含む全テスト pass
- [x] `go test ./internal/agent` — pass
- [x] `go test ./cmd/arc` — pass
- [x] `go build -o .\arc.exe .\cmd\arc` — ビルド成功
- [x] ARC レビュー実行（advisory 2 件、blocking 0 件、いずれも FP）

🤖 Generated with [Claude Code](https://claude.com/claude-code)