### PR TITLE
chore: upstream 新規修正の取り込み (PR #182-#184)

### DIFF
--- a/cmd/arc/review.go
+++ b/cmd/arc/review.go
@@ -39,6 +39,13 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		return domain.ExitError
 	}
 
+	for _, name := range opts.ReviewerAgents {
+		if name == "gemini" {
+			logger.Logf(terminal.StyleWarning, "Warning: Gemini CLI is deprecated and may be removed in a future version. Consider using 'codex' or 'claude' instead.")
+			break
+		}
+	}
+
 	// Preflight: verify required CLIs exist before any work.
 	// Auto-phase may invoke additional agent roles (arch, diff, cross-check),
 	// so check all of them; non-auto-phase only needs reviewer agents.

--- a/cmd/arc/review.go
+++ b/cmd/arc/review.go
@@ -39,13 +39,6 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		return domain.ExitError
 	}
 
-	for _, name := range opts.ReviewerAgents {
-		if name == "gemini" {
-			logger.Logf(terminal.StyleWarning, "Warning: Gemini CLI is deprecated and may be removed in a future version. Consider using 'codex' or 'claude' instead.")
-			break
-		}
-	}
-
 	// Preflight: verify required CLIs exist before any work.
 	// Auto-phase may invoke additional agent roles (arch, diff, cross-check),
 	// so check all of them; non-auto-phase only needs reviewer agents.
@@ -437,6 +430,11 @@ func executeReview(ctx context.Context, opts ReviewOpts, logger *terminal.Logger
 		return domain.ExitError
 	}
 
