### PR TITLE
fix: arc-review を Skills 形式に移行し --local フラグを除去 (#57)

### DIFF
--- a/.claude/skills/arc-review/SKILL.md
+++ b/.claude/skills/arc-review/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: arc-review
+description: >-
+  ARC (Adaptive code-Review Coordinator) を実行し、マルチエージェント
+  レビュー結果を構造化レポートとして報告する。単発レビューとゲートモードを提供。
+argument-hint: "[--gate] [--max-iter N] [--base <ref>] [--reviewer-agent <agents>] [--verbose] [--strict]"
+---
+
 # ARC Review
 
 ARC (Adaptive code-Review Coordinator) を実行し、マルチエージェントレビュー結果を構造化レポートとして報告する。
@@ -50,7 +58,7 @@ C:\Users\kondo\go\bin\arc.exe
 ### ステップ 1: ARC 実行
 
 ```powershell
-$ARC_BIN --local --format json --base <base> --verbose [追加パラメータ] 2>.arc/arc_stderr.tmp
+$ARC_BIN --format json --base <base> --verbose [追加パラメータ] 2>.arc/arc_stderr.tmp
 ```
 
 `--base` が省略された場合は ARC のデフォルト（`main`、`.arc.yaml` で上書き可）に委ねる。
@@ -129,7 +137,7 @@ Iteration N (N = 1 から開始):
        --guidance-file として使用（前 iteration のステップ 11 で生成済み）
 
   2. ARC 実行:
-     $ARC_BIN --local --format json --base <base> --verbose [--guidance-file ...] [追加パラメータ] 2>.arc/arc_stderr.tmp
+     $ARC_BIN --format json --base <base> --verbose [--guidance-file ...] [追加パラメータ] 2>.arc/arc_stderr.tmp
      ※ iteration 2+ でのみ --guidance-file を付与（ユーザー指定時は常に付与）
      ※ --verbose を常に付与し stderr をキャプチャ（Auto-phase モード情報の抽出用）
 


### PR DESCRIPTION
## Summary

- `.claude/commands/arc-review.md` → `.claude/skills/arc-review/SKILL.md` に移行（Claude Code 標準スキル形式）
- YAML frontmatter（`name`, `description`, `argument-hint`）を追加し、バックエンド間のポータビリティを確保
- PR #53 で削除済みの `--local` フラグをコマンドテンプレート 2 箇所から除去
- `.claude/settings.local.json` の permission エントリからも `--local` を除去（gitignore 対象のためコミット外）

Closes #57

## Test plan

- [x] `.claude/` 配下に `--local` の残存がないことを Grep で確認
- [x] `go test ./...` 全 12 パッケージ pass（regression なし）
- [x] スキルリストに新しい `arc-review` が正しい description で認識されることを確認
- [ ] `/arc-review` の runtime invocation 確認（PR マージ後の利用時に検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)