### PR TITLE
chore: upstream 同期 — 依存更新 + Claude billing 注記

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ You also need **at least one** of the following LLM CLIs installed and authentic
 | Claude Code | [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code) | Run `claude login` |
 | Gemini CLI | [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) | Set `GEMINI_API_KEY` or run `gemini auth login` |
 
+> **Claude Code billing note:** ARC invokes Claude Code with the `--print` flag (non-interactive mode). A single ARC run may spawn multiple non-interactive Claude sessions (N reviewers + summarizer + FP filter). Starting June 15, 2026, subscription-authenticated `claude -p` and Agent SDK usage will consume Agent SDK credits; once credits are exhausted, charges fall back to extra usage (API pay-as-you-go) if enabled on your account. When authenticating via `ANTHROPIC_API_KEY`, standard API pay-as-you-go billing applies as before. Check your plan's credit balance and billing settings before running large reviews. For details, see [Agent SDK plan billing](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) and [`claude -p` documentation](https://code.claude.com/docs/en/headless).
+
 ### Optional
 
 | Tool | Installation | Purpose |

--- a/README_JP.md
+++ b/README_JP.md
@@ -45,6 +45,8 @@ Windows では、以下のソースインストールまたはリリース ZIP �
 | Claude Code | [github.com/anthropics/claude-code](https://github.com/anthropics/claude-code) | `claude login` を実行 |
 | Gemini CLI | [github.com/google-gemini/gemini-cli](https://github.com/google-gemini/gemini-cli) | `GEMINI_API_KEY` を設定 or `gemini auth login` を実行 |
 
+> **Claude Code の課金に関する注意:** ARC は Claude Code を `--print` フラグ（非インタラクティブモード）で起動します。1 回の ARC 実行で複数の非インタラクティブ Claude セッションが発生する場合があります（N 個のレビューア + サマライザー + FP フィルター）。2026 年 6 月 15 日以降、サブスクリプション認証での `claude -p` および Agent SDK の利用は Agent SDK クレジットから消費されます。クレジットが枯渇した場合、アカウントで有効になっていれば extra usage（API 従量課金）に移行します。`ANTHROPIC_API_KEY` による認証では、従来通り API の従量課金が適用されます。大規模なレビューを実行する前に、プランのクレジット残高と課金設定をご確認ください。詳細は [Agent SDK プラン課金](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) および [`claude -p` ドキュメント](https://code.claude.com/docs/en/headless) を参照してください。
+
 ### オプション
 
 | ツール | インストール | 用途 |

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	golang.org/x/sys v0.42.0
-	golang.org/x/term v0.41.0
+	golang.org/x/sys v0.44.0
+	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,10 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
-golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
## Summary

フォーク元 `richhaase/agentic-code-reviewer` の merge base `592b012` 以降の更新を取り込み。

- `golang.org/x/term` v0.41.0 → v0.43.0、`golang.org/x/sys` v0.42.0 → v0.44.0 に更新（upstream PR #180, #181 相当）
- README.md に Claude non-interactive billing の注記を中立トーンで追加（upstream PR #182 の事実情報を適応）

### upstream コミットトリアージ

| コミット | 判定 | 理由 |
|---------|------|------|
| `e08dc6c` x/term 0.41→0.42 | **Take** | 基盤依存更新 |
| `a862e27` x/term 0.42→0.43 | **Take** | 同上 |
| `ea6fd6a` billing 警告 + AGENTS.md | **Adapt** | billing 事実情報のみ中立トーンで適応。AGENTS.md はスキップ（独自版既存） |
| `c94ac15` Claude 非推奨化 | **Skip** | "recommend against" トーンがフォーク方針と矛盾 |
| `86675d9` Claude 補足 | **Skip** | 情報は #3 注記に含まれる |

## Test plan

- [x] `go vet ./...` pass
- [x] `go test ./...` 12 パッケージ全 pass
- [x] `go build -o arc.exe ./cmd/arc` 成功
- [x] `./arc.exe --version` 正常起動
- [x] README billing 注記のトーンが中立であることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)