+	// Gemini deprecation warning: only fire when gemini will actually execute.
+	if warnGeminiDeprecation(opts, useGroupedSpecs, groupedSpecs, reviewAgents, actualReviewers) {
+		logger.Logf(terminal.StyleWarning, "Warning: Gemini CLI is deprecated and may be removed in a future version. Consider using 'codex' or 'claude' instead.")
+	}
+
 	if distributionStr != "" {
 		logger.Logf(terminal.StyleInfo, "Agent distribution: %s%s%s",
 			terminal.Color(terminal.Dim), distributionStr, terminal.Color(terminal.Reset))
@@ -742,6 +740,54 @@ func applyVerdictExitPolicy(verdict string, strict bool, findingsCode domain.Exi
 		return domain.ExitNoFindings
 	}
 	return findingsCode
+}
+
+// warnGeminiDeprecation returns true when gemini will actually be invoked in
+// any role during this run. It checks the resolved reviewer agents (accounting
+// for round-robin assignment), summarizer, cross-check, and FP filter roles.
+func warnGeminiDeprecation(opts ReviewOpts, useGroupedSpecs bool, groupedSpecs []runner.ReviewerSpec, reviewAgents []agent.Agent, actualReviewers int) bool {
+	const target = "gemini"
+
+	// Check reviewer agents that will actually be assigned via round-robin.
+	if useGroupedSpecs {
+		for _, s := range groupedSpecs {
+			if s.Agent != nil && s.Agent.Name() == target {
+				return true
+			}
+		}
+	} else {
+		for i := range actualReviewers {
+			a := agent.AgentForReviewer(reviewAgents, i+1)
+			if a != nil && a.Name() == target {
+				return true
+			}
+		}
+	}
+
+	// Check non-reviewer roles.
+	if opts.SummarizerAgent == target {
+		return true
+	}
+	fpAgent := opts.FPFilterAgent
+	if fpAgent == "" {
+		fpAgent = opts.SummarizerAgent
+	}
+	if fpAgent == target {
+		return true
+	}
+	if opts.CrossCheckEnabled {
+		ccAgent := opts.CrossCheckAgent
+		if ccAgent == "" {
+			ccAgent = opts.SummarizerAgent
+		}
+		for _, name := range strings.Split(ccAgent, ",") {
+			if strings.TrimSpace(name) == target {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // shouldUseAutoPhase returns true when auto-phase is enabled and no explicit

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
-	golang.org/x/sys v0.44.0
-	golang.org/x/term v0.43.0
+	golang.org/x/sys v0.46.0
+	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,10 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
-golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/agent/antigravity.go
+++ b/internal/agent/antigravity.go
@@ -1,0 +1,134 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Compile-time interface check
+var _ Agent = (*AntigravityAgent)(nil)
+
+// AntigravityAgent implements the Agent interface for the Antigravity CLI backend.
+type AntigravityAgent struct {
+	opts AgentOptions
+}
+
+const antigravityDefaultPrintTimeout = 30 * time.Minute
+
+// antigravityPrintTimeoutGrace keeps agy's own print timeout slightly above
+// ARC's context deadline. The Go context remains the authoritative timeout so
+// timed-out reviewers are categorized consistently, while agy's lower default
+// timeout is overridden for longer ARC phases.
+const antigravityPrintTimeoutGrace = 5 * time.Second
+
+// NewAntigravityAgentWithOptions creates a new AntigravityAgent instance.
+//
+// Antigravity CLI model selection is currently managed by agy configuration
+// rather than a non-interactive command-line flag, so opts.Model is accepted
+// for factory compatibility and intentionally ignored at execution time.
+func NewAntigravityAgentWithOptions(opts AgentOptions) *AntigravityAgent {
+	return &AntigravityAgent{opts: opts}
+}
+
+// Name returns the agent's identifier.
+func (a *AntigravityAgent) Name() string {
+	return "agy"
+}
+
+// Options returns the AgentOptions the agent was constructed with.
+func (a *AntigravityAgent) Options() AgentOptions {
+	return a.opts
+}
+
+// IsAvailable checks if the agy CLI is installed and accessible.
+func (a *AntigravityAgent) IsAvailable() error {
+	_, err := exec.LookPath("agy")
+	if err != nil {
+		return fmt.Errorf("agy CLI not found in PATH: %w", err)
+	}
+	return nil
+}
+
+// ExecuteReview runs a code review using the agy CLI.
+// Returns an ExecutionResult for streaming the output.
+//
+// Uses the pre-computed diff from config.Diff when available, otherwise fetches it.
+// The diff is either appended to the prompt or written to a reference file for large diffs.
+func (a *AntigravityAgent) ExecuteReview(ctx context.Context, config *ReviewConfig) (*ExecutionResult, error) {
+	if err := a.IsAvailable(); err != nil {
+		return nil, err
+	}
+
+	return executeDiffBasedReview(ctx, config, diffReviewConfig{
+		Command:       "agy",
+		Args:          antigravityPrintArgs(antigravityPrintTimeoutCeiling(config.Timeout)),
+		DefaultPrompt: DefaultAntigravityPrompt,
+		RefFilePrompt: DefaultAntigravityRefFilePrompt,
+	})
+}
+
+// ExecuteSummary runs a summarization task using the agy CLI.
+// Uses 'agy --print=-' with the prompt and input piped via stdin.
+func (a *AntigravityAgent) ExecuteSummary(ctx context.Context, prompt string, input []byte) (*ExecutionResult, error) {
+	if err := a.IsAvailable(); err != nil {
+		return nil, err
+	}
+
+	stdin := io.MultiReader(
+		strings.NewReader(prompt),
+		strings.NewReader("\n\nINPUT JSON:\n"),
+		bytes.NewReader(input),
+		strings.NewReader("\n"),
+	)
+
+	return executeCommand(ctx, executeOptions{
+		Command: "agy",
+		Args:    antigravityPrintArgs(antigravityPrintTimeoutCeilingFromContext(ctx, time.Now())),
+		Stdin:   stdin,
+	})
+}
+
+func antigravityPrintArgs(timeout time.Duration) []string {
+	if timeout <= 0 {
+		timeout = antigravityDefaultPrintTimeout
+	}
+	return []string{"--print=-", "--print-timeout", formatAntigravityTimeout(timeout)}
+}
+
+func formatAntigravityTimeout(timeout time.Duration) string {
+	seconds := int64(timeout / time.Second)
+	if timeout%time.Second != 0 {
+		seconds++
+	}
+	if seconds < 1 {
+		seconds = 1
+	}
+	if seconds%60 == 0 {
+		return fmt.Sprintf("%dm", seconds/60)
+	}
+	return fmt.Sprintf("%ds", seconds)
+}
+
+func antigravityPrintTimeoutCeiling(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return 0
+	}
+	return timeout + antigravityPrintTimeoutGrace
+}
+
+func antigravityPrintTimeoutCeilingFromContext(ctx context.Context, now time.Time) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return 0
+	}
+	remaining := deadline.Sub(now)
+	if remaining <= 0 {
+		return time.Second
+	}
+	return remaining + antigravityPrintTimeoutGrace
+}

--- a/internal/agent/antigravity_review_parser.go
+++ b/internal/agent/antigravity_review_parser.go
@@ -1,0 +1,16 @@
+package agent
+
+// Compile-time interface check
+var _ ReviewParser = (*AntigravityOutputParser)(nil)
+
+// AntigravityOutputParser parses text output from the agy CLI.
+type AntigravityOutputParser struct {
+	*ClaudeOutputParser
+}
+
+// NewAntigravityOutputParser creates a new parser for agy output.
+func NewAntigravityOutputParser(reviewerID int) *AntigravityOutputParser {
+	return &AntigravityOutputParser{
+		ClaudeOutputParser: NewClaudeOutputParser(reviewerID),
+	}
+}

--- a/internal/agent/antigravity_summary_parser.go
+++ b/internal/agent/antigravity_summary_parser.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/masa6161/arc-cli/internal/domain"
+)
+
+// Compile-time interface check
+var _ SummaryParser = (*AntigravitySummaryParser)(nil)
+
+// AntigravitySummaryParser parses summary output from the Antigravity CLI.
+// agy --print emits the model response directly, so summary output is expected
+// to be JSON text, optionally wrapped in markdown fences or surrounding prose.
+type AntigravitySummaryParser struct{}
+
+// NewAntigravitySummaryParser creates a new AntigravitySummaryParser.
+func NewAntigravitySummaryParser() *AntigravitySummaryParser {
+	return &AntigravitySummaryParser{}
+}
+
+// ExtractText extracts the raw JSON response text from agy output.
+func (p *AntigravitySummaryParser) ExtractText(data []byte) (string, error) {
+	return ExtractJSON(string(data))
+}
+
+// Parse parses the summary output and returns grouped findings.
+func (p *AntigravitySummaryParser) Parse(data []byte) (*domain.GroupedFindings, error) {
+	text, err := p.ExtractText(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var grouped domain.GroupedFindings
+	if err := json.Unmarshal([]byte(text), &grouped); err != nil {
+		return nil, err
+	}
+	if err := validateGroupedFindingsShape([]byte(text)); err != nil {
+		return nil, err
+	}
+	if grouped.Info == nil {
+		grouped.Info = []domain.FindingGroup{}
+	}
+	return &grouped, nil
+}
+
+func validateGroupedFindingsShape(data []byte) error {
+	var shape struct {
+		Findings *[]domain.FindingGroup `json:"findings"`
+	}
+	if err := json.Unmarshal(data, &shape); err != nil {
+		return err
+	}
+	if shape.Findings == nil {
+		return fmt.Errorf(`summary JSON missing required "findings" array`)
+	}
+	return nil
+}

--- a/internal/agent/antigravity_summary_parser_test.go
+++ b/internal/agent/antigravity_summary_parser_test.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/masa6161/arc-cli/internal/domain"
+)
+
+func TestNewAntigravitySummaryParser(t *testing.T) {
+	parser := NewAntigravitySummaryParser()
+	if parser == nil {
+		t.Fatal("NewAntigravitySummaryParser() returned nil")
+	}
+}
+
+func TestAntigravitySummaryParser_Parse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    *domain.GroupedFindings
+		wantErr bool
+	}{
+		{
+			name:  "valid raw JSON",
+			input: []byte(`{"findings":[{"title":"Bug Found","summary":"A bug was found","messages":["msg1"],"reviewer_count":2,"sources":[1,2]}],"info":[{"title":"Note","summary":"A note","messages":["info1"],"reviewer_count":1,"sources":[3]}]}`),
+			want: &domain.GroupedFindings{
+				Findings: []domain.FindingGroup{
+					{Title: "Bug Found", Summary: "A bug was found", Messages: []string{"msg1"}, ReviewerCount: 2, Sources: []int{1, 2}},
+				},
+				Info: []domain.FindingGroup{
+					{Title: "Note", Summary: "A note", Messages: []string{"info1"}, ReviewerCount: 1, Sources: []int{3}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "valid JSON with markdown code fence",
+			input: []byte("```json\n{\"findings\":[{\"title\":\"Issue\",\"summary\":\"An issue\",\"messages\":[],\"reviewer_count\":1,\"sources\":[]}],\"info\":[]}\n```"),
+			want: &domain.GroupedFindings{
+				Findings: []domain.FindingGroup{
+					{Title: "Issue", Summary: "An issue", Messages: []string{}, ReviewerCount: 1, Sources: []int{}},
+				},
+				Info: []domain.FindingGroup{},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON",
+			input:   []byte(`{invalid json}`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "missing findings field",
+			input:   []byte(`{"info":[]}`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "missing info field",
+			input:   []byte(`{"findings":[]}`),
+			want:    &domain.GroupedFindings{Findings: []domain.FindingGroup{}, Info: []domain.FindingGroup{}},
+			wantErr: false,
+		},
+		{
+			name:    "null findings field",
+			input:   []byte(`{"findings":null,"info":[]}`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "whitespace padded null findings field",
+			input:   []byte("{\"findings\": \n null \t,\"info\":[]}"),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty input",
+			input:   []byte(``),
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	parser := NewAntigravitySummaryParser()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parser.Parse(tt.input)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if len(got.Findings) != len(tt.want.Findings) {
+				t.Errorf("Parse() got %d findings, want %d", len(got.Findings), len(tt.want.Findings))
+			}
+
+			if len(got.Info) != len(tt.want.Info) {
+				t.Errorf("Parse() got %d info, want %d", len(got.Info), len(tt.want.Info))
+			}
+
+			for i := range got.Findings {
+				if got.Findings[i].Title != tt.want.Findings[i].Title {
+					t.Errorf("Finding[%d].Title = %q, want %q", i, got.Findings[i].Title, tt.want.Findings[i].Title)
+				}
+				if got.Findings[i].Summary != tt.want.Findings[i].Summary {
+					t.Errorf("Finding[%d].Summary = %q, want %q", i, got.Findings[i].Summary, tt.want.Findings[i].Summary)
+				}
+				if got.Findings[i].ReviewerCount != tt.want.Findings[i].ReviewerCount {
+					t.Errorf("Finding[%d].ReviewerCount = %d, want %d", i, got.Findings[i].ReviewerCount, tt.want.Findings[i].ReviewerCount)
+				}
+			}
+		})
+	}
+}
+
+func TestAntigravitySummaryParser_SummaryParserInterface(t *testing.T) {
+	var _ SummaryParser = (*AntigravitySummaryParser)(nil)
+}

--- a/internal/agent/antigravity_test.go
+++ b/internal/agent/antigravity_test.go
@@ -1,0 +1,356 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewAntigravityAgent(t *testing.T) {
+	agent := NewAntigravityAgentWithOptions(AgentOptions{})
+	if agent == nil {
+		t.Fatal("NewAntigravityAgentWithOptions() returned nil")
+	}
+}
+
+func TestAntigravityAgent_Name(t *testing.T) {
+	agent := NewAntigravityAgentWithOptions(AgentOptions{})
+	got := agent.Name()
+	want := "agy"
+	if got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+func TestAntigravityAgent_Options(t *testing.T) {
+	opts := AgentOptions{Model: "test-model", Effort: "high"}
+	agent := NewAntigravityAgentWithOptions(opts)
+	got := agent.Options()
+	if got.Model != "test-model" {
+		t.Errorf("Options().Model = %q, want %q", got.Model, "test-model")
+	}
+	if got.Effort != "high" {
+		t.Errorf("Options().Effort = %q, want %q", got.Effort, "high")
+	}
+}
+
+func TestAntigravityAgent_IsAvailable(t *testing.T) {
+	agent := NewAntigravityAgentWithOptions(AgentOptions{})
+	err := agent.IsAvailable()
+
+	_, lookPathErr := exec.LookPath("agy")
+
+	if lookPathErr != nil {
+		if err == nil {
+			t.Error("IsAvailable() should return error when agy is not in PATH")
+		}
+		if !strings.Contains(err.Error(), "agy CLI not found") {
+			t.Errorf("IsAvailable() error = %v, want error containing 'agy CLI not found'", err)
+		}
+	} else if err != nil {
+		t.Errorf("IsAvailable() unexpected error = %v", err)
+	}
+}
+
+func TestAntigravityAgent_ExecuteReview_AgyNotAvailable(t *testing.T) {
+	originalPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", originalPath)
+	os.Setenv("PATH", "")
+
+	agent := NewAntigravityAgentWithOptions(AgentOptions{})
+	ctx := context.Background()
+	config := &ReviewConfig{
+		BaseRef: "main",
+		WorkDir: ".",
+	}
+
+	result, err := agent.ExecuteReview(ctx, config)
+	if err == nil {
+		if result != nil {
+			result.Close()
+		}
+		t.Error("ExecuteReview() should return error when agy is not available")
+	}
+
+	if !strings.Contains(err.Error(), "agy CLI not found") {
+		t.Errorf("ExecuteReview() error = %v, want error containing 'agy CLI not found'", err)
+	}
+}
+
+func TestAntigravityAgentInterface(t *testing.T) {
+	var _ Agent = (*AntigravityAgent)(nil)
+}
+
+func TestAntigravityAgent_ExecuteSummary_AgyNotAvailable(t *testing.T) {
+	originalPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", originalPath)
+	os.Setenv("PATH", "")
+
+	agent := NewAntigravityAgentWithOptions(AgentOptions{})
+	ctx := context.Background()
+
+	result, err := agent.ExecuteSummary(ctx, "test prompt", []byte(`{"findings":[]}`))
+	if err == nil {
+		if result != nil {
+			result.Close()
+		}
+		t.Error("ExecuteSummary() should return error when agy is not available")
+	}
+
+	if !strings.Contains(err.Error(), "agy CLI not found") {
+		t.Errorf("ExecuteSummary() error = %v, want error containing 'agy CLI not found'", err)
+	}
+}
+
+func TestAntigravityPrintArgs_FormatsTimeoutForCLI(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    []string
+	}{
+		{
+			name:    "whole minutes",
+			timeout: 10 * time.Minute,
+			want:    []string{"--print=-", "--print-timeout", "10m"},
+		},
+		{
+			name:    "whole seconds",
+			timeout: 90 * time.Second,
+			want:    []string{"--print=-", "--print-timeout", "90s"},
+		},
+		{
+			name:    "fractional seconds round up",
+			timeout: 1500 * time.Millisecond,
+			want:    []string{"--print=-", "--print-timeout", "2s"},
+		},
+		{
+			name:    "default",
+			timeout: 0,
+			want:    []string{"--print=-", "--print-timeout", "30m"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := antigravityPrintArgs(tt.timeout)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestAntigravityPrintTimeoutCeilingFromContext(t *testing.T) {
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	t.Run("uses deadline plus grace so context controls timeout", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), now.Add(10*time.Minute))
+		defer cancel()
+
+		got := antigravityPrintTimeoutCeilingFromContext(ctx, now)
+		want := 10*time.Minute + antigravityPrintTimeoutGrace
+		if got != want {
+			t.Fatalf("got %s, want %s", got, want)
+		}
+	})
+
+	t.Run("no deadline uses default", func(t *testing.T) {
+		got := antigravityPrintTimeoutCeilingFromContext(context.Background(), now)
+		if got != 0 {
+			t.Fatalf("got %s, want 0", got)
+		}
+	})
+
+	t.Run("expired deadline uses minimum", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), now.Add(-time.Second))
+		defer cancel()
+
+		got := antigravityPrintTimeoutCeilingFromContext(ctx, now)
+		if got != time.Second {
+			t.Fatalf("got %s, want 1s", got)
+		}
+	})
+}
+
+func antigravityInitTestRepo(t *testing.T, tmpDir string) {
+	t.Helper()
+
+	for _, cmd := range [][]string{
+		{"git", "init"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	} {
+		c := exec.CommandContext(context.Background(), cmd[0], cmd[1:]...)
+		c.Dir = tmpDir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v failed: %v\n%s", cmd, err, out)
+		}
+	}
+
+	testFile := filepath.Join(tmpDir, "test.go")
+	if err := os.WriteFile(testFile, []byte("package main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial"},
+	} {
+		c := exec.CommandContext(context.Background(), cmd[0], cmd[1:]...)
+		c.Dir = tmpDir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git commit %v failed: %v\n%s", cmd, err, out)
+		}
+	}
+}
+
+func TestAntigravityAgent_ExecuteReview_Args(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses shell scripts, not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	antigravityInitTestRepo(t, tmpDir)
+
+	testFile := filepath.Join(tmpDir, "test.go")
+	if err := os.WriteFile(testFile, []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mockScript := filepath.Join(tmpDir, "agy")
+	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"ARG:$arg\"; done\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", originalPath)
+	os.Setenv("PATH", tmpDir+":"+originalPath)
+
+	agent := NewAntigravityAgentWithOptions(AgentOptions{})
+	ctx := context.Background()
+	config := &ReviewConfig{
+		BaseRef: "HEAD",
+		Timeout: 10 * time.Minute,
+		WorkDir: tmpDir,
+	}
+
+	result, err := agent.ExecuteReview(ctx, config)
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "ARG:--print=-\nARG:--print-timeout\nARG:605s\n") {
+		t.Errorf("expected agy print stdin args with configured timeout, got:\n%s", outputStr)
+	}
+}
+
+func TestAntigravityAgent_ExecuteReview_RefFileMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses shell scripts, not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	antigravityInitTestRepo(t, tmpDir)
+
+	testFile := filepath.Join(tmpDir, "test.go")
+	bigContent := strings.Repeat("// line of code\n", RefFileSizeThreshold/16+1)
+	if err := os.WriteFile(testFile, []byte(bigContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mockScript := filepath.Join(tmpDir, "agy")
+	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\ncat\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", originalPath)
+	os.Setenv("PATH", tmpDir+":"+originalPath)
+
+	agent := NewAntigravityAgentWithOptions(AgentOptions{})
+	ctx := context.Background()
+	config := &ReviewConfig{
+		BaseRef: "HEAD",
+		WorkDir: tmpDir,
+	}
+
+	result, err := agent.ExecuteReview(ctx, config)
+	if err != nil {
+		t.Fatalf("ExecuteReview() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, ".arc-diff-") {
+		t.Errorf("expected ref-file path in prompt, got:\n%s", outputStr[:min(200, len(outputStr))])
+	}
+
+	result.Close()
+	matches, _ := filepath.Glob(filepath.Join(tmpDir, ".arc-diff-*"))
+	if len(matches) > 0 {
+		t.Errorf("temp diff file not cleaned up: %v", matches)
+	}
+}
+
+func TestAntigravityAgent_ExecuteSummary_Args(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses shell scripts, not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	mockScript := filepath.Join(tmpDir, "agy")
+	if err := os.WriteFile(mockScript, []byte("#!/bin/sh\nfor arg in \"$@\"; do echo \"ARG:$arg\"; done\ncat\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	originalPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", originalPath)
+	os.Setenv("PATH", tmpDir+":"+originalPath)
+
+	agent := NewAntigravityAgentWithOptions(AgentOptions{Model: "ignored-model"})
+	ctx := context.Background()
+
+	result, err := agent.ExecuteSummary(ctx, "summarize", []byte(`{"findings":[]}`))
+	if err != nil {
+		t.Fatalf("ExecuteSummary() error: %v", err)
+	}
+	defer result.Close()
+
+	output, err := io.ReadAll(result)
+	if err != nil {
+		t.Fatalf("failed to read output: %v", err)
+	}
+
+	outputStr := string(output)
+	if !strings.Contains(outputStr, "ARG:--print=-\nARG:--print-timeout\nARG:30m\n") {
+		t.Errorf("expected agy print stdin args with default timeout, got:\n%s", outputStr)
+	}
+	if strings.Contains(outputStr, "ignored-model") {
+		t.Errorf("agy should not receive unsupported model arg, got:\n%s", outputStr)
+	}
+	if !strings.Contains(outputStr, "INPUT JSON:") {
+		t.Errorf("expected input JSON in stdin, got:\n%s", outputStr)
+	}
+}

--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"runtime"
 	"slices"
 	"strings"
@@ -19,11 +20,39 @@ var authStderrPatterns = []string{
 	"401",
 	"authentication required",
 	"invalid credentials",
+	"login required",
+	"not authenticated",
+	"not signed in",
+}
+
+var authStdoutPrefixes = []string{
+	"api error: 401",
+	"api error: 403",
+	"authentication failed",
+	"error: api error: 401",
+	"error: api error: 403",
+	"error: authentication failed",
+	"error: authentication required",
+	"error: failed to authenticate",
+	"error: invalid authentication credentials",
+	"error: login required",
+	"error: not authenticated",
+	"error: not signed in",
+	"failed to authenticate",
+}
+
+var authStdoutExactMessages = []string{
+	"authentication required",
+	"invalid authentication credentials",
+	"login required",
+	"not authenticated",
+	"not signed in",
 }
 
 // authHints maps agent names to actionable error messages shown on auth failure.
 var authHints = map[string]string{
-	"gemini": "Set GEMINI_API_KEY or run 'gemini auth login' to authenticate.",
+	"agy":    "Run 'agy' and complete Google sign-in, or check your Antigravity CLI credentials.",
+	"gemini": "Authenticate Gemini CLI with enterprise credentials, or use 'agy' for non-enterprise Google access.",
 	"claude": "Run 'claude login' or check your API key configuration.",
 	"codex":  "Set OPENAI_API_KEY or run 'codex auth' to authenticate.",
 }
@@ -36,7 +65,7 @@ var nonAuthStartupPatterns = []string{
 	"access is denied",
 }
 
-func containsAuthSignal(stderr string) bool {
+func containsAuthPattern(stderr string) bool {
 	lower := strings.ToLower(stderr)
 	for _, pattern := range authStderrPatterns {
 		if strings.Contains(lower, pattern) {
@@ -56,10 +85,13 @@ func containsNonAuthStartupSignal(stderr string) bool {
 	return false
 }
 
-// IsAuthFailure returns true if the given exit code and stderr indicate
+// IsAuthFailure returns true if the given exit code and process output indicate
 // an authentication failure for the named agent. Exit code 0 is never
-// considered an auth failure.
-func IsAuthFailure(agentName string, exitCode int, stderr string) bool {
+// considered an auth failure. Some CLIs emit auth failures on stdout as
+// structured JSON instead of stderr. When both streams are provided, stderr is
+// checked broadly and stdout is checked conservatively to avoid misclassifying
+// model findings as authentication failures.
+func IsAuthFailure(agentName string, exitCode int, stderr string, stdout ...string) bool {
 	if exitCode == 0 {
 		return false
 	}
@@ -70,7 +102,7 @@ func IsAuthFailure(agentName string, exitCode int, stderr string) bool {
 			// Preserve known auth exit codes unless stderr clearly indicates a
 			// startup/spawn failure unrelated to authentication.
 			if runtime.GOOS == "windows" {
-				if containsAuthSignal(stderr) {
+				if containsAuthPattern(stderr) {
 					return true
 				}
 				return !containsNonAuthStartupSignal(stderr)
@@ -79,7 +111,80 @@ func IsAuthFailure(agentName string, exitCode int, stderr string) bool {
 		}
 	}
 
-	return containsAuthSignal(stderr)
+	if containsAuthPattern(stderr) {
+		return true
+	}
+
+	for _, text := range stdout {
+		if looksLikeStdoutAuthFailure(text) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func looksLikeStdoutAuthFailure(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false
+	}
+	if looksLikeStructuredStdoutAuthFailure(trimmed) {
+		return true
+	}
+	return looksLikeShortAuthMessage(trimmed)
+}
+
+func looksLikeStructuredStdoutAuthFailure(text string) bool {
+	if !strings.HasPrefix(text, "{") {
+		return false
+	}
+	var envelope struct {
+		IsError        bool   `json:"is_error"`
+		APIErrorStatus int    `json:"api_error_status"`
+		Result         string `json:"result"`
+		Error          string `json:"error"`
+		Message        string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(text), &envelope); err != nil {
+		return false
+	}
+
+	message := strings.Join([]string{envelope.Result, envelope.Error, envelope.Message}, "\n")
+	if envelope.APIErrorStatus == 401 || envelope.APIErrorStatus == 403 {
+		return envelope.IsError
+	}
+	return envelope.IsError && looksLikeShortAuthMessage(message)
+}
+
+func looksLikeShortAuthMessage(text string) bool {
+	lines := strings.Split(strings.TrimSpace(text), "\n")
+	nonEmpty := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			nonEmpty = append(nonEmpty, line)
+		}
+	}
+	if len(nonEmpty) == 0 || len(nonEmpty) > 3 {
+		return false
+	}
+
+	normalized := strings.ToLower(strings.Join(nonEmpty, " "))
+	if len(normalized) > 1024 {
+		return false
+	}
+	for _, message := range authStdoutExactMessages {
+		if normalized == message {
+			return true
+		}
+	}
+	for _, phrase := range authStdoutPrefixes {
+		if strings.HasPrefix(normalized, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 // AuthHint returns an actionable error message for the named agent.

--- a/internal/agent/auth_test.go
+++ b/internal/agent/auth_test.go
@@ -41,6 +41,93 @@ func TestIsAuthFailure(t *testing.T) {
 	}
 }
 
+func TestIsAuthFailureStdout(t *testing.T) {
+	tests := []struct {
+		name     string
+		agent    string
+		exitCode int
+		stderr   string
+		stdout   string
+		want     bool
+	}{
+		{
+			"structured JSON 401",
+			"agy", 1, "",
+			`{"is_error":true,"api_error_status":401,"result":"authentication required"}`,
+			true,
+		},
+		{
+			"structured JSON 403",
+			"agy", 1, "",
+			`{"is_error":true,"api_error_status":403,"error":"forbidden"}`,
+			true,
+		},
+		{
+			"structured JSON 401 but is_error false",
+			"agy", 1, "",
+			`{"is_error":false,"api_error_status":401,"result":"ok"}`,
+			false,
+		},
+		{
+			"short text not authenticated",
+			"agy", 1, "",
+			"not authenticated",
+			true,
+		},
+		{
+			"short text login required",
+			"codex", 1, "",
+			"login required",
+			true,
+		},
+		{
+			"stdout prefix api error 401",
+			"claude", 1, "",
+			"api error: 401 Unauthorized",
+			true,
+		},
+		{
+			"long normal output is not auth failure",
+			"codex", 1, "",
+			"This is a long review output with many lines.\nLine 2\nLine 3\nLine 4\nLine 5",
+			false,
+		},
+		{
+			"exit 0 ignores stdout auth",
+			"agy", 0, "",
+			`{"is_error":true,"api_error_status":401}`,
+			false,
+		},
+		{
+			"stderr auth takes precedence over empty stdout",
+			"codex", 1, "unauthorized", "",
+			true,
+		},
+		{
+			"empty stdout is not auth failure",
+			"agy", 1, "", "",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAuthFailure(tt.agent, tt.exitCode, tt.stderr, tt.stdout)
+			if got != tt.want {
+				t.Errorf("IsAuthFailure(%q, %d, stderr=%q, stdout=%q) = %v, want %v",
+					tt.agent, tt.exitCode, tt.stderr, tt.stdout, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthHintAgy(t *testing.T) {
+	hint := AuthHint("agy")
+	if hint == "" {
+		t.Error("AuthHint(\"agy\") returned empty string")
+	}
+}
+
 func TestAuthHint(t *testing.T) {
 	agents := []string{"gemini", "claude", "codex", "unknown"}
 	for _, name := range agents {

--- a/internal/agent/factory.go
+++ b/internal/agent/factory.go
@@ -30,6 +30,11 @@ var registry = map[string]agentRegistry{
 		newReviewParser:  func(id int) ReviewParser { return NewGeminiOutputParser(id) },
 		newSummaryParser: func() SummaryParser { return NewGeminiSummaryParser() },
 	},
+	"agy": {
+		newAgent:         func(opts AgentOptions) Agent { return NewAntigravityAgentWithOptions(opts) },
+		newReviewParser:  func(id int) ReviewParser { return NewAntigravityOutputParser(id) },
+		newSummaryParser: func() SummaryParser { return NewAntigravitySummaryParser() },
+	},
 }
 
 // SupportedAgents lists all valid agent names.

--- a/internal/agent/factory_test.go
+++ b/internal/agent/factory_test.go
@@ -117,7 +117,7 @@ func TestNewReviewParser(t *testing.T) {
 }
 
 func TestSupportedAgents(t *testing.T) {
-	expected := []string{"codex", "claude", "gemini"}
+	expected := []string{"codex", "claude", "gemini", "agy"}
 	if len(SupportedAgents) != len(expected) {
 		t.Errorf("SupportedAgents has %d elements, want %d", len(SupportedAgents), len(expected))
 	}

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -262,6 +262,48 @@ Skip:
 - Performance micro-optimizations
 {{guidance}}`
 
+// DefaultAntigravityPrompt is the default review prompt for Antigravity CLI.
+const DefaultAntigravityPrompt = `Review this git diff for bugs.
+
+Look for:
+- Logic errors, wrong behavior, crashes
+- Security issues (injection, auth bypass, exposure)
+- Silent failures, swallowed errors
+- Wrong type conversions
+- Missing operations (data not passed, steps skipped)
+
+Skip:
+- Style/formatting
+- Performance unless severe
+- Test files
+- Suggestions
+
+Output format: file:line: description
+{{guidance}}`
+
+// DefaultAntigravityRefFilePrompt is the review prompt used when the diff is
+// passed via a reference file instead of being embedded in the prompt.
+const DefaultAntigravityRefFilePrompt = `Review this git diff for bugs.
+
+The diff to review is in file: %s
+Read the file contents to examine the changes.
+
+Look for:
+- Logic errors, wrong behavior, crashes
+- Security issues (injection, auth bypass, exposure)
+- Silent failures, swallowed errors
+- Wrong type conversions
+- Missing operations (data not passed, steps skipped)
+
+Skip:
+- Style/formatting
+- Performance unless severe
+- Test files
+- Suggestions
+
+Output format: file:line: description
+{{guidance}}`
+
 // DefaultArchPrompt is the default prompt for architecture-phase reviews.
 // Used when ReviewConfig.Phase == "arch".
 const DefaultArchPrompt = `Review this code change for architectural concerns.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -35,11 +35,13 @@ func (c *cappedOutputCapture) Write(p []byte) (int, error) {
 	defer c.mu.Unlock()
 	remaining := c.cap - len(c.buf)
 	if remaining > 0 {
-		if len(p) > remaining {
-			p = p[:remaining]
+		toWrite := p
+		if len(toWrite) > remaining {
+			toWrite = toWrite[:remaining]
 		}
-		c.buf = append(c.buf, p...)
+		c.buf = append(c.buf, toWrite...)
 	}
+	// Always return original len(p) to avoid io.ErrShortWrite from TeeReader.
 	return len(p), nil
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -5,9 +5,11 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"math/rand/v2"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +17,37 @@ import (
 	"github.com/masa6161/arc-cli/internal/domain"
 	"github.com/masa6161/arc-cli/internal/terminal"
 )
+
+// cappedOutputCapture captures up to cap bytes of data written to it.
+// Safe for use as an io.Writer target of io.TeeReader.
+type cappedOutputCapture struct {
+	mu  sync.Mutex
+	buf []byte
+	cap int
+}
+
+func newCappedOutputCapture(cap int) *cappedOutputCapture {
+	return &cappedOutputCapture{buf: make([]byte, 0, cap), cap: cap}
+}
+
+func (c *cappedOutputCapture) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	remaining := c.cap - len(c.buf)
+	if remaining > 0 {
+		if len(p) > remaining {
+			p = p[:remaining]
+		}
+		c.buf = append(c.buf, p...)
+	}
+	return len(p), nil
+}
+
+func (c *cappedOutputCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return string(c.buf)
+}
 
 // maxFindingPreviewLength is the maximum characters shown for a finding in
 // verbose output. Longer findings are truncated with "..." to prevent
@@ -331,8 +364,13 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 		return result
 	}
 
+	// Capture a prefix of stdout for auth failure detection.
+	// The TeeReader is transparent to the parser — it reads the same bytes.
+	stdoutCapture := newCappedOutputCapture(4096)
+	teeReader := io.TeeReader(execResult, stdoutCapture)
+
 	// Configure scanner
-	scanner := bufio.NewScanner(execResult)
+	scanner := bufio.NewScanner(teeReader)
 	agent.ConfigureScanner(scanner)
 
 	// Parse output
@@ -410,7 +448,10 @@ func (r *Runner) runReviewer(ctx context.Context, reviewerID int) domain.Reviewe
 			r.logger.Logf(terminal.StyleWarning, "Reviewer #%d stderr:%s\n%s",
 				reviewerID, terminal.Color(terminal.Reset), result.Stderr)
 		}
-		result.AuthFailed = agent.IsAuthFailure(selectedAgent.Name(), result.ExitCode, execResult.Stderr())
+		result.AuthFailed = agent.IsAuthFailure(selectedAgent.Name(), result.ExitCode, execResult.Stderr(), stdoutCapture.String())
+		if result.AuthFailed {
+			result.Findings = nil
+		}
 	}
 
 	// Record duration after process fully exits

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -753,3 +753,51 @@ func TestRunReviewer_PopulatesStderrOnExecError(t *testing.T) {
 		t.Errorf("expected AgentName=%q, got %q", "codex", result.AgentName)
 	}
 }
+
+func TestCappedOutputCapture(t *testing.T) {
+	t.Run("captures up to cap", func(t *testing.T) {
+		c := newCappedOutputCapture(10)
+		n, err := c.Write([]byte("hello"))
+		if err != nil || n != 5 {
+			t.Fatalf("Write(5) = (%d, %v), want (5, nil)", n, err)
+		}
+		if c.String() != "hello" {
+			t.Errorf("got %q, want %q", c.String(), "hello")
+		}
+	})
+
+	t.Run("truncates at cap boundary", func(t *testing.T) {
+		c := newCappedOutputCapture(8)
+		c.Write([]byte("hello"))
+		n, err := c.Write([]byte("world"))
+		if err != nil || n != 5 {
+			t.Fatalf("Write(5) = (%d, %v), want (5, nil)", n, err)
+		}
+		if c.String() != "hellowor" {
+			t.Errorf("got %q, want %q", c.String(), "hellowor")
+		}
+	})
+
+	t.Run("returns original len after cap exceeded", func(t *testing.T) {
+		c := newCappedOutputCapture(4)
+		c.Write([]byte("full"))
+		n, err := c.Write([]byte("more data"))
+		if err != nil || n != 9 {
+			t.Fatalf("Write(9) after cap = (%d, %v), want (9, nil)", n, err)
+		}
+		if c.String() != "full" {
+			t.Errorf("buffer grew past cap: got %q", c.String())
+		}
+	})
+
+	t.Run("zero cap captures nothing", func(t *testing.T) {
+		c := newCappedOutputCapture(0)
+		n, err := c.Write([]byte("data"))
+		if err != nil || n != 4 {
+			t.Fatalf("Write(4) = (%d, %v), want (4, nil)", n, err)
+		}
+		if c.String() != "" {
+			t.Errorf("got %q, want empty", c.String())
+		}
+	})
+}

--- a/internal/summarizer/summarizer.go
+++ b/internal/summarizer/summarizer.go
@@ -208,6 +208,26 @@ func Summarize(ctx context.Context, agentName string, opts SummarizeOptions, agg
 	stderr := execResult.Stderr()
 	duration := time.Since(start)
 
+	if exitCode != 0 {
+		stdoutHead := string(output)
+		if len(stdoutHead) > 4096 {
+			stdoutHead = stdoutHead[:4096]
+		}
+		if agent.IsAuthFailure(agentName, exitCode, stderr, stdoutHead) {
+			hint := agent.AuthHint(agentName)
+			authStderr := hint
+			if stderr != "" {
+				authStderr = stderr + "\n" + hint
+			}
+			return &Result{
+				Grouped:  domain.GroupedFindings{},
+				ExitCode: exitCode,
+				Stderr:   authStderr,
+				Duration: duration,
+			}, nil
+		}
+	}
+
 	if len(output) == 0 {
 		return &Result{
 			Grouped:  domain.GroupedFindings{},


### PR DESCRIPTION
## Summary

upstream (richhaase/agentic-code-reviewer) の PR #181 以降の新規修正を手動で取り込み。
機械的チェリーピックは行わず、全修正を1対1で検証後に手動適用。

### 取り込み内容

- **x/term v0.44.0, x/sys v0.46.0 依存更新** (upstream PR #184)
- **auth.go stdout 認証検出強化** (upstream commit `7a77994`)
  - `IsAuthFailure` に `stdout ...string` 可変引数を追加（後方互換）
  - JSON 構造化エラー (`api_error_status` 401/403) の検出
  - runner に TeeReader ベースの stdout キャプチャを導入
  - summarizer に認証失敗時の早期 return を追加
  - 我々独自の Windows ガード (`containsNonAuthStartupSignal`) は維持
- **Antigravity (agy) エージェント追加** (upstream PR #183)
  - `AgentOptions` インターフェースに適合（upstream は `model string` のみ）
  - Review パーサー: Claude パーサーへの委譲ラッパー
  - Summary パーサー: JSON 抽出 + GroupedFindings 検証
  - shell スクリプト依存テストは Windows で Skip
  - E2E 検証は agy CLI 入手後に別途実施
- **Gemini 非推奨警告** (upstream commit `50dffb7`)
  - round-robin で実際に割り当てられる reviewer + 全ロール (summarizer, cross-check, fp-filter) を検査
  - gemini が呼び出されないパスでは警告を抑制（upstream より正確な実装）
- **cappedOutputCapture の短書き込みバグ修正**
  - TeeReader 経由使用時の `io.ErrShortWrite` を防止

### 取り込まなかった変更

- `arc → acr` リネーム全般
- `executor.go` / `process_windows.go` の再編（我々の Windows 改善が上位互換）
- Gemini 削除/復活サイクル
- upstream ドキュメント変更

### 関連 Issue

- #62 agy の effort validation / model 設定整備（後日対応）
- #63 agy の公開インターフェース表示への反映（後日対応）

## Test plan

- [x] `go test ./...` 全パス
- [x] テストバイナリ (`.\arc.exe`) ビルド成功
- [x] `--reviewer-agent agy` → `CLI not found in PATH: agy` (exit 2)
- [x] `--reviewer-agent gemini` → 非推奨警告表示 + 正常実行
- [x] `--reviewer-agent codex` → 警告なし、既存パス regression なし
- [x] ARC レビュー実行 (`--base 81f1510`) で実動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/masa6161/arc-cli/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

